### PR TITLE
Add team name search and team/user stat endpoints

### DIFF
--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -8,6 +8,7 @@ from adaptix import Retort
 
 from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole, Event
 from shvatka.core.models import dto, enums
+from shvatka.core.players.dto import PlayerStat as PlayerStatDto
 from shvatka.core.models.dto import action
 from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
@@ -96,6 +97,50 @@ class TeamPlayer:
             date_joined=core.date_joined,
             role=core.role,
             emoji=core.emoji,
+        )
+
+
+@dataclass
+class TeamPlayerHistory:
+    team_player_id: int
+    team: Team | None
+    date_joined: datetime
+    date_left: datetime | None
+    role: str
+    emoji: str | None
+
+    @classmethod
+    def from_core(cls, core: dto.FullTeamPlayer) -> "TeamPlayerHistory":
+        return cls(
+            team_player_id=core.id,
+            team=Team.from_core(core.team),
+            date_joined=core.date_joined,
+            date_left=core.date_left,
+            role=core.role,
+            emoji=core.emoji,
+        )
+
+
+@dataclass
+class PlayerStat:
+    id: int
+    username: str | None
+    can_be_author: bool
+    typed_keys_count: int
+    typed_correct_keys_count: int
+    team_history: list[TeamPlayerHistory]
+    played_games: list["Game"]
+
+    @classmethod
+    def from_core(cls, core: PlayerStatDto) -> "PlayerStat":
+        return cls(
+            id=core.player.id,
+            username=core.player.username,
+            can_be_author=core.player.can_be_author,
+            typed_keys_count=core.player.typed_keys_count,
+            typed_correct_keys_count=core.player.typed_correct_keys_count,
+            team_history=[TeamPlayerHistory.from_core(tp) for tp in core.team_history],
+            played_games=[Game.from_core(game) for game in core.played_games],
         )
 
 

