### PR TITLE
Add cached waiver access to CurrentGameProvider and filter in-game pushes

### DIFF
--- a/shvatka/api/dependencies/other.py
+++ b/shvatka/api/dependencies/other.py
@@ -3,6 +3,7 @@ from dishka import Provider, Scope, provide
 from shvatka.api.config.models.main import ApiConfig
 from shvatka.api.utils.push import WebPushSender
 from shvatka.api.utils.web_input import WebInput, WebGameView, WebGameLogWriter, WebOrgNotifier
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.infrastructure.db.dao.rdb.push_subscription import PushSubscriptionDAO
 
 
@@ -18,8 +19,10 @@ class OtherApiProvider(Provider):
         return WebPushSender(config=config.push, dao=dao)
 
     @provide
-    def view(self, push_sender: WebPushSender) -> WebGameView:
-        return WebGameView(push_sender)
+    def view(
+        self, push_sender: WebPushSender, current_game: CurrentGameProvider
+    ) -> WebGameView:
+        return WebGameView(push_sender, current_game)
 
     @provide
     def log_writer(self) -> WebGameLogWriter:

--- a/shvatka/api/dependencies/other.py
+++ b/shvatka/api/dependencies/other.py
@@ -19,9 +19,7 @@ class OtherApiProvider(Provider):
         return WebPushSender(config=config.push, dao=dao)
 
     @provide
-    def view(
-        self, push_sender: WebPushSender, current_game: CurrentGameProvider
-    ) -> WebGameView:
+    def view(self, push_sender: WebPushSender, current_game: CurrentGameProvider) -> WebGameView:
         return WebGameView(push_sender, current_game)
 
     @provide

--- a/shvatka/api/utils/push.py
+++ b/shvatka/api/utils/push.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,11 +42,15 @@ class WebPushSender:
     config: PushConfig
     dao: PushSubscriptionDAO
 
-    async def send_to_team(self, team_id: int, message: PushMessage) -> None:
+    async def send_to_players(
+        self, player_ids: Collection[int], message: PushMessage
+    ) -> None:
         if not self.config.is_configured:
             logger.debug("web push is disabled or not configured")
             return
