### PR TITLE
Add PUT /users/me/username endpoint and unskip password test

### DIFF
--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -16,6 +16,11 @@ class NewGame:
 
 
 @dataclass
+class ChangeUsername:
+    username: str
+
+
+@dataclass
 class GameStartAt:
     start_at: datetime | None = None
 

--- a/shvatka/api/routes/user.py
+++ b/shvatka/api/routes/user.py
@@ -6,7 +6,7 @@ from dishka.integrations.fastapi import inject
 from fastapi import APIRouter, HTTPException
 from fastapi.params import Body, Path, Query
 
-from shvatka.api.models import responses
+from shvatka.api.models import responses, req
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.players.interactors import GetPlayerInteractor, SearchPlayersInteractor
 from shvatka.core.players.player import set_password, set_player_username, get_player_by_id
@@ -74,10 +74,10 @@ async def set_password_route(
 async def set_username_route(
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
-    username: str = Body(),  # type: ignore[assignment]
+    body: Annotated[req.ChangeUsername, Body()],
 ) -> None:
     player = await identity.get_required_player()
-    await set_player_username(player, username, dao.player)
+    await set_player_username(player, body.username, dao.player)
     raise HTTPException(status_code=200)
 
 

--- a/shvatka/api/routes/user.py
+++ b/shvatka/api/routes/user.py
@@ -9,7 +9,7 @@ from fastapi.params import Body, Path, Query
 from shvatka.api.models import responses
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.players.interactors import GetPlayerInteractor, SearchPlayersInteractor
-from shvatka.core.players.player import set_password, get_player_by_id
+from shvatka.core.players.player import set_password, set_player_username, get_player_by_id
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.api.dependencies.auth import AuthProperties
 
@@ -70,12 +70,24 @@ async def set_password_route(
     raise HTTPException(status_code=200)
 
 
+@inject
+async def set_username_route(
+    identity: FromDishka[IdentityProvider],
+    dao: FromDishka[HolderDao],
+    username: str = Body(),  # type: ignore[assignment]
+) -> None:
+    player = await identity.get_required_player()
+    await set_player_username(player, username, dao.player)
+    raise HTTPException(status_code=200)
+
+
 # users in API is players in core and db
 def setup() -> APIRouter:
     router = APIRouter(prefix="/users")
     router.add_api_route("", search_users, methods=["GET"])
     router.add_api_route("/me", read_users_me, methods=["GET"])
     router.add_api_route("/me/password", set_password_route, methods=["PUT"])
+    router.add_api_route("/me/username", set_username_route, methods=["PUT"])
     router.add_api_route("/{id}/details", read_user_details, methods=["GET"])
     router.add_api_route("/{id}", read_user, methods=["GET"])
     return router

--- a/tests/integration/api_full/test_user.py
+++ b/tests/integration/api_full/test_user.py
@@ -98,7 +98,7 @@ async def test_change_username(client: AsyncClient, harry: dto.Player, token: To
     resp = await client.put(
         "/users/me/username",
         cookies={"Authorization": f"{token.token_type} {token.access_token}"},
-        json=new_username,
+        json={"username": new_username},
     )
     assert resp.is_success
 
@@ -120,6 +120,6 @@ async def test_change_username_occupied(
     resp = await client.put(
         "/users/me/username",
         cookies={"Authorization": f"{token.token_type} {token.access_token}"},
-        json=hermione.username,
+        json={"username": hermione.username},
     )
     assert resp.status_code == 422

--- a/tests/integration/api_full/test_user.py
+++ b/tests/integration/api_full/test_user.py
@@ -71,13 +71,11 @@ async def test_logout(client: AsyncClient, token: Token):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="doesnt work. TODO")
 async def test_change_password(client: AsyncClient, harry: dto.Player, token: Token):
     resp = await client.put(
-        "/users/me/password/",
+        "/users/me/password",
         cookies={"Authorization": f"{token.token_type} {token.access_token}"},
         json="09876",
-        follow_redirects=True,
     )
     assert resp.is_success
 
@@ -92,3 +90,36 @@ async def test_change_password(client: AsyncClient, harry: dto.Player, token: To
         data={"username": harry.username, "password": "09876"},
     )
     assert resp.is_success
+
+
+@pytest.mark.asyncio
+async def test_change_username(client: AsyncClient, harry: dto.Player, token: Token):
+    new_username = "the_chosen_one"
+    resp = await client.put(
+        "/users/me/username",
+        cookies={"Authorization": f"{token.token_type} {token.access_token}"},
+        json=new_username,
+    )
+    assert resp.is_success
+
+    resp = await client.get(
+        "/users/me",
+        cookies={"Authorization": f"{token.token_type} {token.access_token}"},
+        follow_redirects=True,
+    )
+    assert resp.is_success
+    actual = responses.Player(**resp.json())
+    assert actual.id == harry.id
+    assert actual.name_mention == new_username
+
+
+@pytest.mark.asyncio
+async def test_change_username_occupied(
+    client: AsyncClient, harry: dto.Player, hermione: dto.Player, token: Token
+):
+    resp = await client.put(
+        "/users/me/username",
+        cookies={"Authorization": f"{token.token_type} {token.access_token}"},
+        json=hermione.username,
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Adds a new endpoint `PUT /users/me/username` for the authenticated player to change their username, mirroring the existing `PUT /users/me/password` endpoint. It wires the already-existing `set_player_username` core service (which guards against taken usernames) into the API.
- Unskips and fixes `test_change_password`, which was marked `@pytest.mark.skip(reason="doesnt work. TODO")`.

## Why the password test was failing

The test requested `/users/me/password/` (trailing slash) and relied on `follow_redirects=True`. The route is registered as `/users/me/password` (no trailing slash), so the request got a `307` redirect. Under httpx's ASGI transport the redirect drops the request body and the auth cookie, so the handler never received the new password / saw an unauthenticated request. The fix is to request the exact route path, which removes the redirect entirely.

## Tests

- `test_change_password` — now active (no longer skipped); verifies the old password stops working and the new one logs in.
- `test_change_username` — changes the username and confirms `GET /users/me` reflects it.
- `test_change_username_occupied` — confirms changing to another player's username returns `422`.

Note: integration tests rely on testcontainers (Postgres + Redis via Docker), which isn't available in this environment, so they were validated by reasoning + lint rather than executed here.

https://claude.ai/code/session_015unn4Jo6NQuuh5r7oGK1he

---
_Generated by [Claude Code](https://claude.ai/code/session_015unn4Jo6NQuuh5r7oGK1he)_