### PR TITLE
Increase nginx upload limit to 50MB

### DIFF
--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -1,6 +1,8 @@
 server {
     listen 80;
 
+    client_max_body_size 50m;
+
     location /api/ {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://shvatka-backend:8000;


### PR DESCRIPTION
## Summary

- Added `client_max_body_size 50m;` to the nginx server block in `nginx/app.conf`, allowing users to upload files up to 50 MB.

## Test plan

- [ ] Deploy updated nginx config
- [ ] Verify file uploads up to 50 MB succeed
- [ ] Verify requests over 50 MB return `413 Request Entity Too Large`

https://claude.ai/code/session_01XiJc1dyFijucaKuaVKDrwk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiJc1dyFijucaKuaVKDrwk)_