-        subscriptions = await self.dao.get_enabled_for_team(team_id)
+        if not player_ids:
+            return
+        subscriptions = await self.dao.get_enabled_for_players(player_ids)
         await self.send_many(subscriptions, message)
 
     async def send_many(

--- a/shvatka/api/utils/push.py
+++ b/shvatka/api/utils/push.py
@@ -42,9 +42,7 @@ class WebPushSender:
     config: PushConfig
     dao: PushSubscriptionDAO
 
-    async def send_to_players(
-        self, player_ids: Collection[int], message: PushMessage
-    ) -> None:
+    async def send_to_players(self, player_ids: Collection[int], message: PushMessage) -> None:
         if not self.config.is_configured:
             logger.debug("web push is disabled or not configured")
             return

--- a/shvatka/api/utils/web_input.py
+++ b/shvatka/api/utils/web_input.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Iterable
 
 from shvatka.api.utils.push import PushMessage, WebPushSender
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.game_play import GamePreparer
 from shvatka.core.models import dto
 from shvatka.core.models.dto import action
@@ -24,12 +25,18 @@ class WebInput(InputContainer):
 
 
 class WebGameView(GameView):
-    def __init__(self, push_sender: WebPushSender) -> None:
+    def __init__(self, push_sender: WebPushSender, current_game: CurrentGameProvider) -> None:
         self.push_sender = push_sender
+        self.current_game = current_game
+
+    async def _voted_player_ids(self, team: dto.Team) -> set[int]:
+        """Only players who voted yes for the current game should get in-game pushes."""
+        waivers = await self.current_game.get_waivers()
+        return {voted.player.id for voted in waivers.get(team, ())}
 
     async def send_puzzle(self, team: dto.Team, level: dto.Level) -> None:
-        await self.push_sender.send_to_team(
-            team.id,
+        await self.push_sender.send_to_players(
+            await self._voted_player_ids(team),
             PushMessage(
                 title="Новый уровень",
                 body=f"{team.name}: открыт уровень {self._level_label(level)}",
@@ -40,8 +47,8 @@ class WebGameView(GameView):
         )
 
     async def send_hint(self, team: dto.Team, hint_number: int, level: dto.Level) -> None:
-        await self.push_sender.send_to_team(
-            team.id,
+        await self.push_sender.send_to_players(
+            await self._voted_player_ids(team),
             PushMessage(
                 title="Новая подсказка",
                 body=f"{team.name}: подсказка #{hint_number}",
@@ -74,8 +81,8 @@ class WebGameView(GameView):
     async def game_finished(self, team: dto.Team, input_container: InputContainer) -> None:
         if isinstance(input_container, WebInput):
             input_container.game_finished = True
-        await self.push_sender.send_to_team(
-            team.id,
+        await self.push_sender.send_to_players(
+            await self._voted_player_ids(team),
             PushMessage(
                 title="Финиш!",
                 body=f"{team.name}: вы завершили игру",
@@ -86,8 +93,8 @@ class WebGameView(GameView):
         )
 
     async def game_finished_by_all(self, team: dto.Team) -> None:
-        await self.push_sender.send_to_team(
-            team.id,
+        await self.push_sender.send_to_players(
+            await self._voted_player_ids(team),
             PushMessage(
                 title="Игра завершена",
                 body="Все завершили игру",
@@ -102,8 +109,8 @@ class WebGameView(GameView):
     ) -> None:
         if isinstance(input_container, WebInput):
             input_container.effects.append(effects)
-        await self.push_sender.send_to_team(
-            team.id,
+        await self.push_sender.send_to_players(
+            await self._voted_player_ids(team),
             PushMessage(
                 title="Событие на уровне",
                 body=f"{team.name}: сработал эффект",

--- a/shvatka/api/utils/web_input.py
+++ b/shvatka/api/utils/web_input.py
@@ -31,12 +31,18 @@ class WebGameView(GameView):
 
     async def _voted_player_ids(self, team: dto.Team) -> set[int]:
         """Only players who voted yes for the current game should get in-game pushes."""
-        waivers = await self.current_game.get_waivers()
-        return {voted.player.id for voted in waivers.get(team, ())}
+        waivers = await self.current_game.get_team_waivers_by_team(team)
+        return {voted.player.id for voted in waivers}
+
+    async def _send_to_played(self, team: dto.Team, message: PushMessage) -> None:
+        await self.push_sender.send_to_players(
+            player_ids=await self._voted_player_ids(team),
+            message=message,
+        )
 
     async def send_puzzle(self, team: dto.Team, level: dto.Level) -> None:
-        await self.push_sender.send_to_players(
-            await self._voted_player_ids(team),
+        await self._send_to_played(
+            team,
             PushMessage(
                 title="Новый уровень",
                 body=f"{team.name}: открыт уровень {self._level_label(level)}",
@@ -47,8 +53,8 @@ class WebGameView(GameView):
         )
 
     async def send_hint(self, team: dto.Team, hint_number: int, level: dto.Level) -> None:
-        await self.push_sender.send_to_players(
-            await self._voted_player_ids(team),
+        await self._send_to_played(
+            team,
             PushMessage(
                 title="Новая подсказка",
                 body=f"{team.name}: подсказка #{hint_number}",
@@ -81,8 +87,8 @@ class WebGameView(GameView):
     async def game_finished(self, team: dto.Team, input_container: InputContainer) -> None:
         if isinstance(input_container, WebInput):
             input_container.game_finished = True
-        await self.push_sender.send_to_players(
-            await self._voted_player_ids(team),
+        await self._send_to_played(
+            team,
             PushMessage(
                 title="Финиш!",
                 body=f"{team.name}: вы завершили игру",
@@ -93,8 +99,8 @@ class WebGameView(GameView):
         )
 
     async def game_finished_by_all(self, team: dto.Team) -> None:
-        await self.push_sender.send_to_players(
-            await self._voted_player_ids(team),
+        await self._send_to_played(
+            team,
             PushMessage(
                 title="Игра завершена",
                 body="Все завершили игру",
@@ -109,8 +115,8 @@ class WebGameView(GameView):
     ) -> None:
         if isinstance(input_container, WebInput):
             input_container.effects.append(effects)
-        await self.push_sender.send_to_players(
-            await self._voted_player_ids(team),
+        await self._send_to_played(
+            team,
             PushMessage(
                 title="Событие на уровне",
                 body=f"{team.name}: сработал эффект",

--- a/shvatka/core/games/game_play.py
+++ b/shvatka/core/games/game_play.py
@@ -2,11 +2,8 @@ import asyncio
 import logging
 from datetime import timedelta, datetime
 
-from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.game_play import GamePreparer
 from shvatka.core.interfaces.dal.level_times import GameStarter, LevelByTeamGetter
-from shvatka.core.interfaces.dal.waiver import WaiverChecker
-from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.models import dto
 from shvatka.core.models.dto import hints, action
@@ -207,14 +204,3 @@ def need_prepare_now(game: dto.Game) -> bool:
         if (game.start_at - utcnow) < timedelta(minutes=6):
             return True
         return False
-
-
-async def check_waivers(
-    current_game: CurrentGameProvider,
-    identity: IdentityProvider,
-    dao: WaiverChecker,
-) -> bool:
-    game = await current_game.get_required_game()
-    player = await identity.get_required_player()
-    team = await identity.get_required_team()
-    return await dao.check_waiver(player, team, game)

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole
-from shvatka.core.games.game_play import schedule_first_hint, check_waivers
+from shvatka.core.games.game_play import schedule_first_hint
 from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.games.adapters import (
     GameFileReader,
@@ -260,9 +260,7 @@ class CheckKeyInteractor(GamePlayBaseInteractor):
         game = await self.current_game.get_required_full_game()
         player = await identity.get_required_player()
         team = await identity.get_required_team()
-        if not await check_waivers(
-            current_game=self.current_game, identity=identity, dao=self.dao
-        ):
+        if not await self.current_game.is_player_played(identity):
             raise exceptions.WaiverError(
                 team=team, game=game, player=player, text="игрок не заявлен на игру, но ввёл ключ"
             )

--- a/shvatka/core/interfaces/current_game.py
+++ b/shvatka/core/interfaces/current_game.py
@@ -28,15 +28,16 @@ class CurrentGameProvider(Protocol):
         """All teams (with players) which voted yes for the current game."""
         raise NotImplementedError
 
-    async def get_team_waivers(self, identity: IdentityProvider) -> Iterable[dto.VotedPlayer]:
+    async def get_team_waivers_by_team(self, team: dto.Team) -> Iterable[dto.VotedPlayer]:
         """Players of the identity's team which voted yes for the current game."""
         raise NotImplementedError
 
+    async def get_team_waivers(self, identity: IdentityProvider) -> Iterable[dto.VotedPlayer]:
+        return await self.get_team_waivers_by_team(await identity.get_required_team())
+
     async def is_player_played(self, identity: IdentityProvider) -> bool:
         player = await identity.get_required_player()
-        return any(
-            voted.player.id == player.id for voted in await self.get_team_waivers(identity)
-        )
+        return any(voted.player.id == player.id for voted in await self.get_team_waivers(identity))
 
     async def is_team_played(self, identity: IdentityProvider) -> bool:
         return any(True for _ in await self.get_team_waivers(identity))

--- a/shvatka/core/interfaces/current_game.py
+++ b/shvatka/core/interfaces/current_game.py
@@ -1,5 +1,6 @@
-from typing import Protocol
+from typing import Iterable, Protocol
 
+from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.utils import exceptions
 
@@ -22,3 +23,20 @@ class CurrentGameProvider(Protocol):
         if full_game is None:
             raise exceptions.HaveNotActiveGame
         return full_game
+
+    async def get_waivers(self) -> dict[dto.Team, Iterable[dto.VotedPlayer]]:
+        """All teams (with players) which voted yes for the current game."""
+        raise NotImplementedError
+
+    async def get_team_waivers(self, identity: IdentityProvider) -> Iterable[dto.VotedPlayer]:
+        """Players of the identity's team which voted yes for the current game."""
+        raise NotImplementedError
+
+    async def is_player_played(self, identity: IdentityProvider) -> bool:
+        player = await identity.get_required_player()
+        return any(
+            voted.player.id == player.id for voted in await self.get_team_waivers(identity)
+        )
+
+    async def is_team_played(self, identity: IdentityProvider) -> bool:
+        return any(True for _ in await self.get_team_waivers(identity))

--- a/shvatka/core/services/current_game.py
+++ b/shvatka/core/services/current_game.py
@@ -1,13 +1,17 @@
-from typing import TypedDict
+from typing import Iterable, TypedDict
 
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.waiver import GameWaiversGetter
+from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
+from shvatka.core.waiver.services import get_all_played
 from shvatka.infrastructure.db.dao import GameDao
 
 
 class LoadedData(TypedDict, total=False):
     game: dto.Game | None
     full_game: dto.FullGame | None
+    waivers: dict[dto.Team, Iterable[dto.VotedPlayer]]
 
 
 class CurrentGameProviderImpl(CurrentGameProvider):
@@ -15,9 +19,12 @@ class CurrentGameProviderImpl(CurrentGameProvider):
         self,
         *,
         dao: GameDao,
+        waiver_dao: GameWaiversGetter,
     ) -> None:
         self.dao = dao
+        self.waiver_dao = waiver_dao
         self.cache = LoadedData()
+        self.team_waivers_cache: dict[int, Iterable[dto.VotedPlayer]] = {}
 
     async def get_game(self) -> dto.Game | None:
         if "game" in self.cache:
@@ -37,3 +44,20 @@ class CurrentGameProviderImpl(CurrentGameProvider):
         full_game = await self.dao.get_full(game.id)
         self.cache["full_game"] = full_game
         return full_game
+
+    async def get_waivers(self) -> dict[dto.Team, Iterable[dto.VotedPlayer]]:
+        if "waivers" in self.cache:
+            return self.cache["waivers"]
+        game = await self.get_required_game()
+        waivers = await get_all_played(game, self.waiver_dao)
+        self.cache["waivers"] = waivers
+        return waivers
+
+    async def get_team_waivers(self, identity: IdentityProvider) -> Iterable[dto.VotedPlayer]:
+        team = await identity.get_required_team()
+        if team.id in self.team_waivers_cache:
+            return self.team_waivers_cache[team.id]
+        game = await self.get_required_game()
+        players = await self.waiver_dao.get_played(game, team)
+        self.team_waivers_cache[team.id] = players
+        return players

--- a/shvatka/core/services/current_game.py
+++ b/shvatka/core/services/current_game.py
@@ -2,7 +2,6 @@ from typing import Iterable, TypedDict
 
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.waiver import GameWaiversGetter
-from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.waiver.services import get_all_played
 from shvatka.infrastructure.db.dao import GameDao
@@ -53,8 +52,7 @@ class CurrentGameProviderImpl(CurrentGameProvider):
         self.cache["waivers"] = waivers
         return waivers
 
-    async def get_team_waivers(self, identity: IdentityProvider) -> Iterable[dto.VotedPlayer]:
-        team = await identity.get_required_team()
+    async def get_team_waivers_by_team(self, team: dto.Team) -> Iterable[dto.VotedPlayer]:
         if team.id in self.team_waivers_cache:
             return self.team_waivers_cache[team.id]
         game = await self.get_required_game()

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from shvatka.core.games.dto import CurrentHintsOnly, Event
-from shvatka.core.games.game_play import check_waivers
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 
 from shvatka.core.interfaces.dal.complex import GamePackager
@@ -140,7 +139,6 @@ class GameFilesGetterImpl(GameFileReader):
 
 @dataclass(kw_only=True, slots=True)
 class CacheItem:
-    waivers_ok: bool | None = None
     level_time: dto.LevelTime | None = None
 
 
@@ -190,13 +188,7 @@ class GamePlayDaoImpl(GamePlayDao):
         return level_time
 
     async def check_waivers(self, identity: IdentityProvider) -> bool:
-        user_id = await identity.get_required_user_db_id()
-        cache = self.cache.setdefault(user_id, CacheItem())
-        if cache.waivers_ok is not None:
-            return cache.waivers_ok
-        waivers_check_result = await check_waivers(self.current_game, identity, self.dao.waiver)
-        cache.waivers_ok = waivers_check_result
-        return waivers_check_result
+        return await self.current_game.is_player_played(identity)
 
     async def get_effects(self, identity: IdentityProvider) -> list[dto.GameEvent]:
         return await self.dao.events.get_team_events(

--- a/shvatka/infrastructure/db/dao/rdb/push_subscription.py
+++ b/shvatka/infrastructure/db/dao/rdb/push_subscription.py
@@ -1,13 +1,13 @@
 from datetime import datetime, tzinfo
 import typing
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shvatka.core.utils.datetime_utils import tz_utc
-from shvatka.infrastructure.db.models import PushSubscription, TeamPlayer
+from shvatka.infrastructure.db.models import PushSubscription
 from .base import BaseDAO
 
 
@@ -67,13 +67,14 @@ class PushSubscriptionDAO(BaseDAO[PushSubscription]):
             .values(enabled=False, updated_at=self.clock(tz_utc))
         )
 
-    async def get_enabled_for_team(self, team_id: int) -> Sequence[PushSubscription]:
+    async def get_enabled_for_players(
+        self, player_ids: Collection[int]
+    ) -> Sequence[PushSubscription]:
+        if not player_ids:
+            return []
         result = await self.session.scalars(
-            select(PushSubscription)
-            .join(TeamPlayer, TeamPlayer.player_id == PushSubscription.player_id)
-            .where(
-                TeamPlayer.team_id == team_id,
-                TeamPlayer.date_left.is_(None),
+            select(PushSubscription).where(
+                PushSubscription.player_id.in_(player_ids),
                 PushSubscription.enabled.is_(True),
             )
         )

--- a/tests/fixtures/game_fixtures.py
+++ b/tests/fixtures/game_fixtures.py
@@ -10,7 +10,6 @@ from dishka import AsyncContainer
 from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.waiver import GameWaiversGetter
-from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.models.dto.scn.game import RawGameScenario
 from shvatka.core.models.enums.played import Played
@@ -327,10 +326,7 @@ class CurrentGameProviderMock(CurrentGameProvider):
             return {}
         return await get_all_played(self.game, self.waiver_getter)
 
-    async def get_team_waivers(
-        self, identity: IdentityProvider
-    ) -> typing.Iterable[dto.VotedPlayer]:
+    async def get_team_waivers_by_team(self, team: dto.Team) -> typing.Iterable[dto.VotedPlayer]:
         if self.waiver_getter is None:
             return []
-        team = await identity.get_required_team()
         return await self.waiver_getter.get_played(self.game, team)

--- a/tests/fixtures/game_fixtures.py
+++ b/tests/fixtures/game_fixtures.py
@@ -1,4 +1,5 @@
 import asyncio
+import typing
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -8,13 +9,15 @@ from dishka import AsyncContainer
 
 from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.waiver import GameWaiversGetter
+from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.models.dto.scn.game import RawGameScenario
 from shvatka.core.models.enums.played import Played
 from shvatka.core.services.game import upsert_game, start_waivers
 from shvatka.core.services.key import KeyProcessor
 from shvatka.core.players.player import join_team
-from shvatka.core.waiver.services import add_vote, approve_waivers
+from shvatka.core.waiver.services import add_vote, approve_waivers, get_all_played
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
 from shvatka.core.waiver.adapters import WaiverVoteAdder
@@ -88,7 +91,7 @@ async def finished_game(
     locker: KeyCheckerFactory,
 ) -> dto.FullGame:
     game = started_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     await key_processor.submit_key(
         key="SHWRONG",
@@ -215,7 +218,7 @@ async def finished_routed_game(
     locker: KeyCheckerFactory,
 ) -> dto.FullGame:
     game = started_routed_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     await key_processor.submit_key(
         key="SHWRONG",
@@ -311,9 +314,23 @@ async def set_game_started(
 @dataclass
 class CurrentGameProviderMock(CurrentGameProvider):
     game: dto.FullGame
+    waiver_getter: GameWaiversGetter | None = None
 
     async def get_full_game(self) -> dto.FullGame | None:
         return self.game
 
     async def get_game(self) -> dto.Game | None:
         return self.game
+
+    async def get_waivers(self) -> dict[dto.Team, typing.Iterable[dto.VotedPlayer]]:
+        if self.waiver_getter is None:
+            return {}
+        return await get_all_played(self.game, self.waiver_getter)
+
+    async def get_team_waivers(
+        self, identity: IdentityProvider
+    ) -> typing.Iterable[dto.VotedPlayer]:
+        if self.waiver_getter is None:
+            return []
+        team = await identity.get_required_team()
+        return await self.waiver_getter.get_played(self.game, team)

--- a/tests/integration/test_game.py
+++ b/tests/integration/test_game.py
@@ -89,7 +89,7 @@ async def test_game_simple(
     assert game.id == gotten_games[0].id
 
     await start_waivers(game, author, dao.game)
-    active_game = await CurrentGameProviderImpl(dao=dao.game).get_game()
+    active_game = await CurrentGameProviderImpl(dao=dao.game, waiver_dao=dao.waiver).get_game()
     assert GameStatus.getting_waivers == active_game.status
     assert active_game.id == game.id
 

--- a/tests/integration/test_game_play.py
+++ b/tests/integration/test_game_play.py
@@ -82,7 +82,7 @@ async def test_wrong_key(
     dishka_request: AsyncContainer,
 ):
     game = started_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
@@ -134,7 +134,7 @@ async def test_bonus_hint_key(
     scheduler: SchedulerMock,
 ):
     game = started_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
@@ -197,7 +197,7 @@ async def test_game_play(
     started_game: dto.FullGame,
 ):
     game = started_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     # delete slytherin from game
     await leave(draco, draco, dao.team_leaver)
@@ -315,7 +315,7 @@ async def test_fast_play_routed_game(
     started_routed_game: dto.FullGame,
 ):
     game = started_routed_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     # delete slytherin from game
     await leave(draco, draco, dao.team_leaver)
@@ -393,7 +393,7 @@ async def test_cycle_play_routed_game(
     started_routed_game: dto.FullGame,
 ):
     game = started_routed_game
-    current_game = CurrentGameProviderMock(game)
+    current_game = CurrentGameProviderMock(game, dao.waiver)
     key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
     # delete slytherin from game
     await leave(draco, draco, dao.team_leaver)


### PR DESCRIPTION
## What

Extends `CurrentGameProvider` with cached, "voted yes only" waiver access and uses it to centralize waiver checks and to scope in-game web push notifications.

### `CurrentGameProvider`
- `get_waivers() -> dict[dto.Team, Iterable[dto.VotedPlayer]]` — all teams/players that voted yes for the current game (cached).
- `get_team_waivers(identity) -> Iterable[dto.VotedPlayer]` — the identity's team's voted-yes players (cached per team).
- `is_player_played(identity) -> bool` and `is_team_played(identity) -> bool` — convenience helpers built on top of the above (default implementations on the protocol).

`CurrentGameProviderImpl` now also takes a `GameWaiversGetter` (resolved by DI from the existing `WaiverDao`) and caches the all-teams dict and per-team lists separately.

### Centralized waiver checks
`CheckKeyInteractor` and `GamePlayDaoImpl.check_waivers` now delegate to `current_game.is_player_played(identity)`. Because the provider is request-scoped and caches results, repeated waiver checks within a request no longer hit the database multiple times. The now-redundant `check_waivers` helper in `game_play.py` and the local `waivers_ok` cache in `GamePlayDaoImpl` were removed.

### In-game push notifications
`WebGameView` now resolves the team's voted-yes player ids (via `get_waivers()`) and sends pushes only to those players through a new `WebPushSender.send_to_players` / `PushSubscriptionDAO.get_enabled_for_players` path. The unfiltered team-broadcast methods (`send_to_team`, `get_enabled_for_team`) were removed so non-voted players can't accidentally be notified.

## Testing
- `mypy` clean on all changed modules.
- `ruff` clean on changed files (pre-existing `SIM103` warnings in untouched functions of `game_play.py` remain).
- Unit tests pass (`tests/unit`, 60 passed).
- Integration tests (`tests/integration`) could not be run in this environment — they rely on testcontainers and the sandbox network blocks pulling the postgres/redis images. The `CurrentGameProviderMock` was updated to back the new methods with a `GameWaiversGetter`, and test instantiations were updated accordingly.

https://claude.ai/code/session_014Qb7H1fVYU5oNUzTNYofqp

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qb7H1fVYU5oNUzTNYofqp)_