--- a/shvatka/api/routes/team.py
+++ b/shvatka/api/routes/team.py
@@ -13,6 +13,7 @@ from shvatka.core.teams.interactors import (
     EditTeamInteractor,
     GetTeamInteractor,
     RemovePlayerFromTeamInteractor,
+    TeamPlayedGamesInteractor,
     TeamPlayersInteractor,
     TeamsListInteractor,
     UpdateTeamPlayerInteractor,
@@ -24,9 +25,19 @@ async def get_teams(
     interactor: FromDishka[TeamsListInteractor],
     active: Annotated[bool, Query()] = True,
     archive: Annotated[bool, Query()] = False,
+    search: Annotated[str | None, Query()] = None,
 ) -> responses.Items[responses.Team]:
-    teams = await interactor(active=active, archive=archive)
+    teams = await interactor(active=active, archive=archive, name=search)
     return responses.Items([responses.Team.from_core(team) for team in teams])
+
+
+@inject
+async def get_team_stat(
+    interactor: FromDishka[TeamPlayedGamesInteractor],
+    id_: Annotated[int, Path(alias="id")],
+) -> responses.Items[responses.Game]:
+    games = await interactor(id_)
+    return responses.Items([responses.Game.from_core(game) for game in games])
 
 
 @inject
@@ -116,6 +127,7 @@ def setup() -> APIRouter:
     router = APIRouter(prefix="/teams", tags=["teams"])
     router.add_api_route("", get_teams, methods=["GET"])
     router.add_api_route("/my", get_my_team, methods=["GET"])
+    router.add_api_route("/{id}/stat", get_team_stat, methods=["GET"])
     router.add_api_route("/{id}", get_team, methods=["GET"])
     router.add_api_route("/{id}", edit_team, methods=["PUT"])
     router.add_api_route("/{id}/players", get_team_players, methods=["GET"])

--- a/shvatka/api/routes/user.py
+++ b/shvatka/api/routes/user.py
@@ -8,7 +8,11 @@ from fastapi.params import Body, Path, Query
 
 from shvatka.api.models import responses, req
 from shvatka.core.interfaces.identity import IdentityProvider
-from shvatka.core.players.interactors import GetPlayerInteractor, SearchPlayersInteractor
+from shvatka.core.players.interactors import (
+    GetPlayerInteractor,
+    GetPlayerStatInteractor,
+    SearchPlayersInteractor,
+)
 from shvatka.core.players.player import set_password, set_player_username, get_player_by_id
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.api.dependencies.auth import AuthProperties
@@ -59,6 +63,15 @@ async def read_user_details(
 
 
 @inject
+async def read_user_stat(
+    interactor: FromDishka[GetPlayerStatInteractor],
+    id_: Annotated[int, Path(alias="id")],
+) -> responses.PlayerStat:
+    stat = await interactor(id_)
+    return responses.PlayerStat.from_core(stat)
+
+
+@inject
 async def set_password_route(
     auth: FromDishka[AuthProperties],
     identity: FromDishka[IdentityProvider],
@@ -89,5 +102,6 @@ def setup() -> APIRouter:
     router.add_api_route("/me/password", set_password_route, methods=["PUT"])
     router.add_api_route("/me/username", set_username_route, methods=["PUT"])
     router.add_api_route("/{id}/details", read_user_details, methods=["GET"])
+    router.add_api_route("/{id}/stat", read_user_stat, methods=["GET"])
     router.add_api_route("/{id}", read_user, methods=["GET"])
     return router

--- a/shvatka/core/interfaces/dal/player.py
+++ b/shvatka/core/interfaces/dal/player.py
@@ -117,16 +117,6 @@ class TeamPlayerFullHistoryGetter(Protocol):
         raise NotImplementedError
 
 
-class PlayerWithStatGetter(Protocol):
-    async def get_player_with_stat(self, id_: int) -> dto.PlayerWithStat:
-        raise NotImplementedError
-
-
-class PlayedGamesByPlayerGetter(Protocol):
-    async def get_played_games(self, player: dto.Player) -> list[dto.Game]:
-        raise NotImplementedError
-
-
 class TeamPlayersMerger(Protocol):
     async def replace_team_players(self, primary: dto.Team, secondary: dto.Team):
         raise NotImplementedError

--- a/shvatka/core/interfaces/dal/player.py
+++ b/shvatka/core/interfaces/dal/player.py
@@ -117,6 +117,16 @@ class TeamPlayerFullHistoryGetter(Protocol):
         raise NotImplementedError
 
 
+class PlayerWithStatGetter(Protocol):
+    async def get_player_with_stat(self, id_: int) -> dto.PlayerWithStat:
+        raise NotImplementedError
+
+
+class PlayedGamesByPlayerGetter(Protocol):
+    async def get_played_games(self, player: dto.Player) -> list[dto.Game]:
+        raise NotImplementedError
+
+
 class TeamPlayersMerger(Protocol):
     async def replace_team_players(self, primary: dto.Team, secondary: dto.Team):
         raise NotImplementedError

--- a/shvatka/core/interfaces/dal/team.py
+++ b/shvatka/core/interfaces/dal/team.py
@@ -29,7 +29,9 @@ class TeamDescChanger(Committer, Protocol):
 
 
 class TeamsGetter(Protocol):
-    async def get_teams(self, active: bool = True, archive: bool = False) -> list[dto.Team]:
+    async def get_teams(
+        self, active: bool = True, archive: bool = False, name: str | None = None
+    ) -> list[dto.Team]:
         raise NotImplementedError
 
 

--- a/shvatka/core/players/dto.py
+++ b/shvatka/core/players/dto.py
@@ -9,3 +9,16 @@ class PlayerMainInfo:
 
     player: dto.Player
     team_player: dto.FullTeamPlayer | None
+
+
+@dataclass(frozen=True, slots=True)
+class PlayerStat:
+    """Aggregated player statistics for the web UI.
+
+    Includes the player together with key counters, the full history of team
+    memberships and the list of games the player took part in.
+    """
+
+    player: dto.PlayerWithStat
+    team_history: list[dto.FullTeamPlayer]
+    played_games: list[dto.Game]

--- a/shvatka/core/players/interactors.py
+++ b/shvatka/core/players/interactors.py
@@ -6,11 +6,21 @@ on internal domain models so the transport layer (api routes) stays thin.
 
 from dataclasses import dataclass
 
-from shvatka.core.interfaces.dal.player import PlayerByIdGetter, PlayerTeamChecker
+from shvatka.core.interfaces.dal.player import (
+    PlayedGamesByPlayerGetter,
+    PlayerByIdGetter,
+    PlayerTeamChecker,
+    PlayerWithStatGetter,
+    TeamPlayerFullHistoryGetter,
+)
 from shvatka.core.models import dto
-from shvatka.core.players.dto import PlayerMainInfo
+from shvatka.core.players.dto import PlayerMainInfo, PlayerStat
 from shvatka.core.players.interfaces import PlayerSearcher
-from shvatka.core.players.player import get_full_team_player_or_none
+from shvatka.core.players.player import (
+    get_full_team_player_or_none,
+    get_player_with_stat,
+    get_teams_history,
+)
 
 
 @dataclass
@@ -23,6 +33,23 @@ class GetPlayerInteractor:
         team = await self.team_player_dao.get_team(player)
         team_player = await get_full_team_player_or_none(player, team, self.team_player_dao)
         return PlayerMainInfo(player=player, team_player=team_player)
+
+
+@dataclass
+class GetPlayerStatInteractor:
+    player_dao: PlayerWithStatGetter
+    history_dao: TeamPlayerFullHistoryGetter
+    played_games_dao: PlayedGamesByPlayerGetter
+
+    async def __call__(self, player_id: int) -> PlayerStat:
+        player = await get_player_with_stat(player_id, self.player_dao)
+        team_history = await get_teams_history(player, self.history_dao)
+        played_games = await self.played_games_dao.get_played_games(player)
+        return PlayerStat(
+            player=player,
+            team_history=team_history,
+            played_games=played_games,
+        )
 
 
 @dataclass

--- a/shvatka/core/players/interactors.py
+++ b/shvatka/core/players/interactors.py
@@ -7,15 +7,17 @@ on internal domain models so the transport layer (api routes) stays thin.
 from dataclasses import dataclass
 
 from shvatka.core.interfaces.dal.player import (
-    PlayedGamesByPlayerGetter,
     PlayerByIdGetter,
     PlayerTeamChecker,
-    PlayerWithStatGetter,
     TeamPlayerFullHistoryGetter,
 )
 from shvatka.core.models import dto
 from shvatka.core.players.dto import PlayerMainInfo, PlayerStat
-from shvatka.core.players.interfaces import PlayerSearcher
+from shvatka.core.players.interfaces import (
+    PlayedGamesByPlayerGetter,
+    PlayerSearcher,
+    PlayerWithStatGetter,
+)
 from shvatka.core.players.player import (
     get_full_team_player_or_none,
     get_player_with_stat,

--- a/shvatka/core/players/interfaces.py
+++ b/shvatka/core/players/interfaces.py
@@ -27,3 +27,13 @@ class PlayerSearcher(Protocol):
         archive: bool = False,
     ) -> list[dto.Player]:
         raise NotImplementedError
+
+
+class PlayerWithStatGetter(Protocol):
+    async def get_player_with_stat(self, id_: int) -> dto.PlayerWithStat:
+        raise NotImplementedError
+
+
+class PlayedGamesByPlayerGetter(Protocol):
+    async def get_played_games(self, player: dto.Player) -> list[dto.Game]:
+        raise NotImplementedError

--- a/shvatka/core/services/team.py
+++ b/shvatka/core/services/team.py
@@ -86,9 +86,9 @@ async def change_team_desc(
 
 
 async def get_teams(
-    dao: TeamsGetter, active: bool = True, archive: bool = False
+    dao: TeamsGetter, active: bool = True, archive: bool = False, name: str | None = None
 ) -> list[dto.Team]:
-    return await dao.get_teams(active, archive)
+    return await dao.get_teams(active, archive, name)
 
 
 async def get_team_by_id(team_id: int, dao: TeamByIdGetter) -> dto.Team:

--- a/shvatka/core/teams/interactors.py
+++ b/shvatka/core/teams/interactors.py
@@ -15,7 +15,11 @@ from shvatka.core.interfaces.dal.player import (
     TeamPlayerGetter,
     TeamPlayersGetter,
 )
-from shvatka.core.interfaces.dal.team import TeamByIdGetter, TeamsGetter
+from shvatka.core.interfaces.dal.team import (
+    PlayedGamesByTeamGetter,
+    TeamByIdGetter,
+    TeamsGetter,
+)
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto, enums
 from shvatka.core.players.player import (
@@ -25,7 +29,12 @@ from shvatka.core.players.player import (
     join_team,
     leave,
 )
-from shvatka.core.services.team import check_can_change_name, get_team_by_id, get_teams
+from shvatka.core.services.team import (
+    check_can_change_name,
+    get_played_games,
+    get_team_by_id,
+    get_teams,
+)
 from shvatka.core.teams.adapters import TeamEditor, TeamPlayerAdder, TeamPlayerUpdater
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.core.utils.exceptions import PlayerRestoredInTeam
@@ -36,8 +45,10 @@ from shvatka.core.views.team import TeamNotifier
 class TeamsListInteractor:
     dao: TeamsGetter
 
-    async def __call__(self, active: bool = True, archive: bool = False) -> list[dto.Team]:
-        return await get_teams(self.dao, active=active, archive=archive)
+    async def __call__(
+        self, active: bool = True, archive: bool = False, name: str | None = None
+    ) -> list[dto.Team]:
+        return await get_teams(self.dao, active=active, archive=archive, name=name)
 
 
 @dataclass
@@ -46,6 +57,16 @@ class GetTeamInteractor:
 
     async def __call__(self, team_id: int) -> dto.Team:
         return await get_team_by_id(team_id, self.dao)
+
+
+@dataclass
+class TeamPlayedGamesInteractor:
+    team_dao: TeamByIdGetter
+    played_games_dao: PlayedGamesByTeamGetter
+
+    async def __call__(self, team_id: int) -> list[dto.Game]:
+        team = await get_team_by_id(team_id, self.team_dao)
+        return await get_played_games(team, self.played_games_dao)
 
 
 @dataclass

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -76,6 +76,27 @@ class PlayerDao(BaseDAO[models.Player]):
             typed_correct_keys_count=keys_correct_count,
         )
 
+    async def get_played_games(self, player: dto.Player) -> list[dto.Game]:
+        result = await self.session.scalars(
+            select(models.Game)
+            .distinct()
+            .options(
+                joinedload(models.Game.author).options(
+                    joinedload(models.Player.user),
+                    joinedload(models.Player.forum_user),
+                ),
+            )
+            .join(models.Game.waivers)
+            .where(
+                models.Waiver.player_id == player.id,
+                models.Waiver.played == enums.Played.yes,
+                models.Game.number.is_not(None),
+            )
+            .order_by(models.Game.number)
+        )
+        games = result.all()
+        return [game.to_dto(game.author.to_dto_user_prefetched()) for game in games]
+
     async def get_by_user(self, user: dto.User) -> dto.Player:
         return await self.get_by_user_id(user.tg_id)
 

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -136,7 +136,9 @@ class TeamDao(BaseDAO[models.Team]):
         )
         return result.one().to_dto_chat_prefetched()
 
-    async def get_teams(self, active: bool = True, archive: bool = False) -> list[dto.Team]:
+    async def get_teams(
+        self, active: bool = True, archive: bool = False, name: str | None = None
+    ) -> list[dto.Team]:
         query = select(models.Team).options(*get_team_options())
         if not active and not archive:
             query = query.where(false())
@@ -144,6 +146,8 @@ class TeamDao(BaseDAO[models.Team]):
             query = query.where(models.Team.is_dummy.is_(False))
         elif archive:
             query = query.where(models.Team.is_dummy.is_(True))
+        if name:
+            query = query.where(models.Team.name.ilike(f"%{name}%"))
         teams: ScalarResult[models.Team] = await self.session.scalars(query)
         return [team.to_dto_chat_prefetched() for team in teams]
 

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -27,6 +27,7 @@ from shvatka.core.games.org_interactors import (
 )
 from shvatka.core.players.interactors import (
     GetPlayerInteractor,
+    GetPlayerStatInteractor,
     SearchPlayersInteractor,
 )
 from shvatka.core.teams.interactors import (
@@ -34,6 +35,7 @@ from shvatka.core.teams.interactors import (
     EditTeamInteractor,
     GetTeamInteractor,
     RemovePlayerFromTeamInteractor,
+    TeamPlayedGamesInteractor,
     TeamPlayersInteractor,
     TeamsListInteractor,
     UpdateTeamPlayerInteractor,
@@ -225,6 +227,14 @@ class PlayerProvider(Provider):
     def search_players(self, dao: HolderDao) -> SearchPlayersInteractor:
         return SearchPlayersInteractor(dao=dao.player)
 
+    @provide
+    def get_player_stat(self, dao: HolderDao) -> GetPlayerStatInteractor:
+        return GetPlayerStatInteractor(
+            player_dao=dao.player,
+            history_dao=dao.team_player,
+            played_games_dao=dao.player,
+        )
+
 
 class TeamProvider(Provider):
     scope = Scope.REQUEST
@@ -236,6 +246,10 @@ class TeamProvider(Provider):
     @provide
     def get_team(self, dao: HolderDao) -> GetTeamInteractor:
         return GetTeamInteractor(dao=dao.team)
+
+    @provide
+    def get_team_stat(self, dao: HolderDao) -> TeamPlayedGamesInteractor:
+        return TeamPlayedGamesInteractor(team_dao=dao.team, played_games_dao=dao.team)
 
     @provide
     def get_team_players(self, dao: HolderDao) -> TeamPlayersInteractor:

--- a/tests/integration/api_full/test_team.py
+++ b/tests/integration/api_full/test_team.py
@@ -58,6 +58,41 @@ async def test_get_all_teams(
 
 
 @pytest.mark.asyncio
+async def test_search_teams_by_name(
+    client: AsyncClient,
+    gryffindor: dto.Team,
+    slytherin: dto.Team,
+):
+    resp = await client.get(
+        "/teams",
+        params={"search": gryffindor.name[:4]},
+        follow_redirects=True,
+    )
+    assert resp.is_success
+    resp.read()
+    ids = [team["id"] for team in resp.json()["items"]]
+    assert gryffindor.id in ids
+    assert slytherin.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_get_team_stat(
+    client: AsyncClient,
+    finished_game: dto.FullGame,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+):
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    await dao.commit()
+    resp = await client.get(f"/teams/{gryffindor.id}/stat")
+    assert resp.is_success
+    resp.read()
+    items = resp.json()["items"]
+    assert finished_game.id in [game["id"] for game in items]
+
+
+@pytest.mark.asyncio
 async def test_get_team_by_id(
     client: AsyncClient,
     gryffindor: dto.Team,

--- a/tests/integration/api_full/test_user_stat.py
+++ b/tests/integration/api_full/test_user_stat.py
@@ -1,0 +1,57 @@
+import pytest
+from httpx import AsyncClient
+
+from shvatka.core.models import dto
+from shvatka.core.utils.defaults_constants import CAPTAIN_ROLE
+from shvatka.infrastructure.db.dao.holder import HolderDao
+
+
+@pytest.mark.asyncio
+async def test_get_user_stat(
+    client: AsyncClient,
+    finished_game: dto.FullGame,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+):
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    await dao.commit()
+
+    resp = await client.get(f"/users/{harry.id}/stat")
+    assert resp.is_success
+    resp.read()
+    body = resp.json()
+
+    assert body["id"] == harry.id
+    assert body["username"] == harry.username
+    # harry typed one correct key (SH123) in the finished game
+    assert body["typed_keys_count"] >= 1
+    assert body["typed_correct_keys_count"] >= 1
+
+    # team membership history contains gryffindor as captain
+    teams = [tp["team"]["id"] for tp in body["team_history"]]
+    assert gryffindor.id in teams
+    roles = {tp["team"]["id"]: tp["role"] for tp in body["team_history"]}
+    assert roles[gryffindor.id] == CAPTAIN_ROLE
+    assert body["team_history"][0]["date_joined"] is not None
+    assert "date_left" in body["team_history"][0]
+
+    # harry voted "yes", so the finished game is among his played games
+    assert finished_game.id in [game["id"] for game in body["played_games"]]
+
+
+@pytest.mark.asyncio
+async def test_get_user_stat_without_games(
+    client: AsyncClient,
+    hermione: dto.Player,
+):
+    resp = await client.get(f"/users/{hermione.id}/stat")
+    assert resp.is_success
+    resp.read()
+    body = resp.json()
+    assert body["id"] == hermione.id
+    assert body["typed_keys_count"] == 0
+    assert body["typed_correct_keys_count"] == 0
+    assert body["played_games"] == []
+    assert body["team_history"] == []


### PR DESCRIPTION
## Summary

Adds team-name search and two new stat endpoints for the web UI.

### Changes

- **`GET /teams`** — new optional `search` query param. Filters teams by name using a case-insensitive `ILIKE '%search%'` on the DB.
- **`GET /teams/{id}/stat`** — returns `{items: [...games]}` the team has played (games where the team has a waiver and a game number), reusing the existing `get_played_games` method.
- **`GET /users/{id}/stat`** — returns a player's full team-membership history (date joined / left, team, role, emoji), the list of games the player took part in (waiver `played == yes`), and key counters (total typed / correct).

### Implementation notes

- `TeamDao.get_teams` / `TeamsGetter` / service / interactor gained an optional `name` param (backward compatible).
- Added `PlayerDao.get_played_games(player)` (games where the player voted `yes`).
- New interactors `TeamPlayedGamesInteractor` and `GetPlayerStatInteractor`, wired through dishka.
- New response models `PlayerStat` / `TeamPlayerHistory`.

### Tests

- `test_search_teams_by_name`, `test_get_team_stat` in `test_team.py`
- new `test_user_stat.py`

`mypy` and `ruff` pass. Integration tests require Docker (testcontainers/Postgres), which isn't available in this environment, so they were not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186H1eQRkEJnkFTrZ3wVXe9)_