### PR TITLE
Add API routes for editing game drafts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ name: ShvatkaBotBuild
 on:
   push:
     branches: [ master ]
-    tags: ["*.*.*"]
+    tags: ["*.*.*", "*.*.*-dev"]
 
 jobs:
   lint-and-test:

--- a/shvatka/api/dependencies/__init__.py
+++ b/shvatka/api/dependencies/__init__.py
@@ -6,7 +6,9 @@ from shvatka.api.dependencies.auth import AuthProvider
 from shvatka.api.dependencies.api_only import ApiOnlyProvider
 from shvatka.api.dependencies.config import ApiConfigProvider
 from shvatka.api.dependencies.other import OtherApiProvider
+from shvatka.common.factory import DCFProvider
 from shvatka.infrastructure.di import get_providers
+from shvatka.infrastructure.di.interactors import GameEditProvider
 
 
 def setup_di(app: FastAPI, paths_env: str):
@@ -32,6 +34,8 @@ def get_api_specific_providers() -> list[Provider]:
         AuthProvider(),
         ApiConfigProvider(),
         OtherApiProvider(),
+        DCFProvider(),
+        GameEditProvider(),
     ]
 
 

--- a/shvatka/api/dependencies/__init__.py
+++ b/shvatka/api/dependencies/__init__.py
@@ -6,7 +6,6 @@ from shvatka.api.dependencies.auth import AuthProvider
 from shvatka.api.dependencies.api_only import ApiOnlyProvider
 from shvatka.api.dependencies.config import ApiConfigProvider
 from shvatka.api.dependencies.other import OtherApiProvider
-from shvatka.common.factory import DCFProvider
 from shvatka.infrastructure.di import get_providers
 from shvatka.infrastructure.di.interactors import GameEditProvider
 
@@ -34,7 +33,6 @@ def get_api_specific_providers() -> list[Provider]:
         AuthProvider(),
         ApiConfigProvider(),
         OtherApiProvider(),
-        DCFProvider(),
         GameEditProvider(),
     ]
 

--- a/shvatka/api/dependencies/other.py
+++ b/shvatka/api/dependencies/other.py
@@ -7,6 +7,8 @@ from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.infrastructure.db.dao.rdb.push_subscription import PushSubscriptionDAO
 
 
+
+
 class OtherApiProvider(Provider):
     scope = Scope.REQUEST
 

--- a/shvatka/api/dependencies/other.py
+++ b/shvatka/api/dependencies/other.py
@@ -7,8 +7,6 @@ from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.infrastructure.db.dao.rdb.push_subscription import PushSubscriptionDAO
 
 
-
-
 class OtherApiProvider(Provider):
     scope = Scope.REQUEST
 

--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -1,9 +1,27 @@
 from dataclasses import dataclass
+from datetime import datetime
+
+from shvatka.core.models.enums import GameStatus
 
 
 @dataclass
 class Key:
     text: str
+
+
+@dataclass
+class NewGame:
+    name: str
+
+
+@dataclass
+class GameStartAt:
+    start_at: datetime | None = None
+
+
+@dataclass
+class GameStatusChange:
+    status: GameStatus
 
 
 @dataclass(frozen=True, slots=True)

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -3,22 +3,15 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Sequence, Generic
 
-from adaptix import Retort, dumper
-
-from shvatka.common.factory import REQUIRED_GAME_RECIPES
+from shvatka.common.factory import GAME_SCENARIO_RETORT
 from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole, Event
 from shvatka.core.models import dto, enums
-from shvatka.core.models.dto import scn, action
+from shvatka.core.models.dto import action
 from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
 
 T = typing.TypeVar("T")
-retort = Retort(
-    recipe=[
-        *REQUIRED_GAME_RECIPES,
-        dumper(scn.HintsList, lambda x: x.hints),
-    ]
-)
+retort = GAME_SCENARIO_RETORT
 
 
 @dataclass

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -314,3 +314,22 @@ class MyRoleDto:
 class PushConfigResponse:
     enabled: bool
     public_key: str | None
+
+
+@dataclass
+class UploadedFile:
+    guid: str
+    original_filename: str
+    extension: str
+    content_type: enums.HintType | None
+    mime_type: str | None
+
+    @classmethod
+    def from_core(cls, core: hints.SavedFileMeta) -> "UploadedFile":
+        return cls(
+            guid=core.guid,
+            original_filename=core.original_filename,
+            extension=core.extension,
+            content_type=core.content_type,
+            mime_type=core.mime_type,
+        )

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Sequence, Generic
 
-from shvatka.common.factory import GAME_SCENARIO_RETORT
+from adaptix import Retort
+
 from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole, Event
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import action
@@ -11,7 +12,6 @@ from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
 
 T = typing.TypeVar("T")
-retort = GAME_SCENARIO_RETORT
 
 
 @dataclass
@@ -86,7 +86,7 @@ class Level:
     number_in_game: int | None = None
 
     @classmethod
-    def from_core(cls, core: dto.Level | None = None):
+    def from_core(cls, retort: Retort, core: dto.Level | None = None):
         if core is None:
             return None
         return cls(
@@ -109,7 +109,7 @@ class FullGame:
     levels: list[Level] = field(default_factory=list)
 
     @classmethod
-    def from_core(cls, core: dto.FullGame | None = None):
+    def from_core(cls, retort: Retort, core: dto.FullGame | None = None):
         if core is None:
             return None
         return cls(
@@ -118,7 +118,7 @@ class FullGame:
             name=core.name,
             status=core.status,
             start_at=core.start_at,
-            levels=[Level.from_core(level) for level in core.levels],
+            levels=[Level.from_core(retort, level) for level in core.levels],
         )
 
 

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -100,6 +100,21 @@ class Level:
 
 
 @dataclass
+class GameFile:
+    guid: str
+    original_filename: str
+    extension: str
+
+    @classmethod
+    def from_core(cls, core: hints.FileMeta) -> "GameFile":
+        return cls(
+            guid=core.guid,
+            original_filename=core.original_filename,
+            extension=core.extension,
+        )
+
+
+@dataclass
 class FullGame:
     id: int
     author: Player
@@ -107,9 +122,15 @@ class FullGame:
     status: GameStatus
     start_at: datetime | None
     levels: list[Level] = field(default_factory=list)
+    files: list[GameFile] = field(default_factory=list)
 
     @classmethod
-    def from_core(cls, retort: Retort, core: dto.FullGame | None = None):
+    def from_core(
+        cls,
+        retort: Retort,
+        core: dto.FullGame | None = None,
+        files: Sequence[hints.FileMeta] = (),
+    ):
         if core is None:
             return None
         return cls(
@@ -119,6 +140,7 @@ class FullGame:
             status=core.status,
             start_at=core.start_at,
             levels=[Level.from_core(retort, level) for level in core.levels],
+            files=[GameFile.from_core(file) for file in files],
         )
 
 

--- a/shvatka/api/routes/cdn.py
+++ b/shvatka/api/routes/cdn.py
@@ -14,7 +14,7 @@ from shvatka.api.models import responses
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
 )
-from shvatka.core.games.editing_interactors import UploadGameFileInteractor
+from shvatka.core.games.editor_interactors import UploadGameFileInteractor
 
 
 logger = logging.getLogger(__name__)

--- a/shvatka/api/routes/cdn.py
+++ b/shvatka/api/routes/cdn.py
@@ -1,17 +1,20 @@
 import logging
+from io import BytesIO
 from typing import Annotated
 from urllib.parse import quote
 
 from dishka.integrations.fastapi import FromDishka
 from dishka.integrations.fastapi import inject
-from fastapi import APIRouter
+from fastapi import APIRouter, File, UploadFile
 from fastapi.params import Path
 from fastapi.responses import Response
 
 from shvatka.api.dependencies.auth import ApiIdentityProvider
+from shvatka.api.models import responses
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
 )
+from shvatka.core.games.editing_interactors import UploadGameFileInteractor
 
 
 logger = logging.getLogger(__name__)
@@ -42,7 +45,25 @@ async def get_game_file(
     )
 
 
