### PR TITLE
Add played games count to team list and team players list

### DIFF
--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -9,6 +9,8 @@ from adaptix import Retort
 from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole, Event
 from shvatka.core.models import dto, enums
 from shvatka.core.players.dto import PlayerStat as PlayerStatDto
+from shvatka.core.teams.dto import TeamWithStat as TeamWithStatDto
+from shvatka.core.teams.dto import TeamPlayerWithStat as TeamPlayerWithStatDto
 from shvatka.core.models.dto import action
 from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
@@ -57,6 +59,25 @@ class Team:
             name=core.name,
             captain=Player.from_core(core.captain) if core.captain else None,
             description=core.description,
+        )
+
+
+@dataclass
+class TeamWithStat:
+    id: int
+    name: str
+    captain: Player | None
+    description: str | None
+    played_games_count: int
+
+    @classmethod
+    def from_core(cls, core: TeamWithStatDto) -> "TeamWithStat":
+        return cls(
+            id=core.team.id,
+            name=core.team.name,
+            captain=Player.from_core(core.team.captain) if core.team.captain else None,
+            description=core.team.description,
+            played_games_count=core.played_games_count,
         )
 
 
@@ -185,6 +206,34 @@ class TeamMember:
             role=core.role,
             permissions={permission.name: value for permission, value in core.permissions.items()},
             date_joined=core.date_joined,
+        )
+
+
+@dataclass
+class TeamMemberWithStat:
+    team_player_id: int
+    id: int
+    username: str | None
+    can_be_author: bool
+    emoji: str | None
+    role: str
+    permissions: dict[str, bool]
+    date_joined: datetime
+    played_games_count: int
+
+    @classmethod
+    def from_core(cls, core: TeamPlayerWithStatDto) -> "TeamMemberWithStat":
+        tp = core.team_player
+        return cls(
+            team_player_id=tp.id,
+            id=tp.player.id,
+            username=tp.player.username,
+            can_be_author=tp.player.can_be_author,
+            emoji=tp.emoji,
+            role=tp.role,
+            permissions={permission.name: value for permission, value in tp.permissions.items()},
+            date_joined=tp.date_joined,
+            played_games_count=core.played_games_count,
         )
 
 

--- a/shvatka/api/routes/team.py
+++ b/shvatka/api/routes/team.py
@@ -26,9 +26,9 @@ async def get_teams(
     active: Annotated[bool, Query()] = True,
     archive: Annotated[bool, Query()] = False,
     search: Annotated[str | None, Query()] = None,
-) -> responses.Items[responses.Team]:
+) -> responses.Items[responses.TeamWithStat]:
     teams = await interactor(active=active, archive=archive, name=search)
-    return responses.Items([responses.Team.from_core(team) for team in teams])
+    return responses.Items([responses.TeamWithStat.from_core(team) for team in teams])
 
 
 @inject
@@ -90,9 +90,9 @@ async def edit_team(
 async def get_team_players(
     interactor: FromDishka[TeamPlayersInteractor],
     id_: Annotated[int, Path(alias="id")],
-) -> responses.Items[responses.TeamMember]:
+) -> responses.Items[responses.TeamMemberWithStat]:
     players = await interactor(id_)
-    return responses.Items([responses.TeamMember.from_core(player) for player in players])
+    return responses.Items([responses.TeamMemberWithStat.from_core(player) for player in players])
 
 
 @inject

