### PR TITLE
Allow view_scenario orgs to read game files

### DIFF
--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -71,11 +71,13 @@ class GameFileReaderInteractor:
         file_gateway: FileGateway,
         current_game: CurrentGameProvider,
         game_play_dao: GamePlayDao,
+        org_dao: OrgByPlayerGetter,
     ):
         self.file_gateway = file_gateway
         self.dao = dao
         self.current_game = current_game
         self.game_play_dao = game_play_dao
+        self.org_dao = org_dao
 
     async def __call__(
         self, guid: str, game_id: int, identity: IdentityProvider
@@ -83,7 +85,11 @@ class GameFileReaderInteractor:
         user = await identity.get_required_user()
         player = await identity.get_required_player()
         game = await self.dao.get_full(game_id)
-        if game.author.id == player.id or game.is_complete():
+        if (
+            game.author.id == player.id
+            or game.is_complete()
+            or await self.can_view_scenario(game, player)
+        ):
             if guid not in game.get_guids():
                 raise exceptions.FileNotFound(
                     text=f"There is no file with uuid {guid} associated with game id {game_id}",
@@ -109,6 +115,10 @@ class GameFileReaderInteractor:
 
         meta = await self.dao.get_by_guid(guid)
         return meta
+
+    async def can_view_scenario(self, game: dto.Game, player: dto.Player) -> bool:
+        org = await self.org_dao.get_by_player_or_none(game=game, player=player)
+        return org is not None and not org.deleted and org.view_scenario
 
     async def is_guid_in_current_hint(self, identity: IdentityProvider, guid: str) -> bool:
         hints_ = await self.game_play_dao.get_current_hints(identity)

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -10,6 +10,8 @@ from shvatka.common.factory import REQUIRED_GAME_RECIPES
 from shvatka.core.models import dto
 from shvatka.core.models.dto import scn
 from shvatka.core.models.enums import GameStatus
+from shvatka.core.models.enums.org_permission import OrgPermission
+from shvatka.core.services.organizers import flip_permission
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db import models
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -134,6 +136,26 @@ async def test_game_file_game_not_completed(
         cookies={"Authorization": "Bearer " + token.access_token},
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_game_file_view_scenario_org(
+    game: dto.FullGame,
+    dao: HolderDao,
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+):
+    token = auth.create_user_token(harry)
+    org = await dao.organizer.add_new(game, harry)
+    await dao.commit()
+    await flip_permission(game.author, org, OrgPermission.view_scenario, dao.organizer)
+    resp = await client.get(
+        f"/cdn/games/{game.id}/files/{GUID}",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+    assert resp.is_success
+    assert resp.headers.get("X-Accel-Redirect") == f"/protected-files/{GUID}.jpg"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #241. That PR let organizers with the `view_scenario` permission read a game's scenario, but **file serving was not updated** — so such organizers could see the scenario structure yet got a `403` when the front-end tried to load the photo/audio/video files referenced by its hints (in any non-complete game).

This PR closes that gap.

## What changed

- `GameFileReaderInteractor` (`GET /cdn/games/{id}/files/{guid}`) now grants access when the requester is a non-deleted organizer with `view_scenario`, in addition to the existing author / completed-game / active-participation paths. Permitted orgs can fetch any file referenced in the game's scenario (`game.get_guids()`), in any status — mirroring the author branch.
- The interactor gains an `OrgByPlayerGetter` dependency (already provided in the DI container and used by the scenario interactors from #241), resolved via auto-wiring.

Upload (`POST /cdn/games/{id}/files`) is intentionally left author-only — `view_scenario` is a read permission.

## Testing

- `ruff` (lint + format) and `mypy` pass; unit tests pass (`65 passed`).
- Added `test_game_file_view_scenario_org`: grants a non-author player the `view_scenario` org permission on a not-yet-completed game and asserts the file endpoint returns the file (`X-Accel-Redirect`), where the same request previously returned `403` (see the adjacent `test_game_file_game_not_completed`). The full integration suite requires Postgres/Docker (unavailable locally) and runs in CI.

https://claude.ai/code/session_013xZaA6U7qRBTgQyQSubb3G

---
_Generated by [Claude Code](https://claude.ai/code/session_013xZaA6U7qRBTgQyQSubb3G)_