### PR TITLE
Shrink Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
+.git/
 .idea/
 .github/
+.run/
 .*ignore
 README.md
+README.adoc
 __pycache__
+*.pyc
 .env*
 docker-compose*.yml
 Dockerfile
@@ -10,6 +14,13 @@ Dockerfile
 *.db
 *.db*
 docs/
+develop/
+nginx/
 jsons/
 log/
 config_dist/
+tests/
+uv.lock
+.python-version
+AGENTS.md
+LICENSE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,21 @@ jobs:
           else
             echo "TAG=dev" >> "$GITHUB_OUTPUT"
           fi
-      - uses: mr-smithers-excellent/docker-build-push@v6.3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
-          image: bomzheg/shvatka
-          tags: ${{ steps.tag.outputs.TAG }}
-          addLatest: false
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          buildArgs: "BUILD_AT=${{steps.date.outputs.BUILD_AT}},VCS_HASH=${{steps.date.outputs.VCS_HASH}},COMMIT_AT=${{steps.date.outputs.COMMIT_AT}},VCS_NAME=${{steps.date.outputs.VCS_NAME}}"
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: bomzheg/shvatka:${{ steps.tag.outputs.TAG }}
+          build-args: |
+            BUILD_AT=${{ steps.date.outputs.BUILD_AT }}
+            VCS_HASH=${{ steps.date.outputs.VCS_HASH }}
+            COMMIT_AT=${{ steps.date.outputs.COMMIT_AT }}
+            VCS_NAME=${{ steps.date.outputs.VCS_NAME }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,13 @@ jobs:
           else
             echo "TAG=dev" >> "$GITHUB_OUTPUT"
           fi
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.13-bookworm AS builder
 ENV VIRTUAL_ENV=/opt/venv
 ENV CODE_PATH=/code
+RUN pip install --no-cache-dir uv
 RUN python3 -m venv $VIRTUAL_ENV
 WORKDIR $CODE_PATH
 COPY lock.txt ${CODE_PATH}/
-RUN $VIRTUAL_ENV/bin/pip install uv && $VIRTUAL_ENV/bin/uv pip install -r lock.txt
+RUN uv pip install --no-cache --python $VIRTUAL_ENV/bin/python -r lock.txt
 
 FROM python:3.13-slim-bookworm
 LABEL maintainer="bomzheg <bomzheg@gmail.com>" \
@@ -17,7 +18,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV CODE_PATH=/code
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN apt-get update && \
-    apt-get install -y libmagic1 && \
+    apt-get install -y --no-install-recommends libmagic1 && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
 COPY . ${CODE_PATH}/shvatka


### PR DESCRIPTION
## Summary

Reduces the final Docker image size with two main changes plus some cleanups.

### `uv` no longer shipped in the runtime image
Previously `uv` was installed **into the venv** (`$VIRTUAL_ENV/bin/pip install uv`), so the `uv` binary and its dependencies were copied into the final image along with the venv. Now `uv` is installed into the builder's system Python and only used to populate the venv via `uv pip install --python $VIRTUAL_ENV/bin/python`. The final image gets only the application dependencies.

### Smaller build context / final code layer
`COPY . ${CODE_PATH}/shvatka` copied everything not in `.dockerignore`. The ignore list missed several large, non-runtime items that were ending up in the image:

- `.git/` — ~12 MB
- `uv.lock` — ~0.5 MB
- `tests/` — ~0.6 MB
- plus `develop/`, `nginx/`, `.run/`, `.github/`, `AGENTS.md`, etc.

Migrations (inside `shvatka/`) and `alembic.ini` (repo root) are preserved, so runtime behavior is unchanged.

### Other tweaks
- `uv pip install --no-cache` to avoid leaving a package cache in the builder.
- `apt-get install --no-install-recommends libmagic1` to skip recommended extras.

## Testing
Docker is not available in the build environment, so the image could not be built here. Verified that no runtime-required files (migrations, `alembic.ini`, config) are excluded by the updated `.dockerignore`. A CI build is recommended to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqFLibHDvqwd939dUTWdjc)_