### PR TITLE
Update gameplay effect emojis (+💰 / -💸 / ✅ / 💡)

### DIFF
--- a/shvatka/core/views/texts.py
+++ b/shvatka/core/views/texts.py
@@ -40,11 +40,13 @@ def render_effects(effects: action.Effects | None) -> str:
     if effects.next_level:
         result += "🔀"
     elif effects.level_up:
-        result += "🚩"
-    if effects.bonus_minutes:
-        result += "💰"
+        result += "✅"
+    if effects.bonus_minutes > 0:
+        result += "+💰"
+    elif effects.bonus_minutes < 0:
+        result += "-💸"
     if effects.hints_:
-        result += f"[{render_hints(effects.hints_)}]"
+        result += f"💡[{render_hints(effects.hints_)}]"
     return result
 
 


### PR DESCRIPTION
### Motivation
- Align effect spoilers with scenario emojis so level-up, bonus sign and hints are communicated more clearly in keys/events renderings.

### Description
- Update `render_effects` in `shvatka/core/views/texts.py` to keep routed level-up as `🔀`, render normal level-up as `✅`, show `+💰` for positive and `-💸` for negative `bonus_minutes`, and prefix hint lists with `💡` while still using `render_hints`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff5566c68832ab8c111d8492f9028)