--- a/shvatka/core/teams/adapters.py
+++ b/shvatka/core/teams/adapters.py
@@ -1,4 +1,4 @@
-from typing import Protocol
+from typing import Protocol, Sequence
 
 from shvatka.core.interfaces.dal.base import Committer
 from shvatka.core.interfaces.dal.player import (
@@ -12,6 +12,7 @@ from shvatka.core.interfaces.dal.team import (
     TeamByIdGetter,
     TeamDescChanger,
     TeamRenamer,
+    TeamsGetter,
 )
 
 
@@ -32,3 +33,21 @@ class TeamPlayerUpdater(
 
 class TeamEditor(TeamRenamer, TeamDescChanger, TeamByIdGetter, Protocol):
     """DAO contract for renaming a team and changing its description."""
+
+
+class TeamPlayedGamesCounter(Protocol):
+    """DAO contract for counting played games per team in one query."""
+
+    async def get_played_games_counts(self, team_ids: Sequence[int]) -> dict[int, int]:
+        raise NotImplementedError
+
+
+class PlayerPlayedGamesCounter(Protocol):
+    """DAO contract for counting played games per player in one query."""
+
+    async def get_played_games_counts(self, player_ids: Sequence[int]) -> dict[int, int]:
+        raise NotImplementedError
+
+
+class TeamsWithStatGetter(TeamsGetter, TeamPlayedGamesCounter, Protocol):
+    """DAO contract for listing teams together with their played games counts."""

--- a/shvatka/core/teams/dto.py
+++ b/shvatka/core/teams/dto.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from shvatka.core.models import dto
+
+
+@dataclass(frozen=True, slots=True)
+class TeamWithStat:
+    """A team together with aggregated statistics for list views."""
+
+    team: dto.Team
+    played_games_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class TeamPlayerWithStat:
+    """A team member together with aggregated statistics for list views."""
+
+    team_player: dto.FullTeamPlayer
+    played_games_count: int

--- a/shvatka/core/teams/interactors.py
+++ b/shvatka/core/teams/interactors.py
@@ -18,7 +18,6 @@ from shvatka.core.interfaces.dal.player import (
 from shvatka.core.interfaces.dal.team import (
     PlayedGamesByTeamGetter,
     TeamByIdGetter,
-    TeamsGetter,
 )
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto, enums
@@ -35,7 +34,14 @@ from shvatka.core.services.team import (
     get_team_by_id,
     get_teams,
 )
-from shvatka.core.teams.adapters import TeamEditor, TeamPlayerAdder, TeamPlayerUpdater
+from shvatka.core.teams.adapters import (
+    PlayerPlayedGamesCounter,
+    TeamEditor,
+    TeamPlayerAdder,
+    TeamPlayerUpdater,
+    TeamsWithStatGetter,
+)
+from shvatka.core.teams.dto import TeamPlayerWithStat, TeamWithStat
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.core.utils.exceptions import PlayerRestoredInTeam
 from shvatka.core.views.team import TeamNotifier
@@ -43,12 +49,16 @@ from shvatka.core.views.team import TeamNotifier
 
 @dataclass
 class TeamsListInteractor:
-    dao: TeamsGetter
+    dao: TeamsWithStatGetter
 
     async def __call__(
         self, active: bool = True, archive: bool = False, name: str | None = None
-    ) -> list[dto.Team]:
-        return await get_teams(self.dao, active=active, archive=archive, name=name)
+    ) -> list[TeamWithStat]:
+        teams = await get_teams(self.dao, active=active, archive=archive, name=name)
+        counts = await self.dao.get_played_games_counts([team.id for team in teams])
+        return [
+            TeamWithStat(team=team, played_games_count=counts.get(team.id, 0)) for team in teams
+        ]
 
 
 @dataclass
@@ -73,10 +83,19 @@ class TeamPlayedGamesInteractor:
 class TeamPlayersInteractor:
     team_dao: TeamByIdGetter
     players_dao: TeamPlayersGetter
+    counter: PlayerPlayedGamesCounter
 
-    async def __call__(self, team_id: int) -> Sequence[dto.FullTeamPlayer]:
+    async def __call__(self, team_id: int) -> Sequence[TeamPlayerWithStat]:
         team = await get_team_by_id(team_id, self.team_dao)
-        return await get_team_players(team, self.players_dao)
+        players = await get_team_players(team, self.players_dao)
+        counts = await self.counter.get_played_games_counts([p.player_id for p in players])
+        return [
+            TeamPlayerWithStat(
+                team_player=player,
+                played_games_count=counts.get(player.player_id, 0),
+            )
+            for player in players
+        ]
 
 
 @dataclass

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -1,9 +1,9 @@
 import uuid
 from datetime import datetime, tzinfo
 import typing
-from typing import Iterable
+from typing import Iterable, Sequence
 
-from sqlalchemy import select, func, Result, case, delete, ScalarResult, inspect, or_
+from sqlalchemy import select, func, distinct, Result, case, delete, ScalarResult, inspect, or_
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -96,6 +96,24 @@ class PlayerDao(BaseDAO[models.Player]):
         )
         games = result.all()
         return [game.to_dto(game.author.to_dto_user_prefetched()) for game in games]
+
+    async def get_played_games_counts(self, player_ids: Sequence[int]) -> dict[int, int]:
+        if not player_ids:
+            return {}
+        result = await self.session.execute(
+            select(
+                models.Waiver.player_id,
+                func.count(distinct(models.Waiver.game_id)),
+            )
+            .join(models.Game, models.Game.id == models.Waiver.game_id)
+            .where(
+                models.Waiver.player_id.in_(player_ids),
+                models.Waiver.played == enums.Played.yes,
+                models.Game.number.is_not(None),
+            )
+            .group_by(models.Waiver.player_id)
+        )
+        return dict(result.tuples().all())
 
     async def get_by_user(self, user: dto.User) -> dto.Player:
         return await self.get_by_user_id(user.tg_id)

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -2,7 +2,7 @@ from datetime import datetime, tzinfo
 import typing
 from typing import Sequence
 
-from sqlalchemy import select, ScalarResult, false
+from sqlalchemy import select, ScalarResult, false, func, distinct
 from sqlalchemy import update
 from sqlalchemy.exc import NoResultFound, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -170,6 +170,23 @@ class TeamDao(BaseDAO[models.Team]):
         )
         games: Sequence[models.Game] = result.all()
         return [game.to_dto(game.author.to_dto_user_prefetched()) for game in games]
