### PR TITLE
ci: surface test report and coverage in GitHub Actions UI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         if: always()
         continue-on-error: true
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
-      - name: Coverage badge values
+      - name: Coverage comment
         id: coverageComment
         continue-on-error: true
         uses: MishaKav/pytest-coverage-comment@main
@@ -100,7 +100,7 @@ jobs:
           hide-badge: false
           hide-report: true
           create-new-comment: false
-          hide-comment: true
+          hide-comment: false
           report-only-changed-files: false
           remove-link-from-badge: false
       - name: Create the Badge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Publish test report
         if: always()
         continue-on-error: true
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v3
         with:
           name: pytest results
           path: junit.xml
@@ -98,13 +98,13 @@ jobs:
           title: Let's see coverage
           badge-title: coverage
           hide-badge: false
-          hide-report: false
+          hide-report: true
           create-new-comment: false
           hide-comment: true
           report-only-changed-files: false
           remove-link-from-badge: false
       - name: Create the Badge
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@v1.8.0
         continue-on-error: true
         with:
           auth: ${{ secrets.BAGE_GIST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
   test:
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
@@ -60,8 +63,33 @@ jobs:
       - name: Install dependencies
         run: uv venv && uv sync --group test
       - name: Test with pytest
-        run: source .venv/bin/activate && pytest --cov-report "xml:coverage.xml" --cov=shvatka tests/
-      - name: Coverage comment
+        run: >
+          source .venv/bin/activate &&
+          pytest
+          --junitxml=junit.xml
+          --cov-report "xml:coverage.xml"
+          --cov=shvatka tests/
+      - name: Publish test report
+        if: always()
+        continue-on-error: true
+        uses: dorny/test-reporter@v1
+        with:
+          name: pytest results
+          path: junit.xml
+          reporter: java-junit
+      - name: Coverage summary
+        if: always()
+        continue-on-error: true
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage.xml
+          format: markdown
+          output: both
+      - name: Write coverage to job summary
+        if: always()
+        continue-on-error: true
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Coverage badge values
         id: coverageComment
         continue-on-error: true
         uses: MishaKav/pytest-coverage-comment@main
@@ -72,7 +100,7 @@ jobs:
           hide-badge: false
           hide-report: false
           create-new-comment: false
-          hide-comment: false
+          hide-comment: true
           report-only-changed-files: false
           remove-link-from-badge: false
       - name: Create the Badge


### PR DESCRIPTION
## What

Adds GitHub-native test/coverage reporting to the `test` job, as an alternative to the existing PR comment (closer to what GitLab pipelines show).

## Changes to `.github/workflows/test.yml`

- **Test report Check** — pytest now emits JUnit XML (`--junitxml=junit.xml`), published via `dorny/test-reporter` as a Check Run. Test results and failure annotations appear in the PR **Checks** tab (not a comment).
- **Coverage Job Summary** — `irongut/CodeCoverageSummary` reads the existing `coverage.xml` and renders a coverage table into the workflow run's **Job Summary** page (`$GITHUB_STEP_SUMMARY`).
- **Badge preserved, comment dropped** — the `MishaKav/pytest-coverage-comment` step is kept only to compute the coverage value for the dynamic gist badge, with `hide-comment: true` so it no longer posts a PR comment.
- Added `checks: write` permission to the job (required to create the test-report Check Run).

## Where to look after CI runs

- **Run summary page** → coverage table (Job Summary)
- **PR Checks tab** → "pytest results" check with pass/fail counts and annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwMAGpTEjLKxexrnbd4Jvo)_