### PR TITLE
Add API route to rename a game file by guid

### DIFF
--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -21,6 +21,11 @@ class ChangeUsername:
 
 
 @dataclass
+class RenameFile:
+    filename: str
+
+
+@dataclass
 class GameStartAt:
     start_at: datetime | None = None
 

--- a/shvatka/api/routes/cdn.py
+++ b/shvatka/api/routes/cdn.py
@@ -6,16 +6,19 @@ from urllib.parse import quote
 
 from dishka.integrations.fastapi import FromDishka
 from dishka.integrations.fastapi import inject
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, Body, File, UploadFile
 from fastapi.params import Path
 from fastapi.responses import Response
 
 from shvatka.api.dependencies.auth import ApiIdentityProvider
-from shvatka.api.models import responses
+from shvatka.api.models import responses, req
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
 )
-from shvatka.core.games.editor_interactors import UploadGameFileInteractor
+from shvatka.core.games.editor_interactors import (
+    RenameGameFileInteractor,
+    UploadGameFileInteractor,
+)
 from shvatka.core.interfaces.clients.file_storage import FileStorage
 
 
@@ -77,8 +80,26 @@ async def upload_game_file(
     return responses.UploadedFile.from_core(saved)
 
 
+@inject
+async def rename_game_file(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[RenameGameFileInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    guid: Annotated[str, Path(alias="guid")],
+    body: Annotated[req.RenameFile, Body()],
+) -> responses.GameFile:
+    renamed = await interactor(
+        game_id=id_,
+        guid=guid,
+        filename=body.filename,
+        identity=identity,
+    )
+    return responses.GameFile.from_core(renamed)
+
+
 def setup() -> APIRouter:
     router = APIRouter(prefix="/cdn")
     router.add_api_route("/games/{id}/files", upload_game_file, methods=["POST"])
     router.add_api_route("/games/{id}/files/{guid}", get_game_file, methods=["GET"])
+    router.add_api_route("/games/{id}/files/{guid}", rename_game_file, methods=["PATCH"])
     return router

--- a/shvatka/core/games/editor_interactors.py
+++ b/shvatka/core/games/editor_interactors.py
@@ -18,6 +18,7 @@ from shvatka.core.interfaces.dal.game import (
     GameAuthorsFinder,
     GameByIdGetter,
     GameCreator,
+    GameFileRenamer,
     GameFileUploader,
     GameStartPlanner,
     WaiverStarter,
@@ -38,7 +39,7 @@ from shvatka.core.services.game import (
     start_waivers,
     update_game_scenario,
 )
-from shvatka.core.services.scenario.files import save_file
+from shvatka.core.services.scenario.files import rename_file, save_file
 from shvatka.core.utils import exceptions
 
 logger = logging.getLogger(__name__)
@@ -145,3 +146,23 @@ class UploadGameFileInteractor:
         await self.dao.add_game_file(game.id, saved.id)
         await self.dao.commit()
         return saved
+
+
+@dataclass
+class RenameGameFileInteractor:
+    dao: GameFileRenamer
+
+    async def __call__(
+        self,
+        game_id: int,
+        guid: str,
+        filename: str,
+        identity: IdentityProvider,
+    ) -> hints.VerifiableFileMeta:
+        author = await identity.get_required_player()
+        check_allow_be_author(author)
+        game = await self.dao.get_by_id(id_=game_id, author=author)
+        check_game_editable(game)
+        renamed = await rename_file(guid, game_id, filename, self.dao)
+        await self.dao.commit()
+        return renamed

--- a/shvatka/core/interfaces/dal/game.py
+++ b/shvatka/core/interfaces/dal/game.py
@@ -86,6 +86,17 @@ class GameFileUploader(GameByIdGetter, FileUpserter, Protocol):
         raise NotImplementedError
 
 
+class GameFileRenamer(GameByIdGetter, Committer, Protocol):
+    async def is_game_file(self, game_id: int, guid: str) -> bool:
+        raise NotImplementedError
+
+    async def rename_file(self, guid: str, filename: str) -> None:
+        raise NotImplementedError
+
+    async def get_by_guid(self, guid: str) -> hints.VerifiableFileMeta:
+        raise NotImplementedError
+
+
 class ActiveGameFinder(Protocol):
     async def get_active_game(self) -> dto.Game | None:
         raise NotImplementedError

--- a/shvatka/core/services/scenario/files.py
+++ b/shvatka/core/services/scenario/files.py
@@ -6,11 +6,11 @@ from uuid import uuid4
 from shvatka.core.interfaces.clients.file_storage import FileGateway, FileStorage
 from shvatka.core.interfaces.dal.file_info import FileUpserter, GameFilesMetaGetter
 from shvatka.core.interfaces.dal.file_link import LevelFilesSyncDao
-from shvatka.core.interfaces.dal.game import GameUpserter
+from shvatka.core.interfaces.dal.game import GameFileRenamer, GameUpserter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import hints
-from shvatka.core.utils.exceptions import NotAuthorizedForEdit
+from shvatka.core.utils.exceptions import FileNotFound, NotAuthorizedForEdit
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,27 @@ async def save_file(
     saved = await dao.upsert(stored, author)
     await dao.commit()
     return saved
+
+
+async def rename_file(
+    guid: str,
+    game_id: int,
+    filename: str,
+    dao: GameFileRenamer,
+) -> hints.VerifiableFileMeta:
+    """Rename a file (its human-readable ``original_filename``) by guid.
+
+    The file must be usable in the given game (registered in ``game_files``);
+    the physical content and the guid are left untouched, only the display name
+    is changed. The extension is kept as-is.
+    """
+    if not await dao.is_game_file(game_id, guid):
+        raise FileNotFound(
+            text=f"There is no file with uuid {guid} associated with game id {game_id}",
+            game_id=game_id,
+        )
+    await dao.rename_file(guid, filename)
+    return await dao.get_by_guid(guid)
 
 
 async def upsert_files(

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -9,7 +9,12 @@ from shvatka.core.interfaces.current_game import CurrentGameProvider
 
 from shvatka.core.interfaces.dal.complex import GamePackager
 from shvatka.core.games.adapters import GameFileReader, GamePlayDao
-from shvatka.core.interfaces.dal.game import GameUpserter, GameCreator, GameFileUploader
+from shvatka.core.interfaces.dal.game import (
+    GameUpserter,
+    GameCreator,
+    GameFileRenamer,
+    GameFileUploader,
+)
 from shvatka.core.interfaces.dal.level import LevelDeleter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
@@ -155,6 +160,37 @@ class GameFileUploaderImpl(GameFileUploader):
 
     async def add_game_file(self, game_id: int, file_id: int) -> None:
         await self.dao.game_file.add_game_files(game_id, [file_id])
+
+    async def commit(self) -> None:
+        await self.dao.commit()
+
+
+@dataclass
+class GameFileRenamerImpl(GameFileRenamer):
+    """Single DAO for renaming a file usable in a game (cdn endpoint)."""
+
+    dao: "HolderDao"
+
+    async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
+        return await self.dao.game.get_by_id(id_, author)
+
+    async def get_full(self, id_: int) -> dto.FullGame:
+        return await self.dao.game.get_full(id_)
+
+    async def add_levels(self, game: dto.Game) -> dto.FullGame:
+        return await self.dao.game.add_levels(game)
+
+    async def is_game_file(self, game_id: int, guid: str) -> bool:
+        file_ids = await self.dao.file_info.get_ids_by_guids([guid])
+        if not file_ids:
+            return False
+        return file_ids[0] in await self.dao.game_file.get_file_ids(game_id)
+
+    async def rename_file(self, guid: str, filename: str) -> None:
+        await self.dao.file_info.rename_file(guid, filename)
+
+    async def get_by_guid(self, guid: str) -> hints.VerifiableFileMeta:
+        return await self.dao.file_info.get_by_guid(guid)
 
     async def commit(self) -> None:
         await self.dao.commit()

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -46,6 +46,18 @@ class FileLinkMixin:
         await self.dao.game_file.add_game_files(game_id, file_ids)
 
 
+class IsGameFileMixin:
+    """Tells whether a file (by guid) is usable in a given game."""
+
+    dao: "HolderDao"
+
+    async def is_game_file(self, game_id: int, guid: str) -> bool:
+        file_ids = await self.dao.file_info.get_ids_by_guids([guid])
+        if not file_ids:
+            return False
+        return file_ids[0] in await self.dao.game_file.get_file_ids(game_id)
+
+
 @dataclass
 class GameUpserterImpl(FileLinkMixin, GameUpserter):
     async def upsert_game(self, author: dto.Player, scenario: scn.GameScenario) -> dto.Game:
@@ -166,7 +178,7 @@ class GameFileUploaderImpl(GameFileUploader):
 
 
 @dataclass
-class GameFileRenamerImpl(GameFileRenamer):
+class GameFileRenamerImpl(IsGameFileMixin, GameFileRenamer):
     """Single DAO for renaming a file usable in a game (cdn endpoint)."""
 
     dao: "HolderDao"
@@ -179,12 +191,6 @@ class GameFileRenamerImpl(GameFileRenamer):
 
     async def add_levels(self, game: dto.Game) -> dto.FullGame:
         return await self.dao.game.add_levels(game)
-
-    async def is_game_file(self, game_id: int, guid: str) -> bool:
-        file_ids = await self.dao.file_info.get_ids_by_guids([guid])
-        if not file_ids:
-            return False
-        return file_ids[0] in await self.dao.game_file.get_file_ids(game_id)
 
     async def rename_file(self, guid: str, filename: str) -> None:
         await self.dao.file_info.rename_file(guid, filename)
@@ -238,7 +244,7 @@ class GamePackagerImpl(GamePackager):
         return await self.dao.file_info.get_metas_by_ids(file_ids)
 
 
-class GameFilesGetterImpl(GameFileReader):
+class GameFilesGetterImpl(IsGameFileMixin, GameFileReader):
     def __init__(self, dao: "HolderDao"):
         self.dao = dao
 
@@ -259,12 +265,6 @@ class GameFilesGetterImpl(GameFileReader):
 
     async def check_waiver(self, player: dto.Player, team: dto.Team, game: dto.Game) -> bool:
         return await self.dao.waiver.check_waiver(player, team, game)
-
-    async def is_game_file(self, game_id: int, guid: str) -> bool:
-        file_ids = await self.dao.file_info.get_ids_by_guids([guid])
-        if not file_ids:
-            return False
-        return file_ids[0] in await self.dao.game_file.get_file_ids(game_id)
 
 
 @dataclass(kw_only=True, slots=True)

--- a/shvatka/infrastructure/db/dao/rdb/file_info.py
+++ b/shvatka/infrastructure/db/dao/rdb/file_info.py
@@ -108,6 +108,13 @@ class FileInfoDao(BaseDAO[models.FileInfo]):
             update(models.FileInfo).where(models.FileInfo.guid == guid).values(file_id=file_id)
         )
 
+    async def rename_file(self, guid: str, filename: str) -> None:
+        await self.session.execute(
+            update(models.FileInfo)
+            .where(models.FileInfo.guid == guid)
+            .values(original_filename=filename)
+        )
+
     async def get_all(self, limit: int, offset: int) -> Sequence[hints.SavedFileMeta]:
         result: ScalarResult[models.FileInfo] = await self.session.scalars(
             select(models.FileInfo)

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -18,6 +18,7 @@ from shvatka.core.games.editor_interactors import (
     PlanGameStartInteractor,
     ChangeGameStatusInteractor,
     UploadGameFileInteractor,
+    RenameGameFileInteractor,
 )
 from shvatka.core.games.org_interactors import (
     ListGameOrgsInteractor,
@@ -52,7 +53,7 @@ from shvatka.core.games.adapters import (
 )
 from shvatka.core.interfaces.bus import Bus
 from shvatka.core.interfaces.current_game import CurrentGameProvider
-from shvatka.core.interfaces.dal.game import GameByIdGetter, GameFileUploader
+from shvatka.core.interfaces.dal.game import GameByIdGetter, GameFileRenamer, GameFileUploader
 from shvatka.core.interfaces.dal.game_play import GamePlayerDao
 from shvatka.core.services.current_game import CurrentGameProviderImpl
 from shvatka.core.interfaces.dal.waiver import WaiverApprover
@@ -77,6 +78,7 @@ from shvatka.infrastructure.db.dao.complex2.waiver import (
 )
 from shvatka.infrastructure.db.dao.complex.game import GameFilesGetterImpl, GameScenarioEditorImpl
 from shvatka.infrastructure.db.dao.complex.game import (
+    GameFileRenamerImpl,
     GameFileUploaderImpl,
     GamePlayDaoImpl,
 )
@@ -179,6 +181,14 @@ class GameEditProvider(Provider):
     @provide
     def upload_file(self, dao: GameFileUploader, storage: FileStorage) -> UploadGameFileInteractor:
         return UploadGameFileInteractor(storage=storage, dao=dao)
+
+    @provide
+    def game_file_renamer(self, dao: HolderDao) -> GameFileRenamer:
+        return GameFileRenamerImpl(dao=dao)
+
+    @provide
+    def rename_file(self, dao: GameFileRenamer) -> RenameGameFileInteractor:
+        return RenameGameFileInteractor(dao=dao)
 
     @provide
     def list_orgs(self, dao: HolderDao) -> ListGameOrgsInteractor:

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -259,6 +259,78 @@ async def test_upload_game_file(
 
 
 @pytest.mark.asyncio
+async def test_rename_game_file(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft rename file", dao=dao.game_creator)
+    cookies = auth_cookies(auth, author)
+    up = await client.post(
+        f"/cdn/games/{game.id}/files",
+        files={"file": ("note.txt", b"hello world", "text/plain")},
+        cookies=cookies,
+    )
+    assert up.status_code == 200, up.text
+    guid = up.json()["guid"]
+
+    resp = await client.patch(
+        f"/cdn/games/{game.id}/files/{guid}",
+        json={"filename": "renamed"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["guid"] == guid
+    assert resp.json()["original_filename"] == "renamed"
+    # extension is preserved, only the display name changes
+    assert resp.json()["extension"] == ".txt"
+    stored = await dao.file_info.get_by_guid(guid)
+    assert stored.original_filename == "renamed"
+
+
+@pytest.mark.asyncio
+async def test_rename_foreign_game_file_forbidden(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    harry: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft rename forbidden", dao=dao.game_creator)
+    up = await client.post(
+        f"/cdn/games/{game.id}/files",
+        files={"file": ("note.txt", b"hello world", "text/plain")},
+        cookies=auth_cookies(auth, author),
+    )
+    assert up.status_code == 200, up.text
+    guid = up.json()["guid"]
+    # harry is not the author of `game`
+    resp = await client.patch(
+        f"/cdn/games/{game.id}/files/{guid}",
+        json={"filename": "hacked"},
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_rename_file_not_in_game(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft rename missing", dao=dao.game_creator)
+    resp = await client.patch(
+        f"/cdn/games/{game.id}/files/00000000-0000-0000-0000-000000000000",
+        json={"filename": "renamed"},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
 async def test_uploaded_file_listed_without_reference(
     client: AsyncClient,
     auth: AuthProperties,


### PR DESCRIPTION
## Summary

Adds `PATCH /cdn/games/{id}/files/{guid}` to rename a game file's display name (`original_filename`) by its guid, mirroring the existing upload endpoint and applying the same authorization/state checks.

The rename only changes the human-readable `original_filename`; the guid, physical content, and extension are left untouched.

## Checks applied (all other checks as usual)

- Requester must be an author (`check_allow_be_author`)
- Requester must own the game (`get_by_id` with author → `GameHasAnotherAuthor`)
- Game must still be editable (`check_game_editable`)
- The file must be usable in the game, i.e. registered in `game_files` (`is_game_file`) → `FileNotFound` (404) otherwise

## Changes

- **DAL**: `FileInfoDao.rename_file` and a new `GameFileRenamer` protocol
- **Service**: `rename_file` (game-file membership check + rename, returns updated meta)
- **Interactor**: `RenameGameFileInteractor` wiring the author/editable checks
- **Infra**: `GameFileRenamerImpl` complex DAO + dishka provider
- **API**: `RenameFile` request model; route returns the updated `GameFile`
- **Tests**: rename happy path, foreign-game forbidden (422), and file-not-in-game (404)

## Testing

- `ruff check` and `mypy` pass on all changed files
- Route registration and imports verified
- Integration tests added but not run here (they require Docker/testcontainers, which is unavailable in this environment; all pre-existing tests in the file are gated the same way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAPMjorvmEoykRf4EaSNK5)_