### PR TITLE
Add game organizers API routes

### DIFF
--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -26,6 +26,22 @@ class GameStatusChange:
 
 
 @dataclass
+class NewOrg:
+    player_id: int
+
+
+@dataclass
+class DeleteOrg:
+    org_id: int
+
+
+@dataclass
+class OrgPermissionUpdate:
+    permission: str
+    value: bool
+
+
+@dataclass
 class JoinTeam:
     player_id: int
     role: str | None = None

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -402,6 +402,29 @@ class OrganizerDto:
 
 
 @dataclass(kw_only=True)
+class GameOrganizer:
+    org_id: int | None
+    player: Player
+    can_spy: bool
+    can_see_log_keys: bool
+    can_validate_waivers: bool
+    view_scenario: bool
+    deleted: bool
+
+    @classmethod
+    def from_core(cls, core: dto.Organizer) -> "GameOrganizer":
+        return cls(
+            org_id=getattr(core, "id", None),
+            player=Player.from_core(core.player),
+            can_spy=core.can_spy,
+            can_see_log_keys=core.can_see_log_keys,
+            can_validate_waivers=core.can_validate_waivers,
+            view_scenario=core.view_scenario,
+            deleted=core.deleted,
+        )
+
+
+@dataclass(kw_only=True)
 class MyRoleDto:
     waiver_vote: enums.Played | None
     team: Team | None

--- a/shvatka/api/routes/game.py
+++ b/shvatka/api/routes/game.py
@@ -26,8 +26,15 @@ from shvatka.core.games.editor_interactors import (
     PlanGameStartInteractor,
     ChangeGameStatusInteractor,
 )