+
+    async def get_played_games_counts(self, team_ids: Sequence[int]) -> dict[int, int]:
+        if not team_ids:
+            return {}
+        result = await self.session.execute(
+            select(
+                models.Waiver.team_id,
+                func.count(distinct(models.Waiver.game_id)),
+            )
+            .join(models.Game, models.Game.id == models.Waiver.game_id)
+            .where(
+                models.Waiver.team_id.in_(team_ids),
+                models.Game.number.is_not(None),
+            )
+            .group_by(models.Waiver.team_id)
+        )
+        return dict(result.tuples().all())
 
     async def delete(self, team: dto.Team):
         team_db = await self._get_by_id(team.id)

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -253,7 +253,9 @@ class TeamProvider(Provider):
 
     @provide
     def get_team_players(self, dao: HolderDao) -> TeamPlayersInteractor:
-        return TeamPlayersInteractor(team_dao=dao.team, players_dao=dao.team_player)
+        return TeamPlayersInteractor(
+            team_dao=dao.team, players_dao=dao.team_player, counter=dao.player
+        )
 
     @provide
     def add_player(self, dao: HolderDao, notifier: TeamNotifier) -> AddPlayerToTeamInteractor:

--- a/tests/integration/api_full/test_team.py
+++ b/tests/integration/api_full/test_team.py
@@ -54,7 +54,26 @@ async def test_get_all_teams(
     assert resp.is_success
     resp.read()
     items = resp.json()["items"]
-    assert gryffindor.id in [team["id"] for team in items]
+    by_id = {team["id"]: team for team in items}
+    assert gryffindor.id in by_id
+    assert by_id[gryffindor.id]["played_games_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_team_list_played_games_count(
+    client: AsyncClient,
+    finished_game: dto.FullGame,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+):
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    await dao.commit()
+    resp = await client.get("/teams")
+    assert resp.is_success
+    resp.read()
+    by_id = {team["id"]: team for team in resp.json()["items"]}
+    assert by_id[gryffindor.id]["played_games_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -125,6 +144,29 @@ async def test_get_team_players(
     assert by_player[harry.id]["role"] == CAPTAIN_ROLE
     assert "permissions" in by_player[hermione.id]
     assert by_player[hermione.id]["date_joined"] is not None
+    assert by_player[harry.id]["played_games_count"] == 0
+    assert by_player[hermione.id]["played_games_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_team_players_played_games_count(
+    client: AsyncClient,
+    finished_game: dto.FullGame,
+    harry: dto.Player,
+    ron: dto.Player,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+):
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    await dao.commit()
+    resp = await client.get(f"/teams/{gryffindor.id}/players")
+    assert resp.is_success
+    resp.read()
+    by_player = {item["id"]: item for item in resp.json()["items"]}
+    # harry voted "yes" in the finished game; ron voted "no"
+    assert by_player[harry.id]["played_games_count"] == 1
+    assert by_player[ron.id]["played_games_count"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a `played_games_count` to the team list and to the team-players list, computed efficiently (one grouped aggregate query per list, **not** N+1).

### Changes

- **`GET /teams`** — every item now has `played_games_count`: the number of distinct games the team has a waiver in (a published game, `number` not null). This matches the semantics of `GET /teams/{id}/stat`, so the count equals the length of that list.
- **`GET /teams/{id}/players`** — every member now has `played_games_count`: the player's **career** count of games they actually played (`waiver.played == 'yes'`, published games). This matches `played_games` in `GET /users/{id}/stat`.

### Implementation notes

- New DAO methods `TeamDao.get_played_games_counts(team_ids)` and `PlayerDao.get_played_games_counts(player_ids)` — single `COUNT(DISTINCT game_id)` grouped query each; `DISTINCT` is required because `waivers` has one row per player per game.
- The list interactors fetch the rows, then run **one** counts query and merge in Python (2 queries total per request, regardless of list size).
- New DTOs in `shvatka.core.teams.dto` (`TeamWithStat`, `TeamPlayerWithStat`) and new DAL contracts in `shvatka.core.teams.adapters`, kept next to the interactor that uses them (not in `core.models.dto` / `core.interfaces.dal`).
- New response models `TeamWithStat` / `TeamMemberWithStat` (existing `Team` / `TeamMember` shapes are unchanged for other endpoints).

### Semantics note
Team count uses "any waiver for the team" (same as the existing `/teams/{id}/stat`), while the per-player count uses "voted yes" (same as the player's own stat). So a team's count and the sum of its members' counts are intentionally not expected to match — each number mirrors its corresponding existing endpoint.

### Tests
- `test_team_list_played_games_count`, `test_get_team_players_played_games_count`, plus field-presence assertions in existing team tests.

`mypy` and `ruff` pass. Integration tests need Docker (testcontainers/Postgres), unavailable in this environment, so they were not executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186H1eQRkEJnkFTrZ3wVXe9)_