+@inject
+async def upload_game_file(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[UploadGameFileInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    file: Annotated[UploadFile, File()],
+) -> responses.UploadedFile:
+    content = BytesIO(await file.read())
+    saved = await interactor(
+        game_id=id_,
+        content=content,
+        original_filename=file.filename or "document",
+        identity=identity,
+    )
+    return responses.UploadedFile.from_core(saved)
+
+
 def setup() -> APIRouter:
     router = APIRouter(prefix="/cdn")
+    router.add_api_route("/games/{id}/files", upload_game_file, methods=["POST"])
     router.add_api_route("/games/{id}/files/{guid}", get_game_file, methods=["GET"])
     return router

--- a/shvatka/api/routes/game.py
+++ b/shvatka/api/routes/game.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 from dishka.integrations.fastapi import FromDishka
 from dishka.integrations.fastapi import inject
@@ -17,10 +17,17 @@ from shvatka.core.games.interactors import (
     CheckKeyInteractor,
     GamePlayRoleReader,
 )
+from shvatka.core.games.editing_interactors import (
+    MyGamesInteractor,
+    MyGameInteractor,
+    CreateGameInteractor,
+    ChangeGameScenarioInteractor,
+    ChangeGameStartAtInteractor,
+    ChangeGameStatusInteractor,
+)
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.models import enums
 from shvatka.core.services.game import (
-    get_authors_games,
     get_completed_games,
     get_full_game,
 )
@@ -33,9 +40,63 @@ logger = logging.getLogger(__name__)
 @inject
 async def get_my_games_list(
     identity: FromDishka[ApiIdentityProvider],
-    dao: FromDishka[HolderDao],
-):
-    return responses.Page(await get_authors_games(identity, dao.game))
+    interactor: FromDishka[MyGamesInteractor],
+) -> responses.Page[responses.Game]:
+    games = await interactor(identity=identity)
+    return responses.Page([responses.Game.from_core(game) for game in games])
+
+
+@inject
+async def get_my_game(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[MyGameInteractor],
+    id_: Annotated[int, Path(alias="id")],
+) -> responses.FullGame:
+    game = await interactor(game_id=id_, identity=identity)
+    return responses.FullGame.from_core(game)
+
+
+@inject
+async def create_my_game(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[CreateGameInteractor],
+    game: Annotated[req.NewGame, Body()],
+) -> responses.Game:
+    created = await interactor(name=game.name, identity=identity)
+    return responses.Game.from_core(created)
+
+
+@inject
+async def change_my_game_scenario(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[ChangeGameScenarioInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    scenario: Annotated[dict[str, Any], Body()],
+) -> responses.FullGame:
+    game = await interactor(game_id=id_, raw_scn=scenario, identity=identity)
+    return responses.FullGame.from_core(game)
+
+
+@inject
+async def change_my_game_start_at(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[ChangeGameStartAtInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.GameStartAt, Body()],
+) -> responses.Game:
+    game = await interactor(game_id=id_, start_at=body.start_at, identity=identity)
+    return responses.Game.from_core(game)
+
+
+@inject
+async def change_my_game_status(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[ChangeGameStatusInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.GameStatusChange, Body()],
+) -> responses.Game:
+    game = await interactor(game_id=id_, status=body.status, identity=identity)
+    return responses.Game.from_core(game)
 
 
 @inject
@@ -128,6 +189,11 @@ def setup() -> APIRouter:
     router = APIRouter(prefix="/games")
     router.add_api_route("", get_all_games, methods=["GET"])
     router.add_api_route("/my", get_my_games_list, methods=["GET"])
+    router.add_api_route("/my", create_my_game, methods=["POST"])
+    router.add_api_route("/my/{id}", get_my_game, methods=["GET"])
+    router.add_api_route("/my/{id}/scenario", change_my_game_scenario, methods=["PUT"])
+    router.add_api_route("/my/{id}/start_at", change_my_game_start_at, methods=["PUT"])
+    router.add_api_route("/my/{id}/status", change_my_game_status, methods=["PUT"])
     router.add_api_route("/active", get_active_game, methods=["GET"])
     router.add_api_route("/active/me", get_my_role, methods=["GET"])
     router.add_api_route("/running/level/current", get_current_level, methods=["GET"])

--- a/shvatka/api/routes/game.py
+++ b/shvatka/api/routes/game.py
@@ -32,6 +32,7 @@ from shvatka.core.services.game import (
     get_completed_games,
     get_full_game,
 )
+from shvatka.core.services.scenario.files import get_game_file_metas
 from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
@@ -51,11 +52,14 @@ async def get_my_games_list(
 async def get_my_game(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[MyGameInteractor],
+    dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
     id_: Annotated[int, Path(alias="id")],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, identity=identity)
-    return responses.FullGame.from_core(retort, game)
+    author = await identity.get_required_player()
+    files = await get_game_file_metas(game, author, dao.file_info)
+    return responses.FullGame.from_core(retort, game, files)
 
 
 @inject
@@ -72,12 +76,15 @@ async def create_my_game(
 async def change_my_game_scenario(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[ChangeGameScenarioInteractor],
+    dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
     id_: Annotated[int, Path(alias="id")],
     scenario: Annotated[dict[str, Any], Body()],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, raw_scn=scenario, identity=identity)
-    return responses.FullGame.from_core(retort, game)
+    author = await identity.get_required_player()
+    files = await get_game_file_metas(game, author, dao.file_info)
+    return responses.FullGame.from_core(retort, game, files)
 
 
 @inject
@@ -137,7 +144,9 @@ async def get_game_card(
     id_: Annotated[int, Path(alias="id")],
 ):
     game = await get_full_game(id_, identity, dao.game)
-    return responses.FullGame.from_core(retort, game)
+    author = await identity.get_required_player()
+    files = await get_game_file_metas(game, author, dao.file_info)
+    return responses.FullGame.from_core(retort, game, files)
 
 
 @inject

--- a/shvatka/api/routes/game.py
+++ b/shvatka/api/routes/game.py
@@ -18,12 +18,12 @@ from shvatka.core.games.interactors import (
     CheckKeyInteractor,
     GamePlayRoleReader,
 )
-from shvatka.core.games.editing_interactors import (
+from shvatka.core.games.editor_interactors import (
     MyGamesInteractor,
     MyGameInteractor,
     CreateGameInteractor,
     ChangeGameScenarioInteractor,
-    ChangeGameStartAtInteractor,
+    PlanGameStartInteractor,
     ChangeGameStatusInteractor,
 )
 from shvatka.core.interfaces.current_game import CurrentGameProvider
@@ -83,7 +83,7 @@ async def change_my_game_scenario(
 @inject
 async def change_my_game_start_at(
     identity: FromDishka[ApiIdentityProvider],
-    interactor: FromDishka[ChangeGameStartAtInteractor],
+    interactor: FromDishka[PlanGameStartInteractor],
     id_: Annotated[int, Path(alias="id")],
     body: Annotated[req.GameStartAt, Body()],
 ) -> responses.Game:

--- a/shvatka/api/routes/game.py
+++ b/shvatka/api/routes/game.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Annotated, Any
 
+from adaptix import Retort
 from dishka.integrations.fastapi import FromDishka
 from dishka.integrations.fastapi import inject
 from fastapi import APIRouter, Body, HTTPException
@@ -50,10 +51,11 @@ async def get_my_games_list(
 async def get_my_game(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[MyGameInteractor],
+    retort: FromDishka[Retort],
     id_: Annotated[int, Path(alias="id")],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, identity=identity)
-    return responses.FullGame.from_core(game)
+    return responses.FullGame.from_core(retort, game)
 
 
 @inject
@@ -70,11 +72,12 @@ async def create_my_game(
 async def change_my_game_scenario(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[ChangeGameScenarioInteractor],
+    retort: FromDishka[Retort],
     id_: Annotated[int, Path(alias="id")],
     scenario: Annotated[dict[str, Any], Body()],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, raw_scn=scenario, identity=identity)
-    return responses.FullGame.from_core(game)
+    return responses.FullGame.from_core(retort, game)
 
 
 @inject
@@ -130,10 +133,11 @@ async def get_all_games(
 async def get_game_card(
     dao: FromDishka[HolderDao],
     identity: FromDishka[ApiIdentityProvider],
+    retort: FromDishka[Retort],
     id_: Annotated[int, Path(alias="id")],
 ):
     game = await get_full_game(id_, identity, dao.game)
-    return responses.FullGame.from_core(game)
+    return responses.FullGame.from_core(retort, game)
 
 
 @inject

--- a/shvatka/common/factory.py
+++ b/shvatka/common/factory.py
@@ -8,7 +8,6 @@ from adaptix import (
     P,
     name_mapping,
     loader,
-    dumper,
     Chain,
 )
 from adaptix.load_error import LoadError
@@ -48,42 +47,28 @@ REQUIRED_GAME_RECIPES = [
     ),  # internal class, can be broken in next adaptix version
 ]
 
-
-def create_game_retort() -> Retort:
-    """adaptix Retort for game scenarios using plain snake_case field names.
-
-    Used by the API for both parsing incoming scenarios and dumping them back, so the
-    request and response shapes are symmetric. Unlike :class:`DCFProvider` (legacy, kebab),
-    this does not pull in dataclass_factory.
-    """
-    return Retort(
-        recipe=[
-            *REQUIRED_GAME_RECIPES,
-            dumper(scn.HintsList, lambda x: x.hints),
-            validator(
-                pred=P[scn.LevelScenario].id,
-                func=lambda x: validate_level_id(x) is not None,
-                error=lambda x: typing.cast(
-                    LoadError,
-                    exceptions.ScenarioNotCorrect(name_id=x, text=f"name_id ({x}) not correct"),
-                ),
+VALIDATION_GAME_RECIPES = [
+    validator(
+        pred=P[scn.LevelScenario].id,
+        func=lambda x: validate_level_id(x) is not None,
+        error=lambda x: typing.cast(
+            LoadError,
+            exceptions.ScenarioNotCorrect(
+                name_id=x, text=f"name_id ({x}) not correct"
             ),
-            validator(
-                pred=P[scn.LevelScenario].keys,
-                func=is_multiple_keys_normal,
-                error=lambda x: typing.cast(
-                    LoadError,
-                    exceptions.ScenarioNotCorrect(
-                        notify_user=INVALID_KEY_ERROR, text="invalid keys"
-                    ),
-                ),
+        ),
+    ),
+    validator(
+        pred=P[scn.LevelScenario].keys,
+        func=is_multiple_keys_normal,
+        error=lambda x: typing.cast(
+            LoadError,
+            exceptions.ScenarioNotCorrect(
+                notify_user=INVALID_KEY_ERROR, text="invalid keys"
             ),
-        ]
-    )
-
-
-GAME_SCENARIO_RETORT: Retort = create_game_retort()
-
+        ),
+    ),
+]
 
 class DCFProvider(Provider):
     scope = Scope.APP
@@ -100,30 +85,8 @@ class DCFProvider(Provider):
     def create_retort(self) -> Retort:
         retort = Retort(
             recipe=[
-                name_mapping(
-                    name_style=adaptix.NameStyle.LOWER_KEBAB,
-                ),
                 *REQUIRED_GAME_RECIPES,
-                validator(
-                    pred=P[scn.LevelScenario].id,
-                    func=lambda x: validate_level_id(x) is not None,
-                    error=lambda x: typing.cast(
-                        LoadError,
-                        exceptions.ScenarioNotCorrect(
-                            name_id=x, text=f"name_id ({x}) not correct"
-                        ),
-                    ),
-                ),
-                validator(
-                    pred=P[scn.LevelScenario].keys,
-                    func=is_multiple_keys_normal,
-                    error=lambda x: typing.cast(
-                        LoadError,
-                        exceptions.ScenarioNotCorrect(
-                            notify_user=INVALID_KEY_ERROR, text="invalid keys"
-                        ),
-                    ),
-                ),
+                *VALIDATION_GAME_RECIPES
             ]
         )
         return retort

--- a/shvatka/common/factory.py
+++ b/shvatka/common/factory.py
@@ -1,6 +1,5 @@
 import typing
 
-import adaptix
 import dataclass_factory
 from adaptix import (
     Retort,
@@ -53,9 +52,7 @@ VALIDATION_GAME_RECIPES = [
         func=lambda x: validate_level_id(x) is not None,
         error=lambda x: typing.cast(
             LoadError,
-            exceptions.ScenarioNotCorrect(
-                name_id=x, text=f"name_id ({x}) not correct"
-            ),
+            exceptions.ScenarioNotCorrect(name_id=x, text=f"name_id ({x}) not correct"),
         ),
     ),
     validator(
@@ -63,12 +60,11 @@ VALIDATION_GAME_RECIPES = [
         func=is_multiple_keys_normal,
         error=lambda x: typing.cast(
             LoadError,
-            exceptions.ScenarioNotCorrect(
-                notify_user=INVALID_KEY_ERROR, text="invalid keys"
-            ),
+            exceptions.ScenarioNotCorrect(notify_user=INVALID_KEY_ERROR, text="invalid keys"),
         ),
     ),
 ]
+
 
 class DCFProvider(Provider):
     scope = Scope.APP
@@ -83,12 +79,7 @@ class DCFProvider(Provider):
 
     @provide
     def create_retort(self) -> Retort:
-        retort = Retort(
-            recipe=[
-                *REQUIRED_GAME_RECIPES,
-                *VALIDATION_GAME_RECIPES
-            ]
-        )
+        retort = Retort(recipe=[*REQUIRED_GAME_RECIPES, *VALIDATION_GAME_RECIPES])
         return retort
 
 

--- a/shvatka/common/factory.py
+++ b/shvatka/common/factory.py
@@ -8,6 +8,7 @@ from adaptix import (
     P,
     name_mapping,
     loader,
+    dumper,
     Chain,
 )
 from adaptix.load_error import LoadError
@@ -46,6 +47,42 @@ REQUIRED_GAME_RECIPES = [
         scn.Conditions, list[action.AnyCondition]
     ),  # internal class, can be broken in next adaptix version
 ]
+
+
+def create_game_retort() -> Retort:
+    """adaptix Retort for game scenarios using plain snake_case field names.
+
+    Used by the API for both parsing incoming scenarios and dumping them back, so the
+    request and response shapes are symmetric. Unlike :class:`DCFProvider` (legacy, kebab),
+    this does not pull in dataclass_factory.
+    """
+    return Retort(
+        recipe=[
+            *REQUIRED_GAME_RECIPES,
+            dumper(scn.HintsList, lambda x: x.hints),
+            validator(
+                pred=P[scn.LevelScenario].id,
+                func=lambda x: validate_level_id(x) is not None,
+                error=lambda x: typing.cast(
+                    LoadError,
+                    exceptions.ScenarioNotCorrect(name_id=x, text=f"name_id ({x}) not correct"),
+                ),
+            ),
+            validator(
+                pred=P[scn.LevelScenario].keys,
+                func=is_multiple_keys_normal,
+                error=lambda x: typing.cast(
+                    LoadError,
+                    exceptions.ScenarioNotCorrect(
+                        notify_user=INVALID_KEY_ERROR, text="invalid keys"
+                    ),
+                ),
+            ),
+        ]
+    )
+
+
+GAME_SCENARIO_RETORT: Retort = create_game_retort()
 
 
 class DCFProvider(Provider):

--- a/shvatka/core/games/editing_interactors.py
+++ b/shvatka/core/games/editing_interactors.py
@@ -1,0 +1,143 @@
+"""Interactors used by the web UI to create and edit game drafts.
+
+They wrap the domain services from :mod:`shvatka.core.services.game` and operate
+on internal domain models (FullGame, GameScenario, ...) so the transport layer
+(api routes) stays thin.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import BinaryIO
+
+from adaptix import Retort
+
+from shvatka.core.interfaces.clients.file_storage import FileStorage
+from shvatka.core.interfaces.dal.complex import GameCompleter, GameScenarioEditor
+from shvatka.core.interfaces.dal.file_info import FileUpserter
+from shvatka.core.interfaces.dal.game import (
+    GameAuthorsFinder,
+    GameByIdGetter,
+    GameCreator,
+    GameStartPlanner,
+    WaiverStarter,
+)
+from shvatka.core.interfaces.identity import IdentityProvider
+from shvatka.core.interfaces.scheduler import Scheduler
+from shvatka.core.models import dto, enums
+from shvatka.core.models.dto import hints
+from shvatka.core.players.player import check_allow_be_author
+from shvatka.core.rules.game import check_game_editable
+from shvatka.core.services.game import (
+    cancel_planed_start,
+    complete_game,
+    create_game,
+    get_authors_games,
+    get_full_game,
+    plain_start,
+    start_waivers,
+    update_game_scenario,
+)
+from shvatka.core.services.scenario.files import save_file
+from shvatka.core.utils import exceptions
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MyGamesInteractor:
+    dao: GameAuthorsFinder
+
+    async def __call__(self, identity: IdentityProvider) -> list[dto.Game]:
+        return await get_authors_games(identity, self.dao)
+
+
+@dataclass
+class MyGameInteractor:
+    dao: GameByIdGetter
+
+    async def __call__(self, game_id: int, identity: IdentityProvider) -> dto.FullGame:
+        return await get_full_game(game_id, identity, self.dao)
+
+
+@dataclass
+class CreateGameInteractor:
+    dao: GameCreator
+
+    async def __call__(self, name: str, identity: IdentityProvider) -> dto.Game:
+        author = await identity.get_required_player()
+        return await create_game(author=author, name=name, dao=self.dao)
+
+
+@dataclass
+class ChangeGameScenarioInteractor:
+    dao: GameScenarioEditor
+    retort: Retort
+
+    async def __call__(
+        self, game_id: int, raw_scn: dict, identity: IdentityProvider
+    ) -> dto.FullGame:
+        author = await identity.get_required_player()
+        return await update_game_scenario(game_id, raw_scn, author, self.dao, self.retort)
+
+
+@dataclass
+class ChangeGameStartAtInteractor:
+    getter: GameByIdGetter
+    dao: GameStartPlanner
+    scheduler: Scheduler
+
+    async def __call__(
+        self, game_id: int, start_at: datetime | None, identity: IdentityProvider
+    ) -> dto.Game:
+        author = await identity.get_required_player()
+        game = await self.getter.get_by_id(id_=game_id, author=author)
+        if start_at is None:
+            await cancel_planed_start(game, author, self.scheduler, self.dao)
+        else:
+            await plain_start(game, author, start_at, self.dao, self.scheduler)
+        return game
+
+
+@dataclass
+class ChangeGameStatusInteractor:
+    getter: GameByIdGetter
+    waiver_starter: WaiverStarter
+    completer: GameCompleter
+
+    async def __call__(
+        self, game_id: int, status: enums.GameStatus, identity: IdentityProvider
+    ) -> dto.Game:
+        author = await identity.get_required_player()
+        game = await self.getter.get_by_id(id_=game_id, author=author)
+        if status == enums.GameStatus.getting_waivers:
+            await start_waivers(game, author, self.waiver_starter)
+        elif status == enums.GameStatus.complete:
+            await complete_game(game, self.completer)
+        else:
+            raise exceptions.CantEditGame(
+                game=game,
+                player=author,
+                text=f"unsupported status transition to {status.name}",
+            )
+        return game
+
+
+@dataclass
+class UploadGameFileInteractor:
+    storage: FileStorage
+    game_dao: GameByIdGetter
+    file_dao: FileUpserter
+
+    async def __call__(
+        self,
+        game_id: int,
+        content: BinaryIO,
+        original_filename: str,
+        identity: IdentityProvider,
+    ) -> hints.SavedFileMeta:
+        author = await identity.get_required_player()
+        check_allow_be_author(author)
+        game = await self.game_dao.get_by_id(id_=game_id, author=author)
+        check_game_editable(game)
+        return await save_file(author, content, original_filename, self.storage, self.file_dao)

--- a/shvatka/core/games/editor_interactors.py
+++ b/shvatka/core/games/editor_interactors.py
@@ -82,7 +82,7 @@ class ChangeGameScenarioInteractor:
 
 
 @dataclass
-class ChangeGameStartAtInteractor:
+class PlanGameStartInteractor:
     getter: GameByIdGetter
     dao: GameStartPlanner
     scheduler: Scheduler

--- a/shvatka/core/interfaces/dal/complex.py
+++ b/shvatka/core/interfaces/dal/complex.py
@@ -54,7 +54,5 @@ class GamePackager(GameKeyGetter, LevelTimesGetter, GameWaiversGetter, FileInfoG
         raise NotImplementedError
 
 
-class GameScenarioEditor(
-    GameUpserter, GameRenamer, GameByIdGetter, FileInfoGetter, Protocol
-):
+class GameScenarioEditor(GameUpserter, GameRenamer, GameByIdGetter, FileInfoGetter, Protocol):
     pass

--- a/shvatka/core/interfaces/dal/complex.py
+++ b/shvatka/core/interfaces/dal/complex.py
@@ -7,6 +7,8 @@ from shvatka.core.interfaces.dal.game import (
     GameNumberUpdater,
     GameStatusCompleter,
     GameByIdGetter,
+    GameUpserter,
+    GameRenamer,
 )
 from shvatka.core.interfaces.dal.key_log import TeamKeysMerger, GameKeyGetter
 from shvatka.core.interfaces.dal.level import MaxLevelNumberGetter
@@ -50,3 +52,9 @@ class GameCompleter(
 class GamePackager(GameKeyGetter, LevelTimesGetter, GameWaiversGetter, FileInfoGetter, Protocol):
     async def get_full(self, id_: int) -> dto.FullGame:
         raise NotImplementedError
+
+
+class GameScenarioEditor(
+    GameUpserter, GameRenamer, GameByIdGetter, FileInfoGetter, Protocol
+):
+    pass

--- a/shvatka/core/interfaces/dal/file_info.py
+++ b/shvatka/core/interfaces/dal/file_info.py
@@ -1,5 +1,6 @@
 from typing import Protocol
 
+from shvatka.core.interfaces.dal.base import Committer
 from shvatka.core.models import dto
 from shvatka.core.models.dto import hints
 
@@ -11,4 +12,12 @@ class FileInfoMerger(Protocol):
 
 class FileInfoGetter(Protocol):
     async def get_by_guid(self, guid: str) -> hints.VerifiableFileMeta:
+        raise NotImplementedError
+
+
+class FileUpserter(Committer, Protocol):
+    async def upsert(self, file: hints.FileMeta, author: dto.Player) -> hints.SavedFileMeta:
+        raise NotImplementedError
+
+    async def check_author_can_own_guid(self, author: dto.Player, guid: str) -> None:
         raise NotImplementedError

--- a/shvatka/core/services/game.py
+++ b/shvatka/core/services/game.py
@@ -78,10 +78,10 @@ async def update_game_scenario(
     enforced) instead of by name, so the game can be safely renamed.
     """
     check_allow_be_author(author)
-    game_scn = parse_uploaded_game(scn.RawGameScenario(scn=raw_scn, files={}), retort)
     game = await dao.get_by_id(id_=id_, author=author)
     check_can_read(game, author)
     check_game_editable(game)
+    game_scn = parse_uploaded_game(scn.RawGameScenario(scn=raw_scn, files={}), retort)
     for file in game_scn.files:
         await dao.check_author_can_own_guid(author, file.guid)
     if game.name != game_scn.name:

--- a/shvatka/core/services/game.py
+++ b/shvatka/core/services/game.py
@@ -78,10 +78,10 @@ async def update_game_scenario(
     enforced) instead of by name, so the game can be safely renamed.
     """
     check_allow_be_author(author)
+    game_scn = parse_uploaded_game(scn.RawGameScenario(scn=raw_scn, files={}), retort)
     game = await dao.get_by_id(id_=id_, author=author)
     check_can_read(game, author)
     check_game_editable(game)
-    game_scn = parse_uploaded_game(scn.RawGameScenario(scn=raw_scn, files={}), retort)
     for file in game_scn.files:
         await dao.check_author_can_own_guid(author, file.guid)
     if game.name != game_scn.name:

--- a/shvatka/core/services/game.py
+++ b/shvatka/core/services/game.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from adaptix import Retort
 
 from shvatka.core.interfaces.clients.file_storage import FileGateway
-from shvatka.core.interfaces.dal.complex import GameCompleter, GamePackager
+from shvatka.core.interfaces.dal.complex import GameCompleter, GamePackager, GameScenarioEditor
 from shvatka.core.interfaces.dal.game import (
     GameUpserter,
     GameCreator,
@@ -54,6 +54,44 @@ async def upsert_game(
     guids = await upsert_files(author, raw_scn.files, game_scn.files, dao, file_gateway)
     check_all_files_saved(game=game_scn, guids=guids)
     game = await dao.upsert_game(author, game_scn)
+    await dao.unlink_all(game)
+    levels = []
+    for number, level in enumerate(game_scn.levels):
+        saved_level = await dao.upsert_gamed(author, level, game, number)
+        levels.append(saved_level)
+    await dao.commit()
+    return game.to_full_game(levels)
+
+
+async def update_game_scenario(
+    id_: int,
+    raw_scn: dict,
+    author: dto.Player,
+    dao: GameScenarioEditor,
+    retort: Retort,
+) -> dto.FullGame:
+    """Replace the whole scenario of an existing game draft identified by ``id_``.
+
+    Unlike :func:`upsert_game`, this does not receive file contents: files are
+    expected to be already uploaded (e.g. via the cdn endpoint) and the scenario
+    only references their guids. The game is looked up by id (and ownership is
+    enforced) instead of by name, so the game can be safely renamed.
+    """
+    check_allow_be_author(author)
+    game_scn = parse_uploaded_game(scn.RawGameScenario(scn=raw_scn, files={}), retort)
+    game = await dao.get_by_id(id_=id_, author=author)
+    check_can_read(game, author)
+    check_game_editable(game)
+    for file in game_scn.files:
+        await dao.check_author_can_own_guid(author, file.guid)
+    if game.name != game_scn.name:
+        if not await dao.is_name_available(game_scn.name):
+            raise CantEditGame(
+                player=author,
+                text=f"cant rename game to {game_scn.name} (name is already taken)",
+            )
+        await dao.rename_game(game, game_scn.name)
+        game.name = game_scn.name
     await dao.unlink_all(game)
     levels = []
     for number, level in enumerate(game_scn.levels):

--- a/shvatka/core/services/scenario/files.py
+++ b/shvatka/core/services/scenario/files.py
@@ -83,6 +83,26 @@ async def get_file_metas(
     return file_metas
 
 
+async def get_game_file_metas(
+    game: dto.FullGame, author: dto.Player, dao: FileInfoGetter
+) -> list[hints.FileMeta]:
+    """File metas of every distinct file referenced by the game (for the web UI).
+
+    Deduplicates guids (a file may be used by several hints) and enforces the same
+    read permission as the other file readers.
+    """
+    file_metas: list[hints.FileMeta] = []
+    seen: set[str] = set()
+    for guid in game.get_guids():
+        if guid in seen:
+            continue
+        seen.add(guid)
+        file_meta = await dao.get_by_guid(guid)
+        check_file_meta_can_read(author, file_meta, game)
+        file_metas.append(file_meta)
+    return file_metas
+
+
 async def get_file_contents(
     file_metas: Sequence[hints.FileMeta], file_gateway: FileGateway
 ) -> dict[str, BinaryIO]:

--- a/shvatka/core/services/scenario/files.py
+++ b/shvatka/core/services/scenario/files.py
@@ -1,11 +1,60 @@
+from pathlib import Path
 from typing import BinaryIO, Sequence
+from uuid import uuid4
 
-from shvatka.core.interfaces.clients.file_storage import FileGateway
-from shvatka.core.interfaces.dal.file_info import FileInfoGetter
+from shvatka.core.interfaces.clients.file_storage import FileGateway, FileStorage
+from shvatka.core.interfaces.dal.file_info import FileInfoGetter, FileUpserter
 from shvatka.core.interfaces.dal.game import GameUpserter
-from shvatka.core.models import dto
+from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import hints
 from shvatka.core.utils.exceptions import NotAuthorizedForEdit
+
+
+_MIME_PREFIX_TO_HINT_TYPE = {
+    "image": enums.HintType.photo,
+    "video": enums.HintType.video,
+    "audio": enums.HintType.audio,
+}
+
+
+def hint_type_by_mime(mime_type: str | None) -> enums.HintType:
+    """Best-effort mapping of a detected mime type to a HintType.
+
+    Anything that is not a recognised image/video/audio is treated as a document.
+    """
+    if mime_type:
+        prefix = mime_type.split("/", maxsplit=1)[0]
+        if prefix in _MIME_PREFIX_TO_HINT_TYPE:
+            return _MIME_PREFIX_TO_HINT_TYPE[prefix]
+    return enums.HintType.document
+
+
+async def save_file(
+    author: dto.Player,
+    content: BinaryIO,
+    original_filename: str,
+    storage: FileStorage,
+    dao: FileUpserter,
+) -> hints.SavedFileMeta:
+    """Store a single uploaded file (from the web UI) and persist its FileInfo.
+
+    Generates a fresh guid, stores the content via the file storage (which detects
+    sha256/mime and deduplicates) and saves the resulting meta to the DB. The actual
+    content type is derived from the detected mime type.
+    """
+    guid = str(uuid4())
+    extension = "".join(Path(original_filename).suffixes)
+    name = original_filename[: -len(extension)] if extension else original_filename
+    file_meta = hints.UploadedFileMeta(
+        guid=guid,
+        original_filename=name,
+        extension=extension,
+    )
+    stored = await storage.put(file_meta, content)
+    stored.content_type = hint_type_by_mime(stored.mime_type)
+    saved = await dao.upsert(stored, author)
+    await dao.commit()
+    return saved
 
 
 async def upsert_files(

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -62,6 +62,27 @@ class GameUpserterImpl(GameUpserter):
 
 
 @dataclass
+class GameScenarioEditorImpl(GameUpserterImpl):
+    """Combines game upsert, rename, reading by id and file checks for editing
+    an existing game draft (identified by id) from the web UI."""
+
+    async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
+        return await self.dao.game.get_by_id(id_, author)
+
+    async def get_full(self, id_: int) -> dto.FullGame:
+        return await self.dao.game.get_full(id_)
+
+    async def add_levels(self, game: dto.Game) -> dto.FullGame:
+        return await self.dao.game.add_levels(game)
+
+    async def rename_game(self, game: dto.Game, new_name: str) -> None:
+        await self.dao.game.rename_game(game, new_name)
+
+    async def get_by_guid(self, guid: str) -> hints.VerifiableFileMeta:
+        return await self.dao.file_info.get_by_guid(guid)
+
+
+@dataclass
 class GameCreatorImpl(GameCreator):
     dao: "HolderDao"
 

--- a/shvatka/infrastructure/db/dao/holder.py
+++ b/shvatka/infrastructure/db/dao/holder.py
@@ -9,7 +9,6 @@ from shvatka.core.interfaces.dal.complex import (
     TypedKeyGetter,
     GameStatDao,
     GamePackager,
-    GameScenarioEditor,
 )
 from shvatka.core.interfaces.dal.game import GameUpserter, GameCreator
 from shvatka.core.interfaces.dal.game_play import GamePreparer, GamePlayerDao
@@ -23,7 +22,6 @@ from .complex.game import (
     GameUpserterImpl,
     GameCreatorImpl,
     GamePackagerImpl,
-    GameScenarioEditorImpl,
 )
 from .complex.game_play import GamePreparerImpl, GameStarterImpl, GamePlayerDaoImpl
 from .complex.key_log import TypedKeyGetterImpl
@@ -106,10 +104,6 @@ class HolderDao:
     @property
     def game_packager(self) -> GamePackager:
         return GamePackagerImpl(dao=self)
-
-    @property
-    def game_scenario_editor(self) -> GameScenarioEditor:
-        return GameScenarioEditorImpl(dao=self)
 
     @property
     def team_creator(self) -> TeamCreator:

--- a/shvatka/infrastructure/db/dao/holder.py
+++ b/shvatka/infrastructure/db/dao/holder.py
@@ -9,6 +9,7 @@ from shvatka.core.interfaces.dal.complex import (
     TypedKeyGetter,
     GameStatDao,
     GamePackager,
+    GameScenarioEditor,
 )
 from shvatka.core.interfaces.dal.game import GameUpserter, GameCreator
 from shvatka.core.interfaces.dal.game_play import GamePreparer, GamePlayerDao
@@ -18,7 +19,12 @@ from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.interfaces.dal.player import TeamLeaver, PlayerPromoter, PlayerMerger
 from shvatka.core.interfaces.dal.team import TeamCreator
 from shvatka.core.interfaces.dal.waiver import WaiverApprover
-from .complex.game import GameUpserterImpl, GameCreatorImpl, GamePackagerImpl
+from .complex.game import (
+    GameUpserterImpl,
+    GameCreatorImpl,
+    GamePackagerImpl,
+    GameScenarioEditorImpl,
+)
 from .complex.game_play import GamePreparerImpl, GameStarterImpl, GamePlayerDaoImpl
 from .complex.key_log import TypedKeyGetterImpl
 from .complex.level_testing import LevelTestComplex
@@ -100,6 +106,10 @@ class HolderDao:
     @property
     def game_packager(self) -> GamePackager:
         return GamePackagerImpl(dao=self)
+
+    @property
+    def game_scenario_editor(self) -> GameScenarioEditor:
+        return GameScenarioEditorImpl(dao=self)
 
     @property
     def team_creator(self) -> TeamCreator:

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -1,5 +1,6 @@
-from adaptix import Retort
 from dishka import Provider, Scope, provide
+
+from shvatka.common.factory import GAME_SCENARIO_RETORT
 
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
@@ -127,8 +128,10 @@ class GameEditProvider(Provider):
         return CreateGameInteractor(dao.game_creator)
 
     @provide
-    def change_scenario(self, dao: HolderDao, retort: Retort) -> ChangeGameScenarioInteractor:
-        return ChangeGameScenarioInteractor(dao=dao.game_scenario_editor, retort=retort)
+    def change_scenario(self, dao: HolderDao) -> ChangeGameScenarioInteractor:
+        return ChangeGameScenarioInteractor(
+            dao=dao.game_scenario_editor, retort=GAME_SCENARIO_RETORT
+        )
 
     @provide
     def change_start_at(

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -1,6 +1,5 @@
+from adaptix import Retort
 from dishka import Provider, Scope, provide
-
-from shvatka.common.factory import GAME_SCENARIO_RETORT
 
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
@@ -128,10 +127,8 @@ class GameEditProvider(Provider):
         return CreateGameInteractor(dao.game_creator)
 
     @provide
-    def change_scenario(self, dao: HolderDao) -> ChangeGameScenarioInteractor:
-        return ChangeGameScenarioInteractor(
-            dao=dao.game_scenario_editor, retort=GAME_SCENARIO_RETORT
-        )
+    def change_scenario(self, dao: HolderDao, retort: Retort) -> ChangeGameScenarioInteractor:
+        return ChangeGameScenarioInteractor(dao=dao.game_scenario_editor, retort=retort)
 
     @provide
     def change_start_at(

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -1,3 +1,4 @@
+from adaptix import Retort
 from dishka import Provider, Scope, provide
 
 from shvatka.core.games.interactors import (
@@ -9,6 +10,17 @@ from shvatka.core.games.interactors import (
     CheckKeyInteractor,
     GamePlayRoleReader,
 )
+from shvatka.core.games.editing_interactors import (
+    MyGamesInteractor,
+    MyGameInteractor,
+    CreateGameInteractor,
+    ChangeGameScenarioInteractor,
+    ChangeGameStartAtInteractor,
+    ChangeGameStatusInteractor,
+    UploadGameFileInteractor,
+)
+from shvatka.core.interfaces.clients.file_storage import FileStorage
+from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.games.adapters import (
     GameFileReader,
     GameKeysReader,
@@ -97,6 +109,44 @@ class GamePlayProvider(Provider):
 
     all_game_keys_reader_interactor = provide(AllGameKeysReaderInteractor)
     transitions_reader_interactor = provide(GameScenarioTransitionsInteractor)
+
+
+class GameEditProvider(Provider):
+    scope = Scope.REQUEST
+
+    @provide
+    def my_games(self, dao: HolderDao) -> MyGamesInteractor:
+        return MyGamesInteractor(dao.game)
+
+    @provide
+    def my_game(self, dao: HolderDao) -> MyGameInteractor:
+        return MyGameInteractor(dao.game)
+
+    @provide
+    def create_game(self, dao: HolderDao) -> CreateGameInteractor:
+        return CreateGameInteractor(dao.game_creator)
+
+    @provide
+    def change_scenario(self, dao: HolderDao, retort: Retort) -> ChangeGameScenarioInteractor:
+        return ChangeGameScenarioInteractor(dao=dao.game_scenario_editor, retort=retort)
+
+    @provide
+    def change_start_at(
+        self, dao: HolderDao, scheduler: Scheduler
+    ) -> ChangeGameStartAtInteractor:
+        return ChangeGameStartAtInteractor(getter=dao.game, dao=dao.game, scheduler=scheduler)
+
+    @provide
+    def change_status(self, dao: HolderDao) -> ChangeGameStatusInteractor:
+        return ChangeGameStatusInteractor(
+            getter=dao.game, waiver_starter=dao.game, completer=dao.game
+        )
+
+    @provide
+    def upload_file(self, dao: HolderDao, storage: FileStorage) -> UploadGameFileInteractor:
+        return UploadGameFileInteractor(
+            storage=storage, game_dao=dao.game, file_dao=dao.file_info
+        )
 
 
 class WaiverProvider(Provider):

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -131,9 +131,7 @@ class GameEditProvider(Provider):
         return ChangeGameScenarioInteractor(dao=dao.game_scenario_editor, retort=retort)
 
     @provide
-    def change_start_at(
-        self, dao: HolderDao, scheduler: Scheduler
-    ) -> ChangeGameStartAtInteractor:
+    def change_start_at(self, dao: HolderDao, scheduler: Scheduler) -> ChangeGameStartAtInteractor:
         return ChangeGameStartAtInteractor(getter=dao.game, dao=dao.game, scheduler=scheduler)
 
     @provide
@@ -144,9 +142,7 @@ class GameEditProvider(Provider):
 
     @provide
     def upload_file(self, dao: HolderDao, storage: FileStorage) -> UploadGameFileInteractor:
-        return UploadGameFileInteractor(
-            storage=storage, game_dao=dao.game, file_dao=dao.file_info
-        )
+        return UploadGameFileInteractor(storage=storage, game_dao=dao.game, file_dao=dao.file_info)
 
 
 class WaiverProvider(Provider):

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -10,16 +10,17 @@ from shvatka.core.games.interactors import (
     CheckKeyInteractor,
     GamePlayRoleReader,
 )
-from shvatka.core.games.editing_interactors import (
+from shvatka.core.games.editor_interactors import (
     MyGamesInteractor,
     MyGameInteractor,
     CreateGameInteractor,
     ChangeGameScenarioInteractor,
-    ChangeGameStartAtInteractor,
+    PlanGameStartInteractor,
     ChangeGameStatusInteractor,
     UploadGameFileInteractor,
 )
 from shvatka.core.interfaces.clients.file_storage import FileStorage
+from shvatka.core.interfaces.dal.complex import GameScenarioEditor
 from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.games.adapters import (
     GameFileReader,
@@ -50,7 +51,7 @@ from shvatka.infrastructure.db.dao.complex2.waiver import (
     WaiverVoteGetterImpl,
     PollDraftsReaderImpl,
 )
-from shvatka.infrastructure.db.dao.complex.game import GameFilesGetterImpl
+from shvatka.infrastructure.db.dao.complex.game import GameFilesGetterImpl, GameScenarioEditorImpl
 from shvatka.infrastructure.db.dao.complex.game import (
     GamePlayDaoImpl,
 )
@@ -127,12 +128,18 @@ class GameEditProvider(Provider):
         return CreateGameInteractor(dao.game_creator)
 
     @provide
-    def change_scenario(self, dao: HolderDao, retort: Retort) -> ChangeGameScenarioInteractor:
-        return ChangeGameScenarioInteractor(dao=dao.game_scenario_editor, retort=retort)
+    def game_scenario_editor(self, dao: HolderDao) -> GameScenarioEditor:
+        return GameScenarioEditorImpl(dao=dao)
 
     @provide
-    def change_start_at(self, dao: HolderDao, scheduler: Scheduler) -> ChangeGameStartAtInteractor:
-        return ChangeGameStartAtInteractor(getter=dao.game, dao=dao.game, scheduler=scheduler)
+    def change_scenario(
+        self, dao: GameScenarioEditor, retort: Retort
+    ) -> ChangeGameScenarioInteractor:
+        return ChangeGameScenarioInteractor(dao=dao, retort=retort)
+
+    @provide
+    def change_start_at(self, dao: HolderDao, scheduler: Scheduler) -> PlanGameStartInteractor:
+        return PlanGameStartInteractor(getter=dao.game, dao=dao.game, scheduler=scheduler)
 
     @provide
     def change_status(self, dao: HolderDao) -> ChangeGameStatusInteractor:

--- a/tests/fixtures/resources/all_types.yml
+++ b/tests/fixtures/resources/all_types.yml
@@ -7,7 +7,7 @@ levels:
       - type: WIN_KEY
         keys:
           - "SH123"
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -27,58 +27,58 @@ levels:
       - time: 3
         hint:
           - type: photo
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
             caption: "фоточка"
       - time: 4
         hint:
           - type: audio
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
-            thumb-guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            thumb_guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
             caption: "музончик"
       - time: 5
         hint:
           - type: video
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
-            thumb-guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            thumb_guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
             caption: "видосик"
       - time: 6
         hint:
           - type: document
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
-            thumb-guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            thumb_guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
             caption: "файлик"
       - time: 7
         hint:
           - type: animation
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
-            thumb-guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            thumb_guid: 83e6a132-5c25-4fb1-8683-29ad498e90d8
             caption: "гифка"
       - time: 8
         hint:
           - type: voice
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
             caption: "войс"
       - time: 9
         hint:
           - type: video_note
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
       - time: 10
         hint:
           - type: contact
-            phone-number: "+71234567890"
-            first-name: "Albus"
-            last-name: "Dumbledore"
+            phone_number: "+71234567890"
+            first_name: "Albus"
+            last_name: "Dumbledore"
       - time: 11
         hint:
           - type: sticker
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
 
 files:
   - guid: "a3bc9b96-3bb8-4dbc-b996-ce1015e66e53"
-    original-filename: "hint2"
+    original_filename: "hint2"
     extension: ".jpg"
-    tg-link:
-      file-id: "98765"
-      content-type: "photo"
-    file-content-link:
-      file-path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"
+    tg_link:
+      file_id: "98765"
+      content_type: "photo"
+    file_content_link:
+      file_path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"

--- a/tests/fixtures/resources/complex_scn.yml
+++ b/tests/fixtures/resources/complex_scn.yml
@@ -13,7 +13,7 @@ levels:
           - "SHBONUS"
         effects:
           id: 019d16d6-95f5-7c85-bae6-7a1a84932ac5
-          bonus-minutes: 10
+          bonus_minutes: 10
       - type: EFFECTS_KEY
         keys:
          - "SHBONUSHINT"
@@ -32,9 +32,9 @@ levels:
           id: 019d16d7-3eca-7f9e-b94c-b0fe6d949994
           hints:
             - type: photo
-              file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+              file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
               caption: hello
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -44,7 +44,7 @@ levels:
       - time: 2
         hint:
           - type: photo
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e53
             caption: "привет"
       - time: 4
         hint:
@@ -60,7 +60,7 @@ levels:
     conditions:
       - type: WIN_KEY
         keys: [ "SHOOT" ]
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -83,10 +83,10 @@ levels:
             text: "SHOOT"
 files:
   - guid: "a3bc9b96-3bb8-4dbc-b996-ce1015e66e53"
-    original-filename: "hint2"
+    original_filename: "hint2"
     extension: ".jpg"
-    tg-link:
-      file-id: "98765"
-      content-type: "photo"
-    file-content-link:
-      file-path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"
+    tg_link:
+      file_id: "98765"
+      content_type: "photo"
+    file_content_link:
+      file_path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"

--- a/tests/fixtures/resources/routed_scn.yml
+++ b/tests/fixtures/resources/routed_scn.yml
@@ -11,21 +11,21 @@ levels:
         keys: [ "SHTO1" ]
         effects:
           id: 019d1bcc-7889-79c8-9bfb-0e7a2ec65dd8
-          level-up: true
-          next-level: first
+          level_up: true
+          next_level: first
       - type: EFFECTS_KEY
         keys: [ "SHTO2" ]
         effects:
           id: 019d1bcc-7889-79c8-9bfb-0e7a2ec65dd9
-          level-up: true
-          next-level: second
+          level_up: true
+          next_level: second
       - type: EFFECTS_KEY
         keys: [ "SHTO3" ]
         effects:
           id: 019d1bcd-620f-7214-a61b-65764940ea7a
-          level-up: true
-          next-level: third
-    time-hints:
+          level_up: true
+          next_level: third
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -54,21 +54,21 @@ levels:
         keys: [ "SHTO1" ]
         effects:
           id: 019d1c19-f72b-7e23-ae1e-a5eb9c2fb4b5
-          level-up: true
-          next-level: first
+          level_up: true
+          next_level: first
       - type: EFFECTS_KEY
         keys: [ "SHTO2" ]
         effects:
           id: 019d1c1a-254a-76f3-bfe3-18d0591788dd
-          level-up: true
-          next-level: second
+          level_up: true
+          next_level: second
       - type: EFFECTS_KEY
         keys: [ "SHTO3" ]
         effects:
           id: 019d1c1a-4378-7093-82bf-6e676bfdea56
-          level-up: true
-          next-level: third
-    time-hints:
+          level_up: true
+          next_level: third
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -98,21 +98,21 @@ levels:
         keys: [ "SHTO1" ]
         effects:
           id: 019d1c1a-6c30-7af7-88c9-85b65b2d4b18
-          level-up: true
-          next-level: first
+          level_up: true
+          next_level: first
       - type: EFFECTS_KEY
         keys: [ "SHTO2" ]
         effects:
           id: 019d1c1a-88e0-788a-8ada-ea3eccd7eb62
-          level-up: true
-          next-level: second
+          level_up: true
+          next_level: second
       - type: EFFECTS_KEY
         keys: [ "SHTO3" ]
         effects:
           id: 019d1c1a-a64a-7f84-aabb-9c9d2dfdd4fb
-          level-up: true
-          next-level: third
-    time-hints:
+          level_up: true
+          next_level: third
+    time_hints:
       - time: 0
         hint:
           - type: text

--- a/tests/fixtures/resources/scn_no_file_guid.yml
+++ b/tests/fixtures/resources/scn_no_file_guid.yml
@@ -7,7 +7,7 @@ levels:
       - type: WIN_KEY
         keys:
           - "SH123"
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -16,7 +16,7 @@ levels:
         hint:
           - type: photo
             # next is guid with 54 at the end. in files there is guid with 53
-            file-guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e54
+            file_guid: a3bc9b96-3bb8-4dbc-b996-ce1015e66e54
             caption: "привет"
       - time: 6
         hint:
@@ -24,10 +24,10 @@ levels:
             text: "SH123\nSH321"
 files:
   - guid: "a3bc9b96-3bb8-4dbc-b996-ce1015e66e53"
-    original-filename: "hint2"
+    original_filename: "hint2"
     extension: ".jpg"
-    tg-link:
-      file-id: "98765"
-      content-type: "photo"
-    file-content-link:
-      file-path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"
+    tg_link:
+      file_id: "98765"
+      content_type: "photo"
+    file_content_link:
+      file_path: "tests/fixtures/resources/a3bc9b96-3bb8-4dbc-b996-ce1015e66e53.jpg"

--- a/tests/fixtures/resources/simple_scn.yml
+++ b/tests/fixtures/resources/simple_scn.yml
@@ -8,7 +8,7 @@ levels:
         keys:
           - "SH123"
           - "SH321"
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -33,7 +33,7 @@ levels:
     conditions:
       - type: WIN_KEY
         keys: [ "SHOOT" ]
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text

--- a/tests/fixtures/resources/three_lvl_scn.yml
+++ b/tests/fixtures/resources/three_lvl_scn.yml
@@ -8,7 +8,7 @@ levels:
         keys:
           - "SH123"
           - "SH321"
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -33,7 +33,7 @@ levels:
     conditions:
       - type: WIN_KEY
         keys: [ "SHOOT" ]
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text
@@ -59,7 +59,7 @@ levels:
     conditions:
       - type: WIN_KEY
         keys: [ "SHARP" ]
-    time-hints:
+    time_hints:
       - time: 0
         hint:
           - type: text

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -92,9 +92,7 @@ async def test_my_game_full(
     assert body["id"] == game.id
     assert len(body["levels"]) == len(game.levels)
     # the `game` fixture references one file (deduplicated across hints)
-    assert body["files"] == [
-        {"guid": GUID, "original_filename": "hint2", "extension": ".jpg"}
-    ]
+    assert body["files"] == [{"guid": GUID, "original_filename": "hint2", "extension": ".jpg"}]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -1,18 +1,42 @@
 from datetime import datetime, timedelta
 
 import pytest
-from adaptix import Retort
 from httpx import AsyncClient
 
 from shvatka.api.dependencies.auth import AuthProperties
 from shvatka.api.models import responses
-from shvatka.common.factory import REQUIRED_GAME_RECIPES
+from shvatka.common.factory import GAME_SCENARIO_RETORT
 from shvatka.core.models import dto
-from shvatka.core.models.dto.scn.game import RawGameScenario
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.services.game import create_game
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db.dao.holder import HolderDao
+
+# Scenario body for PUT /games/my/{id}/scenario — snake_case (same casing in and out).
+SNAKE_SCENARIO: dict = {
+    "name": "scenario via api",
+    "__model_version__": 1,
+    "files": [],
+    "levels": [
+        {
+            "id": "first",
+            "__model_version__": 1,
+            "conditions": [{"type": "WIN_KEY", "keys": ["SH123", "SH321"]}],
+            "time_hints": [
+                {"time": 0, "hint": [{"type": "text", "text": "загадка"}]},
+                {"time": 5, "hint": [{"type": "text", "text": "подсказка"}]},
+            ],
+        },
+        {
+            "id": "second",
+            "__model_version__": 1,
+            "conditions": [{"type": "WIN_KEY", "keys": ["SHOOT"]}],
+            "time_hints": [
+                {"time": 0, "hint": [{"type": "text", "text": "загадка два"}]},
+            ],
+        },
+    ],
+}
 
 
 def auth_cookies(auth: AuthProperties, player: dto.Player) -> dict[str, str]:
@@ -74,23 +98,23 @@ async def test_change_scenario(
     auth: AuthProperties,
     author: dto.Player,
     dao: HolderDao,
-    simple_scn: RawGameScenario,
 ):
     game = await create_game(author=author, name="draft to fill", dao=dao.game_creator)
     resp = await client.put(
         f"/games/my/{game.id}/scenario",
-        json=simple_scn.scn,
+        json=SNAKE_SCENARIO,
         cookies=auth_cookies(auth, author),
     )
     assert resp.status_code == 200, resp.text
-    retort = Retort(recipe=[*REQUIRED_GAME_RECIPES])
-    actual = retort.load(resp.json(), responses.FullGame)
+    actual = GAME_SCENARIO_RETORT.load(resp.json(), responses.FullGame)
     assert actual.id == game.id
-    assert actual.name == simple_scn.scn["name"]
-    assert len(actual.levels) == len(simple_scn.scn["levels"])
+    assert actual.name == SNAKE_SCENARIO["name"]
+    assert len(actual.levels) == len(SNAKE_SCENARIO["levels"])
+    # response scenario must be the same snake_case shape that was sent in
+    assert "time_hints" in actual.levels[0].scenario
     stored = await dao.game.get_full(game.id)
-    assert stored.name == simple_scn.scn["name"]
-    assert len(stored.levels) == len(simple_scn.scn["levels"])
+    assert stored.name == SNAKE_SCENARIO["name"]
+    assert len(stored.levels) == len(SNAKE_SCENARIO["levels"])
 
 
 @pytest.mark.asyncio
@@ -169,12 +193,11 @@ async def test_change_scenario_foreign_game_forbidden(
     auth: AuthProperties,
     harry: dto.Player,
     game: dto.FullGame,
-    simple_scn: RawGameScenario,
 ):
     # harry is not the author of `game`
     resp = await client.put(
         f"/games/my/{game.id}/scenario",
-        json=simple_scn.scn,
+        json=SNAKE_SCENARIO,
         cookies=auth_cookies(auth, harry),
     )
     assert resp.status_code == 422, resp.text

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -11,6 +11,7 @@ from shvatka.core.models.enums import GameStatus
 from shvatka.core.services.game import create_game
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from tests.fixtures.scn_fixtures import GUID
 
 # Scenario body for PUT /games/my/{id}/scenario — snake_case (same casing in and out).
 SNAKE_SCENARIO: dict = {
@@ -90,6 +91,67 @@ async def test_my_game_full(
     body = resp.json()
     assert body["id"] == game.id
     assert len(body["levels"]) == len(game.levels)
+    # the `game` fixture references one file (deduplicated across hints)
+    assert body["files"] == [
+        {"guid": GUID, "original_filename": "hint2", "extension": ".jpg"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scenario_files_round_trip(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft with file ref", dao=dao.game_creator)
+    cookies = auth_cookies(auth, author)
+    # upload a file and reference it from a hint
+    up = await client.post(
+        f"/cdn/games/{game.id}/files",
+        files={"file": ("pic.png", b"\x89PNG\r\n\x1a\n binary", "image/png")},
+        cookies=cookies,
+    )
+    assert up.status_code == 200, up.text
+    f = up.json()
+    scenario = {
+        "name": "with files",
+        "__model_version__": 1,
+        "files": [
+            {
+                "guid": f["guid"],
+                "original_filename": f["original_filename"],
+                "extension": f["extension"],
+            }
+        ],
+        "levels": [
+            {
+                "id": "first",
+                "__model_version__": 1,
+                "conditions": [{"type": "WIN_KEY", "keys": ["SH123"]}],
+                "time_hints": [
+                    {
+                        "time": 0,
+                        "hint": [{"type": "photo", "file_guid": f["guid"], "caption": "pic"}],
+                    }
+                ],
+            }
+        ],
+    }
+    expected_files = [
+        {
+            "guid": f["guid"],
+            "original_filename": f["original_filename"],
+            "extension": f["extension"],
+        }
+    ]
+    put = await client.put(f"/games/my/{game.id}/scenario", json=scenario, cookies=cookies)
+    assert put.status_code == 200, put.text
+    assert put.json()["files"] == expected_files
+    # and the GET reflects the same files section
+    got = await client.get(f"/games/my/{game.id}", cookies=cookies)
+    assert got.status_code == 200, got.text
+    assert got.json()["files"] == expected_files
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -1,0 +1,181 @@
+from datetime import datetime, timedelta
+
+import pytest
+from adaptix import Retort
+from httpx import AsyncClient
+
+from shvatka.api.dependencies.auth import AuthProperties
+from shvatka.api.models import responses
+from shvatka.common.factory import REQUIRED_GAME_RECIPES
+from shvatka.core.models import dto
+from shvatka.core.models.dto.scn.game import RawGameScenario
+from shvatka.core.models.enums import GameStatus
+from shvatka.core.services.game import create_game
+from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.infrastructure.db.dao.holder import HolderDao
+
+
+def auth_cookies(auth: AuthProperties, player: dto.Player) -> dict[str, str]:
+    token = auth.create_user_token(player)
+    return {"Authorization": "Bearer " + token.access_token}
+
+
+@pytest.mark.asyncio
+async def test_create_my_game(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    resp = await client.post(
+        "/games/my",
+        json={"name": "my brand new game"},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["name"] == "my brand new game"
+    assert body["status"] == GameStatus.underconstruction.value
+    stored = await dao.game.get_by_id(body["id"], author)
+    assert stored.name == "my brand new game"
+
+
+@pytest.mark.asyncio
+async def test_my_games_list(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft for list", dao=dao.game_creator)
+    resp = await client.get("/games/my", cookies=auth_cookies(auth, author))
+    assert resp.status_code == 200, resp.text
+    ids = [g["id"] for g in resp.json()["content"]]
+    assert game.id in ids
+
+
+@pytest.mark.asyncio
+async def test_my_game_full(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    game: dto.FullGame,
+):
+    resp = await client.get(f"/games/my/{game.id}", cookies=auth_cookies(auth, author))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == game.id
+    assert len(body["levels"]) == len(game.levels)
+
+
+@pytest.mark.asyncio
+async def test_change_scenario(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+    simple_scn: RawGameScenario,
+):
+    game = await create_game(author=author, name="draft to fill", dao=dao.game_creator)
+    resp = await client.put(
+        f"/games/my/{game.id}/scenario",
+        json=simple_scn.scn,
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    retort = Retort(recipe=[*REQUIRED_GAME_RECIPES])
+    actual = retort.load(resp.json(), responses.FullGame)
+    assert actual.id == game.id
+    assert actual.name == simple_scn.scn["name"]
+    assert len(actual.levels) == len(simple_scn.scn["levels"])
+    stored = await dao.game.get_full(game.id)
+    assert stored.name == simple_scn.scn["name"]
+    assert len(stored.levels) == len(simple_scn.scn["levels"])
+
+
+@pytest.mark.asyncio
+async def test_change_start_at(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft to schedule", dao=dao.game_creator)
+    start_at = datetime.now(tz=tz_utc) + timedelta(days=1)
+    resp = await client.put(
+        f"/games/my/{game.id}/start_at",
+        json={"start_at": start_at.isoformat()},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    stored = await dao.game.get_by_id(game.id, author)
+    assert stored.start_at is not None
+    assert stored.start_at.astimezone(tz_utc) == start_at
+
+    resp = await client.put(
+        f"/games/my/{game.id}/start_at",
+        json={"start_at": None},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    stored = await dao.game.get_by_id(game.id, author)
+    assert stored.start_at is None
+
+
+@pytest.mark.asyncio
+async def test_change_status(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft to publish", dao=dao.game_creator)
+    resp = await client.put(
+        f"/games/my/{game.id}/status",
+        json={"status": GameStatus.getting_waivers.value},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == GameStatus.getting_waivers.value
+    stored = await dao.game.get_by_id(game.id, author)
+    assert stored.status == GameStatus.getting_waivers
+
+
+@pytest.mark.asyncio
+async def test_upload_game_file(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft with files", dao=dao.game_creator)
+    resp = await client.post(
+        f"/cdn/games/{game.id}/files",
+        files={"file": ("note.txt", b"hello world", "text/plain")},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["guid"]
+    assert body["original_filename"] == "note"
+    assert body["extension"] == ".txt"
+    stored = await dao.file_info.get_by_guid(body["guid"])
+    assert stored.author_id == author.id
+
+
+@pytest.mark.asyncio
+async def test_change_scenario_foreign_game_forbidden(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    game: dto.FullGame,
+    simple_scn: RawGameScenario,
+):
+    # harry is not the author of `game`
+    resp = await client.put(
+        f"/games/my/{game.id}/scenario",
+        json=simple_scn.scn,
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "GameHasAnotherAuthor"

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
 
 import pytest
+from adaptix import Retort
 from httpx import AsyncClient
 
 from shvatka.api.dependencies.auth import AuthProperties
 from shvatka.api.models import responses
-from shvatka.common.factory import GAME_SCENARIO_RETORT
 from shvatka.core.models import dto
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.services.game import create_game
@@ -98,6 +98,7 @@ async def test_change_scenario(
     auth: AuthProperties,
     author: dto.Player,
     dao: HolderDao,
+    retort: Retort,
 ):
     game = await create_game(author=author, name="draft to fill", dao=dao.game_creator)
     resp = await client.put(
@@ -106,7 +107,7 @@ async def test_change_scenario(
         cookies=auth_cookies(auth, author),
     )
     assert resp.status_code == 200, resp.text
-    actual = GAME_SCENARIO_RETORT.load(resp.json(), responses.FullGame)
+    actual = retort.load(resp.json(), responses.FullGame)
     assert actual.id == game.id
     assert actual.name == SNAKE_SCENARIO["name"]
     assert len(actual.levels) == len(SNAKE_SCENARIO["levels"])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,6 +38,7 @@ from shvatka.infrastructure.di import (
     ContextProvider,
     DAOProvider,
 )
+from shvatka.infrastructure.di.interactors import GameEditProvider
 from shvatka.main_factory import ComplexOnlyProvider
 from shvatka.tgbot.main_factory import DpProvider, GameToolsProvider, BotIdpProvider
 from shvatka.infrastructure.db.factory import LockProvider
@@ -81,6 +82,7 @@ async def dishka():
         TelegraphProvider(),
         ContextProvider(),
         GamePlayProvider(),
+        GameEditProvider(),
         WaiverProvider(),
         PrinterProvider(),
         GameToolsProvider(),

--- a/tests/unit/serialization/test_deserialize.py
+++ b/tests/unit/serialization/test_deserialize.py
@@ -52,7 +52,7 @@ def test_deserialize_invalid_level(simple_scn: RawGameScenario, retort: Retort):
         load_level(level, retort)
 
     level = deepcopy(level_source)
-    level["time_hints"] = level.pop("time-hints")
+    level["time-hints"] = level.pop("time_hints")
     with pytest.raises(ScenarioNotCorrect):
         load_level(level, retort)
 
@@ -99,24 +99,24 @@ def test_serialize_simple(retort: Retort):
     serialized = retort.dump(game_example)
     assert serialized == {
         "name": "Funny game",
-        "author": {"can-be-author": True, "id": 100, "is-dummy": False, "username": None},
+        "author": {"can_be_author": True, "id": 100, "is_dummy": False, "username": None},
         "id": 10,
         "number": 20,
-        "manage-token": "",
-        "start-at": GAME_START_EXAMPLE.isoformat(),
+        "manage_token": "",
+        "start_at": GAME_START_EXAMPLE.isoformat(),
         "status": "complete",
         "results": {
-            "published-chanel-id": None,
-            "results-picture-file-id": None,
-            "keys-url": None,
+            "published_chanel_id": None,
+            "results_picture_file_id": None,
+            "keys_url": None,
         },
         "levels": [
             {
-                "db-id": 100,
-                "author": {"can-be-author": True, "id": 100, "is-dummy": False, "username": None},
-                "name-id": "level_100",
-                "game-id": 10,
-                "number-in-game": 0,
+                "db_id": 100,
+                "author": {"can_be_author": True, "id": 100, "is_dummy": False, "username": None},
+                "name_id": "level_100",
+                "game_id": 10,
+                "number_in_game": 0,
                 "scenario": {
                     "id": "level_100",
                     "__model_version__": 1,
@@ -134,23 +134,23 @@ def test_serialize_simple(retort: Retort):
                                     {
                                         "type": "text",
                                         "text": "hello",
-                                        "link-preview": None,
+                                        "link_preview": None,
                                     },
                                 ),
-                                "bonus-minutes": 1,
-                                "level-up": False,
-                                "next-level": None,
+                                "bonus_minutes": 1,
+                                "level_up": False,
+                                "next_level": None,
                             },
                         },
                     ],
-                    "time-hints": [
+                    "time_hints": [
                         {
                             "time": 0,
                             "hint": [
                                 {
                                     "type": "text",
                                     "text": "level_100_0",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -160,7 +160,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_100_10",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -170,7 +170,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_100_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -180,7 +180,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_100_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -190,7 +190,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_100_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -200,7 +200,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_100_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -208,11 +208,11 @@ def test_serialize_simple(retort: Retort):
                 },
             },
             {
-                "db-id": 101,
-                "author": {"can-be-author": True, "id": 100, "is-dummy": False, "username": None},
-                "name-id": "level_101",
-                "game-id": 10,
-                "number-in-game": 1,
+                "db_id": 101,
+                "author": {"can_be_author": True, "id": 100, "is_dummy": False, "username": None},
+                "name_id": "level_101",
+                "game_id": 10,
+                "number_in_game": 1,
                 "scenario": {
                     "id": "level_101",
                     "__model_version__": 1,
@@ -222,14 +222,14 @@ def test_serialize_simple(retort: Retort):
                             "keys": ("SH2",),
                         }
                     ],
-                    "time-hints": [
+                    "time_hints": [
                         {
                             "time": 0,
                             "hint": [
                                 {
                                     "type": "text",
                                     "text": "level_101_0",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -239,7 +239,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_101_10",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -249,7 +249,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_101_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -259,7 +259,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_101_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -269,7 +269,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_101_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -279,7 +279,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_101_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -287,11 +287,11 @@ def test_serialize_simple(retort: Retort):
                 },
             },
             {
-                "db-id": 102,
-                "author": {"can-be-author": True, "id": 100, "is-dummy": False, "username": None},
-                "name-id": "level_102",
-                "game-id": 10,
-                "number-in-game": 0,
+                "db_id": 102,
+                "author": {"can_be_author": True, "id": 100, "is_dummy": False, "username": None},
+                "name_id": "level_102",
+                "game_id": 10,
+                "number_in_game": 0,
                 "scenario": {
                     "id": "level_102",
                     "__model_version__": 1,
@@ -301,14 +301,14 @@ def test_serialize_simple(retort: Retort):
                             "keys": ("SH3",),
                         }
                     ],
-                    "time-hints": [
+                    "time_hints": [
                         {
                             "time": 0,
                             "hint": [
                                 {
                                     "type": "text",
                                     "text": "level_102_0",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -318,7 +318,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_102_10",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -328,7 +328,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_102_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -338,7 +338,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_102_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -348,7 +348,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_102_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -358,7 +358,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_102_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -366,11 +366,11 @@ def test_serialize_simple(retort: Retort):
                 },
             },
             {
-                "db-id": 103,
-                "author": {"can-be-author": True, "id": 100, "is-dummy": False, "username": None},
-                "name-id": "level_103",
-                "game-id": 10,
-                "number-in-game": 0,
+                "db_id": 103,
+                "author": {"can_be_author": True, "id": 100, "is_dummy": False, "username": None},
+                "name_id": "level_103",
+                "game_id": 10,
+                "number_in_game": 0,
                 "scenario": {
                     "id": "level_103",
                     "__model_version__": 1,
@@ -380,14 +380,14 @@ def test_serialize_simple(retort: Retort):
                             "keys": ("SH4",),
                         }
                     ],
-                    "time-hints": [
+                    "time_hints": [
                         {
                             "time": 0,
                             "hint": [
                                 {
                                     "type": "text",
                                     "text": "level_103_0",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -397,7 +397,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_103_10",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -407,7 +407,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_103_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -417,7 +417,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_103_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -427,7 +427,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_103_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },
@@ -437,7 +437,7 @@ def test_serialize_simple(retort: Retort):
                                 {
                                     "type": "text",
                                     "text": "level_103_20",
-                                    "link-preview": None,
+                                    "link_preview": None,
                                 }
                             ],
                         },


### PR DESCRIPTION
## What

Adds the web-UI endpoints for creating and editing game drafts. Everything goes through interactors that operate on the existing domain models (parsing/validating into internal `FullGame` / `GameScenario` models).

| Method & path | Purpose |
|---|---|
| `GET /api/games/my` | list my (non-complete) game drafts |
| `GET /api/games/my/{id}` | full game by id (author only) |
| `POST /api/games/my` | create a new game draft |
| `PUT /api/games/my/{id}/scenario` | replace the whole game scenario |
| `PUT /api/games/my/{id}/start_at` | set/clear planned start datetime |
| `PUT /api/games/my/{id}/status` | change game status |
| `POST /api/cdn/games/{id}/files` | upload a file, returns fileInfo with `guid` |

## How

- **Interactors** (`shvatka/core/games/editing_interactors.py`) wrap the existing domain services (`create_game`, `update_game_scenario`, `plain_start`/`cancel_planed_start`, `start_waivers`/`complete_game`, file save). Wired via a new `GameEditProvider` in the API container, plus `DCFProvider` so a validating `Retort` is available.
- **Scenario edits are id-based** (`update_game_scenario`), so a draft can be safely renamed. Files are expected to be pre-uploaded via the cdn endpoint; the service validates that referenced guids are owned by the author (`check_author_can_own_guid`) and reuses the scenario validation (`UploadedGameScenario` post-init: level routing + all-files-saved).
- **File upload** stores the content via `FileStorage` (sha256/mime detection + dedup) and persists a `FileInfo`, returning the generated guid. Content type is derived from the detected mime.
- New `GameScenarioEditor` DAO protocol/impl combines upsert + rename + read-by-id + file checks; new `FileUpserter` protocol for the upload path.
- `GET /api/games/my` now returns `responses.Game` (previously serialized raw core `dto.Game`, which leaked `manage_token`).

## Status transitions

`PUT /status` supports the transitions backed by existing domain services: `getting_waivers` (start waivers) and `complete` (complete a finished game). Other targets return a clear `CantEditGame` error rather than silently doing nothing.

## Tests

Adds `tests/integration/api_full/test_game_edit.py` covering create / list / read / scenario change / start_at (set + clear) / status change / file upload / foreign-author rejection. Full api + bot integration and unit suites pass locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZqn1VzSQvXPCXnXmz4sJc)_