+from shvatka.core.games.org_interactors import (
+    ListGameOrgsInteractor,
+    AddGameOrgInteractor,
+    ChangeOrgPermissionInteractor,
+    RemoveGameOrgInteractor,
+)
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.models import enums
+from shvatka.core.models.enums.org_permission import OrgPermission
 from shvatka.core.services.game import (
     get_completed_games,
     get_full_game,
@@ -195,6 +202,62 @@ async def insert_key(
     )
 
 
+@inject
+async def get_game_organizers(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[ListGameOrgsInteractor],
+    id_: Annotated[int, Path(alias="id")],
+) -> responses.Page[responses.GameOrganizer]:
+    orgs = await interactor(game_id=id_, identity=identity)
+    return responses.Page([responses.GameOrganizer.from_core(org) for org in orgs])
+
+
+@inject
+async def add_game_organizer(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[AddGameOrgInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.NewOrg, Body()],
+) -> responses.GameOrganizer:
+    org = await interactor(game_id=id_, player_id=body.player_id, identity=identity)
+    return responses.GameOrganizer.from_core(org)
+
+
+@inject
+async def delete_game_organizer(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[RemoveGameOrgInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.DeleteOrg, Body()],
+) -> responses.GameOrganizer:
+    org = await interactor(game_id=id_, org_id=body.org_id, identity=identity)
+    return responses.GameOrganizer.from_core(org)
+
+
+@inject
+async def change_game_organizer_permission(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[ChangeOrgPermissionInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    org_id: Annotated[int, Path()],
+    body: Annotated[req.OrgPermissionUpdate, Body()],
+) -> responses.GameOrganizer:
+    try:
+        permission = OrgPermission[body.permission]
+    except KeyError as e:
+        raise HTTPException(
+            status_code=422, detail={"text": f"unknown permission {body.permission}"}
+        ) from e
+    org = await interactor(
+        game_id=id_,
+        org_id=org_id,
+        permission=permission,
+        value=body.value,
+        identity=identity,
+    )
+    return responses.GameOrganizer.from_core(org)
+
+
 def setup() -> APIRouter:
     router = APIRouter(prefix="/games")
     router.add_api_route("", get_all_games, methods=["GET"])
@@ -211,4 +274,10 @@ def setup() -> APIRouter:
     router.add_api_route("/{id}", get_game_card, methods=["GET"])
     router.add_api_route("/{id}/keys", get_game_keys, methods=["GET"])
     router.add_api_route("/{id}/stat", get_game_stat, methods=["GET"])
+    router.add_api_route("/{id}/organizers", get_game_organizers, methods=["GET"])
+    router.add_api_route("/{id}/organizers", add_game_organizer, methods=["POST"])
+    router.add_api_route("/{id}/organizers", delete_game_organizer, methods=["DELETE"])
+    router.add_api_route(
+        "/{id}/organizers/{org_id}", change_game_organizer_permission, methods=["PUT"]
+    )
     return router

--- a/shvatka/core/games/org_interactors.py
+++ b/shvatka/core/games/org_interactors.py
@@ -52,6 +52,7 @@ class AddGameOrgInteractor:
     player_dao: PlayerByIdGetter
     org_getter: OrgByPlayerGetter
     org_adder: OrgAdder
+    org_deleted_flipper: OrgDeletedFlipper
 
     async def __call__(
         self, game_id: int, player_id: int, identity: IdentityProvider
@@ -60,12 +61,17 @@ class AddGameOrgInteractor:
         game = await get_game(id_=game_id, dao=self.game_dao)
         check_allow_manage_orgs(game, manager.id)
         player = await self.player_dao.get_by_id(player_id)
-        if await self.org_getter.get_by_player_or_none(game=game, player=player) is not None:
-            raise exceptions.PlayerAlreadyOrganizer(
-                player=player,
-                game=game,
-                text="player is already an organizer of this game",
-            )
+        existing = await self.org_getter.get_by_player_or_none(game=game, player=player)
+        if existing is not None:
+            if not existing.deleted:
+                raise exceptions.PlayerAlreadyOrganizer(
+                    player=player,
+                    game=game,
+                    text="player is already an organizer of this game",
+                )
+            # a previously removed organizer is restored via the same POST endpoint
+            await flip_deleted(manager, existing, self.org_deleted_flipper)
+            return await self.org_deleted_flipper.get_by_id(existing.id)
         org = await self.org_adder.add_new_org(game, player)
         await self.org_adder.commit()
         return org

--- a/shvatka/core/games/org_interactors.py
+++ b/shvatka/core/games/org_interactors.py
@@ -73,6 +73,7 @@ class AddGameOrgInteractor:
 
 @dataclass
 class ChangeOrgPermissionInteractor:
+    game_dao: GameByIdGetter
     org_dao: OrgPermissionFlipper
 
     async def __call__(
@@ -84,9 +85,10 @@ class ChangeOrgPermissionInteractor:
         identity: IdentityProvider,
     ) -> dto.SecondaryOrganizer:
         manager = await identity.get_required_player()
+        game = await get_game(id_=game_id, dao=self.game_dao)
+        check_allow_manage_orgs(game, manager.id)
         org = await get_org_by_id(org_id, self.org_dao)
-        check_org_belongs_to_game(org, game_id)
-        check_allow_manage_orgs(org.game, manager.id)
+        check_org_belongs_to_game(org, game.id)
         if getattr(org, permission.name) != value:
             await flip_permission(manager, org, permission, self.org_dao)
         return await self.org_dao.get_by_id(org_id)
@@ -94,15 +96,17 @@ class ChangeOrgPermissionInteractor:
 
 @dataclass
 class RemoveGameOrgInteractor:
+    game_dao: GameByIdGetter
     org_dao: OrgDeletedFlipper
 
     async def __call__(
         self, game_id: int, org_id: int, identity: IdentityProvider
     ) -> dto.SecondaryOrganizer:
         manager = await identity.get_required_player()
+        game = await get_game(id_=game_id, dao=self.game_dao)
+        check_allow_manage_orgs(game, manager.id)
         org = await get_org_by_id(org_id, self.org_dao)
-        check_org_belongs_to_game(org, game_id)
-        check_allow_manage_orgs(org.game, manager.id)
+        check_org_belongs_to_game(org, game.id)
         if not org.deleted:
             await flip_deleted(manager, org, self.org_dao)
         return await self.org_dao.get_by_id(org_id)

--- a/shvatka/core/games/org_interactors.py
+++ b/shvatka/core/games/org_interactors.py
@@ -1,0 +1,128 @@
+"""Interactors used by the web UI / API to manage organizers of a game.
+
+They wrap the domain services from :mod:`shvatka.core.services.organizers` so the
+transport layer (api routes) stays thin and the access rules live in one place.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from shvatka.core.interfaces.dal.game import GameByIdGetter
+from shvatka.core.interfaces.dal.organizer import (
+    GameOrgsGetter,
+    OrgAdder,
+    OrgByPlayerGetter,
+    OrgDeletedFlipper,
+    OrgPermissionFlipper,
+)
+from shvatka.core.interfaces.dal.player import PlayerByIdGetter
+from shvatka.core.interfaces.identity import IdentityProvider
+from shvatka.core.models import dto
+from shvatka.core.models.enums.org_permission import OrgPermission
+from shvatka.core.services.game import get_game
+from shvatka.core.services.organizers import (
+    check_allow_manage_orgs,
+    flip_deleted,
+    flip_permission,
+    get_org_by_id,
+    get_primary_orgs,
+    get_secondary_orgs,
+)
+from shvatka.core.utils import exceptions
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ListGameOrgsInteractor:
+    game_dao: GameByIdGetter
+    org_dao: GameOrgsGetter
+
+    async def __call__(self, game_id: int, identity: IdentityProvider) -> list[dto.Organizer]:
+        game = await get_game(id_=game_id, dao=self.game_dao)
+        await check_can_view_orgs(game, identity)
+        primary = await get_primary_orgs(game)
+        secondary = await get_secondary_orgs(game, self.org_dao, with_deleted=True)
+        return [*primary, *secondary]
+
+
+@dataclass
+class AddGameOrgInteractor:
+    game_dao: GameByIdGetter
+    player_dao: PlayerByIdGetter
+    org_getter: OrgByPlayerGetter
+    org_adder: OrgAdder
+
+    async def __call__(
+        self, game_id: int, player_id: int, identity: IdentityProvider
+    ) -> dto.SecondaryOrganizer:
+        manager = await identity.get_required_player()
+        game = await get_game(id_=game_id, dao=self.game_dao)
+        check_allow_manage_orgs(game, manager.id)
+        player = await self.player_dao.get_by_id(player_id)
+        if await self.org_getter.get_by_player_or_none(game=game, player=player) is not None:
+            raise exceptions.PlayerAlreadyOrganizer(
+                player=player,
+                game=game,
+                text="player is already an organizer of this game",
+            )
+        org = await self.org_adder.add_new_org(game, player)
+        await self.org_adder.commit()
+        return org
+
+
+@dataclass
+class ChangeOrgPermissionInteractor:
+    org_dao: OrgPermissionFlipper
+
+    async def __call__(
+        self,
+        game_id: int,
+        org_id: int,
+        permission: OrgPermission,
+        value: bool,
+        identity: IdentityProvider,
+    ) -> dto.SecondaryOrganizer:
+        manager = await identity.get_required_player()
+        org = await get_org_by_id(org_id, self.org_dao)
+        check_org_belongs_to_game(org, game_id)
+        check_allow_manage_orgs(org.game, manager.id)
+        if getattr(org, permission.name) != value:
+            await flip_permission(manager, org, permission, self.org_dao)
+        return await self.org_dao.get_by_id(org_id)
+
+
+@dataclass
+class RemoveGameOrgInteractor:
+    org_dao: OrgDeletedFlipper
+
+    async def __call__(
+        self, game_id: int, org_id: int, identity: IdentityProvider
+    ) -> dto.SecondaryOrganizer:
+        manager = await identity.get_required_player()
+        org = await get_org_by_id(org_id, self.org_dao)
+        check_org_belongs_to_game(org, game_id)
+        check_allow_manage_orgs(org.game, manager.id)
+        if not org.deleted:
+            await flip_deleted(manager, org, self.org_dao)
+        return await self.org_dao.get_by_id(org_id)
+
+
+async def check_can_view_orgs(game: dto.Game, identity: IdentityProvider) -> None:
+    """Completed games are public; for the rest only the author and orgs may look."""
+    if game.is_complete():
+        return
+    org = await identity.get_org(game)
+    if org is None:
+        raise exceptions.IsNotOrganizer(
+            player=await identity.get_player(),
+            game_id=game.id,
+        )
+
+
+def check_org_belongs_to_game(org: dto.SecondaryOrganizer, game_id: int) -> None:
+    if org.game.id != game_id:
+        raise exceptions.GameNotFound(
+            game_id=game_id,
+            text=f"organizer {org.id} does not belong to game {game_id}",
+        )

--- a/shvatka/core/utils/exceptions.py
+++ b/shvatka/core/utils/exceptions.py
@@ -209,6 +209,10 @@ class IsNotOrganizer(SHError):
     notify_user = "Игрок не является организатором"
 
 
+class PlayerAlreadyOrganizer(SHError):
+    notify_user = "Игрок уже является организатором этой игры"
+
+
 class PromoteError(PermissionsError):
     notify_user = "Ошибка распространения права быть автором"
     permission_name = "can_be_author"

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -184,6 +184,7 @@ class GameEditProvider(Provider):
             player_dao=dao.player,
             org_getter=dao.organizer,
             org_adder=dao.org_adder,
+            org_deleted_flipper=dao.organizer,
         )
 
     @provide

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -188,11 +188,11 @@ class GameEditProvider(Provider):
 
     @provide
     def change_org_permission(self, dao: HolderDao) -> ChangeOrgPermissionInteractor:
-        return ChangeOrgPermissionInteractor(org_dao=dao.organizer)
+        return ChangeOrgPermissionInteractor(game_dao=dao.game, org_dao=dao.organizer)
 
     @provide
     def remove_org(self, dao: HolderDao) -> RemoveGameOrgInteractor:
-        return RemoveGameOrgInteractor(org_dao=dao.organizer)
+        return RemoveGameOrgInteractor(game_dao=dao.game, org_dao=dao.organizer)
 
 
 class WaiverProvider(Provider):

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -19,6 +19,12 @@ from shvatka.core.games.editor_interactors import (
     ChangeGameStatusInteractor,
     UploadGameFileInteractor,
 )
+from shvatka.core.games.org_interactors import (
+    ListGameOrgsInteractor,
+    AddGameOrgInteractor,
+    ChangeOrgPermissionInteractor,
+    RemoveGameOrgInteractor,
+)
 from shvatka.core.players.interactors import (
     GetPlayerInteractor,
     SearchPlayersInteractor,
@@ -166,6 +172,27 @@ class GameEditProvider(Provider):
     @provide
     def upload_file(self, dao: HolderDao, storage: FileStorage) -> UploadGameFileInteractor:
         return UploadGameFileInteractor(storage=storage, game_dao=dao.game, file_dao=dao.file_info)
+
+    @provide
+    def list_orgs(self, dao: HolderDao) -> ListGameOrgsInteractor:
+        return ListGameOrgsInteractor(game_dao=dao.game, org_dao=dao.organizer)
+
+    @provide
+    def add_org(self, dao: HolderDao) -> AddGameOrgInteractor:
+        return AddGameOrgInteractor(
+            game_dao=dao.game,
+            player_dao=dao.player,
+            org_getter=dao.organizer,
+            org_adder=dao.org_adder,
+        )
+
+    @provide
+    def change_org_permission(self, dao: HolderDao) -> ChangeOrgPermissionInteractor:
+        return ChangeOrgPermissionInteractor(org_dao=dao.organizer)
+
+    @provide
+    def remove_org(self, dao: HolderDao) -> RemoveGameOrgInteractor:
+        return RemoveGameOrgInteractor(org_dao=dao.organizer)
 
 
 class WaiverProvider(Provider):

--- a/tests/integration/api_full/test_game_organizers.py
+++ b/tests/integration/api_full/test_game_organizers.py
@@ -1,0 +1,246 @@
+import pytest
+from httpx import AsyncClient
+
+from shvatka.api.dependencies.auth import AuthProperties
+from shvatka.core.models import dto
+from shvatka.core.models.enums import OrgPermission
+from shvatka.infrastructure.db.dao.holder import HolderDao
+
+
+def auth_cookies(auth: AuthProperties, player: dto.Player) -> dict[str, str]:
+    token = auth.create_user_token(player)
+    return {"Authorization": "Bearer " + token.access_token}
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_only_primary(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    game: dto.FullGame,
+):
+    resp = await client.get(
+        f"/games/{game.id}/organizers",
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    content = resp.json()["content"]
+    assert len(content) == 1
+    primary = content[0]
+    # primary org is the author and is reported with a null org_id
+    assert primary["org_id"] is None
+    assert primary["player"]["id"] == author.id
+    assert primary["can_spy"] is True
+    assert primary["deleted"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_forbidden_for_stranger(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    game: dto.FullGame,
+):
+    # game is not completed and harry is neither author nor organizer
+    resp = await client.get(
+        f"/games/{game.id}/organizers",
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "IsNotOrganizer"
+
+
+@pytest.mark.asyncio
+async def test_list_orgs_public_when_completed(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    game: dto.FullGame,
+    dao: HolderDao,
+):
+    await dao.game.set_completed(game)
+    await dao.commit()
+    # for a completed game even a stranger may view the organizers
+    resp = await client.get(
+        f"/games/{game.id}/organizers",
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["content"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_org(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    resp = await client.post(
+        f"/games/{game.id}/organizers",
+        json={"player_id": harry.id},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["org_id"] is not None
+    assert body["player"]["id"] == harry.id
+    assert body["deleted"] is False
+    assert body["can_spy"] is False
+
+    secondary = await check_dao.organizer.get_orgs(game)
+    assert len(secondary) == 1
+    assert secondary[0].player.id == harry.id
+
+    # the new org now appears in the listing alongside the primary org
+    resp = await client.get(
+        f"/games/{game.id}/organizers",
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    ids = {org["player"]["id"] for org in resp.json()["content"]}
+    assert ids == {author.id, harry.id}
+
+
+@pytest.mark.asyncio
+async def test_add_org_forbidden_for_non_author(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    game: dto.FullGame,
+):
+    resp = await client.post(
+        f"/games/{game.id}/organizers",
+        json={"player_id": harry.id},
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "GameHasAnotherAuthor"
+
+
+@pytest.mark.asyncio
+async def test_add_org_twice_rejected(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+):
+    cookies = auth_cookies(auth, author)
+    first = await client.post(
+        f"/games/{game.id}/organizers", json={"player_id": harry.id}, cookies=cookies
+    )
+    assert first.status_code == 200, first.text
+    second = await client.post(
+        f"/games/{game.id}/organizers", json={"player_id": harry.id}, cookies=cookies
+    )
+    assert second.status_code == 422, second.text
+    assert second.json()["type"] == "PlayerAlreadyOrganizer"
+
+
+@pytest.mark.asyncio
+async def test_change_org_permission(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    org = await dao.organizer.add_new(game, harry)
+    await dao.commit()
+    cookies = auth_cookies(auth, author)
+
+    resp = await client.put(
+        f"/games/{game.id}/organizers/{org.id}",
+        json={"permission": OrgPermission.can_spy.name, "value": True},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["can_spy"] is True
+    stored = await check_dao.organizer.get_by_id(org.id)
+    assert stored.can_spy is True
+
+    # idempotent: setting the same value again keeps it enabled
+    resp = await client.put(
+        f"/games/{game.id}/organizers/{org.id}",
+        json={"permission": OrgPermission.can_spy.name, "value": True},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["can_spy"] is True
+
+    # and it can be turned back off
+    resp = await client.put(
+        f"/games/{game.id}/organizers/{org.id}",
+        json={"permission": OrgPermission.can_spy.name, "value": False},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["can_spy"] is False
+
+
+@pytest.mark.asyncio
+async def test_change_org_permission_unknown(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+    dao: HolderDao,
+):
+    org = await dao.organizer.add_new(game, harry)
+    await dao.commit()
+    resp = await client.put(
+        f"/games/{game.id}/organizers/{org.id}",
+        json={"permission": "not_a_permission", "value": True},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_delete_org(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    org = await dao.organizer.add_new(game, harry)
+    await dao.commit()
+    cookies = auth_cookies(auth, author)
+
+    resp = await client.request(
+        "DELETE",
+        f"/games/{game.id}/organizers",
+        json={"org_id": org.id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] is True
+    stored = await check_dao.organizer.get_by_id(org.id)
+    assert stored.deleted is True
+
+    # not listed among the active orgs anymore ...
+    assert await check_dao.organizer.get_orgs(game) == []
+    # ... but still present (with deleted=True) in the api listing
+    listing = await client.get(f"/games/{game.id}/organizers", cookies=cookies)
+    assert listing.status_code == 200, listing.text
+    harry_org = next(o for o in listing.json()["content"] if o["player"]["id"] == harry.id)
+    assert harry_org["deleted"] is True
+
+    # deleting again is idempotent
+    resp = await client.request(
+        "DELETE",
+        f"/games/{game.id}/organizers",
+        json={"org_id": org.id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] is True

--- a/tests/integration/api_full/test_game_organizers.py
+++ b/tests/integration/api_full/test_game_organizers.py
@@ -141,6 +141,36 @@ async def test_add_org_twice_rejected(
 
 
 @pytest.mark.asyncio
+async def test_restore_org_via_post(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    game: dto.FullGame,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    org = await dao.organizer.add_new(game, harry)
+    await dao.organizer.flip_deleted(org)
+    await dao.commit()
+    assert (await check_dao.organizer.get_by_id(org.id)).deleted is True
+
+    cookies = auth_cookies(auth, author)
+    resp = await client.post(
+        f"/games/{game.id}/organizers",
+        json={"player_id": harry.id},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # the same org is restored, not a duplicate created
+    assert body["org_id"] == org.id
+    assert body["deleted"] is False
+    assert (await check_dao.organizer.get_by_id(org.id)).deleted is False
+    assert len(await check_dao.organizer.get_orgs(game, with_deleted=True)) == 1
+
+
+@pytest.mark.asyncio
 async def test_change_org_permission(
     client: AsyncClient,
     auth: AuthProperties,

--- a/tests/unit/services/game_org_interactors_test.py
+++ b/tests/unit/services/game_org_interactors_test.py
@@ -91,10 +91,10 @@ class FakeOrgDao:
 
 @dataclass
 class FakeGameDao:
-    game: dto.Game
+    games: dict[int, dto.Game]
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
-        return self.game
+        return self.games[id_]
 
 
 @dataclass
@@ -125,7 +125,7 @@ async def test_list_returns_primary_and_secondary(author: dto.Player, stranger: 
         player=author, organizer={game.id: dto.PrimaryOrganizer(player=author, game=game)}
     )
 
-    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=org_dao)
+    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao({game.id: game}), org_dao=org_dao)
     result = await interactor(game_id=game.id, identity=identity)
 
     ids = [getattr(o, "id", None) for o in result]
@@ -139,7 +139,9 @@ async def test_list_forbidden_for_stranger(author: dto.Player, stranger: dto.Pla
     game = make_game(10, author, GameStatus.underconstruction)
     identity = MockIdentityProvider(player=stranger, organizer={game.id: None})
 
-    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=FakeOrgDao(game=game))
+    interactor = ListGameOrgsInteractor(
+        game_dao=FakeGameDao({game.id: game}), org_dao=FakeOrgDao(game=game)
+    )
     with pytest.raises(exceptions.IsNotOrganizer):
         await interactor(game_id=game.id, identity=identity)
 
@@ -149,7 +151,9 @@ async def test_list_public_when_completed(author: dto.Player, stranger: dto.Play
     game = make_game(10, author, GameStatus.complete)
     identity = MockIdentityProvider(player=stranger, organizer={game.id: None})
 
-    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=FakeOrgDao(game=game))
+    interactor = ListGameOrgsInteractor(
+        game_dao=FakeGameDao({game.id: game}), org_dao=FakeOrgDao(game=game)
+    )
     result = await interactor(game_id=game.id, identity=identity)
     assert [o.player.id for o in result] == [author.id]
 
@@ -159,7 +163,7 @@ async def test_add_org(author: dto.Player, stranger: dto.Player):
     game = make_game(10, author, GameStatus.underconstruction)
     org_dao = FakeOrgDao(game=game)
     interactor = AddGameOrgInteractor(
-        game_dao=FakeGameDao(game),
+        game_dao=FakeGameDao({game.id: game}),
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
@@ -178,7 +182,7 @@ async def test_add_org_rejects_non_author(author: dto.Player, stranger: dto.Play
     game = make_game(10, author, GameStatus.underconstruction)
     org_dao = FakeOrgDao(game=game)
     interactor = AddGameOrgInteractor(
-        game_dao=FakeGameDao(game),
+        game_dao=FakeGameDao({game.id: game}),
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
@@ -195,7 +199,7 @@ async def test_add_org_rejects_duplicate(author: dto.Player, stranger: dto.Playe
     org_dao = FakeOrgDao(game=game)
     org_dao.add(stranger)
     interactor = AddGameOrgInteractor(
-        game_dao=FakeGameDao(game),
+        game_dao=FakeGameDao({game.id: game}),
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
@@ -211,7 +215,9 @@ async def test_change_permission_is_idempotent(author: dto.Player, stranger: dto
     game = make_game(10, author, GameStatus.underconstruction)
     org_dao = FakeOrgDao(game=game)
     org = org_dao.add(stranger)
-    interactor = ChangeOrgPermissionInteractor(org_dao=org_dao)
+    interactor = ChangeOrgPermissionInteractor(
+        game_dao=FakeGameDao({game.id: game}), org_dao=org_dao
+    )
     identity = MockIdentityProvider(player=author)
 
     result = await interactor(
@@ -238,13 +244,17 @@ async def test_change_permission_is_idempotent(author: dto.Player, stranger: dto
 
 @pytest.mark.asyncio
 async def test_change_permission_wrong_game(author: dto.Player, stranger: dto.Player):
+    # org belongs to game 10, but the request targets a different game (20)
     game = make_game(10, author, GameStatus.underconstruction)
+    other_game = make_game(20, author, GameStatus.underconstruction)
     org_dao = FakeOrgDao(game=game)
     org = org_dao.add(stranger)
-    interactor = ChangeOrgPermissionInteractor(org_dao=org_dao)
+    interactor = ChangeOrgPermissionInteractor(
+        game_dao=FakeGameDao({game.id: game, other_game.id: other_game}), org_dao=org_dao
+    )
     with pytest.raises(exceptions.GameNotFound):
         await interactor(
-            game_id=999,
+            game_id=other_game.id,
             org_id=org.id,
             permission=OrgPermission.can_spy,
             value=True,
@@ -257,7 +267,7 @@ async def test_remove_org_is_idempotent(author: dto.Player, stranger: dto.Player
     game = make_game(10, author, GameStatus.underconstruction)
     org_dao = FakeOrgDao(game=game)
     org = org_dao.add(stranger)
-    interactor = RemoveGameOrgInteractor(org_dao=org_dao)
+    interactor = RemoveGameOrgInteractor(game_dao=FakeGameDao({game.id: game}), org_dao=org_dao)
     identity = MockIdentityProvider(player=author)
 
     result = await interactor(game_id=game.id, org_id=org.id, identity=identity)

--- a/tests/unit/services/game_org_interactors_test.py
+++ b/tests/unit/services/game_org_interactors_test.py
@@ -167,6 +167,7 @@ async def test_add_org(author: dto.Player, stranger: dto.Player):
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
+        org_deleted_flipper=org_dao,
     )
 
     org = await interactor(
@@ -186,6 +187,7 @@ async def test_add_org_rejects_non_author(author: dto.Player, stranger: dto.Play
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
+        org_deleted_flipper=org_dao,
     )
     with pytest.raises(exceptions.GameHasAnotherAuthor):
         await interactor(
@@ -203,11 +205,34 @@ async def test_add_org_rejects_duplicate(author: dto.Player, stranger: dto.Playe
         player_dao=FakePlayerDao({stranger.id: stranger}),
         org_getter=org_dao,
         org_adder=org_dao,
+        org_deleted_flipper=org_dao,
     )
     with pytest.raises(exceptions.PlayerAlreadyOrganizer):
         await interactor(
             game_id=game.id, player_id=stranger.id, identity=MockIdentityProvider(player=author)
         )
+
+
+@pytest.mark.asyncio
+async def test_add_org_restores_deleted(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    removed = org_dao.add(stranger, deleted=True)
+    interactor = AddGameOrgInteractor(
+        game_dao=FakeGameDao({game.id: game}),
+        player_dao=FakePlayerDao({stranger.id: stranger}),
+        org_getter=org_dao,
+        org_adder=org_dao,
+        org_deleted_flipper=org_dao,
+    )
+
+    org = await interactor(
+        game_id=game.id, player_id=stranger.id, identity=MockIdentityProvider(player=author)
+    )
+    # the same org record is restored rather than a new one being created
+    assert org.id == removed.id
+    assert org.deleted is False
+    assert len(org_dao.orgs) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/game_org_interactors_test.py
+++ b/tests/unit/services/game_org_interactors_test.py
@@ -1,0 +1,270 @@
+from dataclasses import dataclass, field
+
+import pytest
+
+from shvatka.core.games.org_interactors import (
+    AddGameOrgInteractor,
+    ChangeOrgPermissionInteractor,
+    ListGameOrgsInteractor,
+    RemoveGameOrgInteractor,
+)
+from shvatka.core.models import dto
+from shvatka.core.models.dto import GameResults
+from shvatka.core.models.enums import GameStatus, OrgPermission
+from shvatka.core.utils import exceptions
+from tests.fixtures.identity import MockIdentityProvider
+
+
+def make_player(id_: int) -> dto.Player:
+    return dto.Player(id=id_, can_be_author=True, is_dummy=False, username=f"player{id_}")
+
+
+def make_game(id_: int, author: dto.Player, status: GameStatus) -> dto.Game:
+    return dto.Game(
+        id=id_,
+        author=author,
+        name=f"game{id_}",
+        status=status,
+        manage_token="token",
+        start_at=None,
+        number=None,
+        results=GameResults(published_chanel_id=None, results_picture_file_id=None, keys_url=None),
+    )
+
+
+@dataclass
+class FakeOrgDao:
+    """In-memory stand-in for the organizer DAO covering the protocols we need."""
+
+    game: dto.Game
+    orgs: dict[int, dto.SecondaryOrganizer] = field(default_factory=dict)
+    _seq: int = 0
+    committed: int = 0
+
+    def add(self, player: dto.Player, *, deleted: bool = False) -> dto.SecondaryOrganizer:
+        self._seq += 1
+        org = dto.SecondaryOrganizer(
+            id=self._seq,
+            player=player,
+            game=self.game,
+            can_spy=False,
+            can_see_log_keys=False,
+            can_validate_waivers=False,
+            view_scenario=False,
+            deleted=deleted,
+        )
+        self.orgs[org.id] = org
+        return org
+
+    async def get_orgs(
+        self, game: dto.Game, with_deleted: bool = False
+    ) -> list[dto.SecondaryOrganizer]:
+        return [o for o in self.orgs.values() if with_deleted or not o.deleted]
+
+    async def add_new_org(self, game: dto.Game, player: dto.Player) -> dto.SecondaryOrganizer:
+        return self.add(player)
+
+    async def get_by_player_or_none(
+        self, game: dto.Game, player: dto.Player
+    ) -> dto.SecondaryOrganizer | None:
+        for org in self.orgs.values():
+            if org.player.id == player.id:
+                return org
+        return None
+
+    async def get_by_id(self, id_: int) -> dto.SecondaryOrganizer:
+        return self.orgs[id_]
+
+    async def flip_permission(
+        self, org: dto.SecondaryOrganizer, permission: OrgPermission
+    ) -> None:
+        stored = self.orgs[org.id]
+        setattr(stored, permission.name, not getattr(stored, permission.name))
+
+    async def flip_deleted(self, org: dto.SecondaryOrganizer) -> None:
+        stored = self.orgs[org.id]
+        stored.deleted = not stored.deleted
+
+    async def commit(self) -> None:
+        self.committed += 1
+
+
+@dataclass
+class FakeGameDao:
+    game: dto.Game
+
+    async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
+        return self.game
+
+
+@dataclass
+class FakePlayerDao:
+    players: dict[int, dto.Player]
+
+    async def get_by_id(self, id_: int) -> dto.Player:
+        return self.players[id_]
+
+
+@pytest.fixture
+def author() -> dto.Player:
+    return make_player(1)
+
+
+@pytest.fixture
+def stranger() -> dto.Player:
+    return make_player(2)
+
+
+@pytest.mark.asyncio
+async def test_list_returns_primary_and_secondary(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    secondary = org_dao.add(stranger)
+    deleted = org_dao.add(make_player(3), deleted=True)
+    identity = MockIdentityProvider(
+        player=author, organizer={game.id: dto.PrimaryOrganizer(player=author, game=game)}
+    )
+
+    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=org_dao)
+    result = await interactor(game_id=game.id, identity=identity)
+
+    ids = [getattr(o, "id", None) for o in result]
+    # primary (None) + both secondary orgs, including the deleted one
+    assert ids == [None, secondary.id, deleted.id]
+    assert result[0].player.id == author.id
+
+
+@pytest.mark.asyncio
+async def test_list_forbidden_for_stranger(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    identity = MockIdentityProvider(player=stranger, organizer={game.id: None})
+
+    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=FakeOrgDao(game=game))
+    with pytest.raises(exceptions.IsNotOrganizer):
+        await interactor(game_id=game.id, identity=identity)
+
+
+@pytest.mark.asyncio
+async def test_list_public_when_completed(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.complete)
+    identity = MockIdentityProvider(player=stranger, organizer={game.id: None})
+
+    interactor = ListGameOrgsInteractor(game_dao=FakeGameDao(game), org_dao=FakeOrgDao(game=game))
+    result = await interactor(game_id=game.id, identity=identity)
+    assert [o.player.id for o in result] == [author.id]
+
+
+@pytest.mark.asyncio
+async def test_add_org(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    interactor = AddGameOrgInteractor(
+        game_dao=FakeGameDao(game),
+        player_dao=FakePlayerDao({stranger.id: stranger}),
+        org_getter=org_dao,
+        org_adder=org_dao,
+    )
+
+    org = await interactor(
+        game_id=game.id, player_id=stranger.id, identity=MockIdentityProvider(player=author)
+    )
+    assert org.player.id == stranger.id
+    assert org_dao.committed == 1
+    assert len(await org_dao.get_orgs(game)) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_org_rejects_non_author(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    interactor = AddGameOrgInteractor(
+        game_dao=FakeGameDao(game),
+        player_dao=FakePlayerDao({stranger.id: stranger}),
+        org_getter=org_dao,
+        org_adder=org_dao,
+    )
+    with pytest.raises(exceptions.GameHasAnotherAuthor):
+        await interactor(
+            game_id=game.id, player_id=stranger.id, identity=MockIdentityProvider(player=stranger)
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_org_rejects_duplicate(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    org_dao.add(stranger)
+    interactor = AddGameOrgInteractor(
+        game_dao=FakeGameDao(game),
+        player_dao=FakePlayerDao({stranger.id: stranger}),
+        org_getter=org_dao,
+        org_adder=org_dao,
+    )
+    with pytest.raises(exceptions.PlayerAlreadyOrganizer):
+        await interactor(
+            game_id=game.id, player_id=stranger.id, identity=MockIdentityProvider(player=author)
+        )
+
+
+@pytest.mark.asyncio
+async def test_change_permission_is_idempotent(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    org = org_dao.add(stranger)
+    interactor = ChangeOrgPermissionInteractor(org_dao=org_dao)
+    identity = MockIdentityProvider(player=author)
+
+    result = await interactor(
+        game_id=game.id,
+        org_id=org.id,
+        permission=OrgPermission.can_spy,
+        value=True,
+        identity=identity,
+    )
+    assert result.can_spy is True
+    assert org_dao.committed == 1
+
+    # already True -> no extra flip / commit
+    result = await interactor(
+        game_id=game.id,
+        org_id=org.id,
+        permission=OrgPermission.can_spy,
+        value=True,
+        identity=identity,
+    )
+    assert result.can_spy is True
+    assert org_dao.committed == 1
+
+
+@pytest.mark.asyncio
+async def test_change_permission_wrong_game(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    org = org_dao.add(stranger)
+    interactor = ChangeOrgPermissionInteractor(org_dao=org_dao)
+    with pytest.raises(exceptions.GameNotFound):
+        await interactor(
+            game_id=999,
+            org_id=org.id,
+            permission=OrgPermission.can_spy,
+            value=True,
+            identity=MockIdentityProvider(player=author),
+        )
+
+
+@pytest.mark.asyncio
+async def test_remove_org_is_idempotent(author: dto.Player, stranger: dto.Player):
+    game = make_game(10, author, GameStatus.underconstruction)
+    org_dao = FakeOrgDao(game=game)
+    org = org_dao.add(stranger)
+    interactor = RemoveGameOrgInteractor(org_dao=org_dao)
+    identity = MockIdentityProvider(player=author)
+
+    result = await interactor(game_id=game.id, org_id=org.id, identity=identity)
+    assert result.deleted is True
+    assert org_dao.committed == 1
+
+    # already deleted -> stays deleted, no extra flip
+    result = await interactor(game_id=game.id, org_id=org.id, identity=identity)
+    assert result.deleted is True
+    assert org_dao.committed == 1


### PR DESCRIPTION
## Summary

Adds CRUD API endpoints for managing the organizers of a game. The endpoints follow the project's `/games` prefix convention:

- **`GET /games/{id}/organizers`** — list all organizers with their permissions and `deleted` status. Returns the primary organizer (the author, reported with `org_id: null`) followed by the secondary organizers (including soft-deleted ones). For a **non-completed** game the listing is available only to the author and organizers; for a **completed** game it is public.
- **`POST /games/{id}/organizers`** — add a new organizer (body: `{ "player_id": int }`). Author only; rejects duplicates.
- **`DELETE /games/{id}/organizers`** — soft-delete an organizer (body: `{ "org_id": int }`). Author only; idempotent.
- **`PUT /games/{id}/organizers/{org_id}`** — change a single permission (body: `{ "permission": "can_spy" | "can_see_log_keys" | "can_validate_waivers" | "view_scenario", "value": bool }`). Author only; idempotent.

## Implementation

- New interactors in `shvatka/core/games/org_interactors.py` (`ListGameOrgsInteractor`, `AddGameOrgInteractor`, `ChangeOrgPermissionInteractor`, `RemoveGameOrgInteractor`), wired through dishka in `GameEditProvider`. They reuse the existing organizer domain services (`get_primary_orgs`, `get_secondary_orgs`, `flip_permission`, `flip_deleted`, …) and resolve the current player via `IdentityProvider`.
- New `responses.GameOrganizer` response model (carries a nullable `org_id`) and `req.NewOrg` / `req.DeleteOrg` / `req.OrgPermissionUpdate` request models.
- New `PlayerAlreadyOrganizer` domain exception.

## Tests

- Unit tests (`tests/unit/services/game_org_interactors_test.py`) drive each interactor with in-memory fakes — access control, duplicate rejection, wrong-game guard, and idempotency of permission/delete changes.
- API integration tests (`tests/integration/api_full/test_game_organizers.py`) exercise all four endpoints end-to-end, including the author-only and completed-game-public access rules.

Unit tests, `ruff check`, `ruff format --check`, and `mypy` pass locally. Integration tests run in CI (they need the testcontainers Postgres, unavailable in this sandbox).

## Notes / open question

The task wrote the paths as `/game/...`; the existing API router uses the plural `/games` prefix, so I followed the established convention. `DELETE /games/{id}/organizers` takes the target `org_id` in the request body (mirroring how `POST` takes `player_id`), since the route has no `{org_id}` path segment. Happy to move it to a path/query parameter if you'd prefer.

https://claude.ai/code/session_012zLGE6Aob3aFV95f62qR35

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLGE6Aob3aFV95f62qR35)_