### PR TITLE
Fix hint_sender fallback when file_id is null; save new file_id after content upload

### DIFF
--- a/shvatka/tgbot/models/hint.py
+++ b/shvatka/tgbot/models/hint.py
@@ -22,7 +22,17 @@ class BaseHintView(ABC):
 
 @dataclass(kw_only=True)
 class BaseHintLinkView(BaseHintView, metaclass=ABCMeta):
-    pass
+    def is_sendable(self) -> bool:
+        """whether there is enough data (e.g. file_id) to send this view at all"""
+        return True
+
+
+@dataclass(kw_only=True)
+class FileIdLinkViewMixin(BaseHintLinkView, metaclass=ABCMeta):
+    file_id: str | None
+
+    def is_sendable(self) -> bool:
+        return self.file_id is not None
 
 
 @dataclass(kw_only=True)
@@ -77,8 +87,7 @@ class VenueHintView(BaseHintLinkView, BaseHintContentView):
 
 
 @dataclass(kw_only=True)
-class PhotoLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
+class PhotoLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     show_caption_above_media: bool | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
@@ -103,8 +112,7 @@ class PhotoContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class AudioLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
+class AudioLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     thumb: str | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
@@ -128,8 +136,7 @@ class AudioContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class VideoLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
+class VideoLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     show_caption_above_media: bool | None = None
     thumb: str | None = None
 
@@ -157,8 +164,7 @@ class VideoContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class DocumentLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
+class DocumentLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     thumb: str | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
@@ -182,8 +188,7 @@ class DocumentContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class AnimationLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
+class AnimationLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     thumb: str | None = None
     show_caption_above_media: bool | None = None
 
@@ -211,9 +216,7 @@ class AnimationContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class VoiceLinkView(BaseHintLinkView, CaptionViewMixin):
-    file_id: str
-
+class VoiceLinkView(FileIdLinkViewMixin, CaptionViewMixin):
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "voice": self.file_id,
@@ -233,9 +236,7 @@ class VoiceContentView(BaseHintContentView, CaptionViewMixin):
 
 
 @dataclass(kw_only=True)
-class VideoNoteLinkView(BaseHintLinkView):
-    file_id: str
-
+class VideoNoteLinkView(FileIdLinkViewMixin):
     def specific_kwargs(self) -> dict[str, Any]:
         return {"video_note": self.file_id}
 
@@ -265,9 +266,7 @@ class ContactHintView(BaseHintLinkView, BaseHintContentView):
 
 
 @dataclass(kw_only=True)
-class StickerHintLinkView(BaseHintLinkView):
-    file_id: str
-
+class StickerHintLinkView(FileIdLinkViewMixin):
     def specific_kwargs(self) -> dict[str, Any]:
         return {"sticker": self.file_id}
 

--- a/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
+++ b/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
@@ -134,7 +134,7 @@ class HintContentResolver:
             case _:
                 raise RuntimeError("unknown hint type")
 
-    async def _resolve_file_id(self, guid: str) -> str:
+    async def _resolve_file_id(self, guid: str) -> str | None:
         tg_link = (await self.dao.get_by_guid(guid)).tg_link
         return tg_link.file_id
 

--- a/shvatka/tgbot/views/hint_sender.py
+++ b/shvatka/tgbot/views/hint_sender.py
@@ -7,10 +7,13 @@ from typing import Iterable, Callable, Awaitable, Collection
 from aiogram import Bot
 from aiogram.exceptions import TelegramAPIError
 from aiogram.types import Message
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from shvatka.core.models import enums
 from shvatka.core.models.dto import hints
+from shvatka.infrastructure.db.dao import FileInfoDao
 from shvatka.tgbot.views.hint_factory.hint_content_resolver import HintContentResolver
+from shvatka.tgbot.views.hint_factory.hint_parser import parse_message
 
 logger = logging.getLogger(__name__)
 METHODS: dict[enums.HintType, Callable[..., Awaitable[Message]]] = {
@@ -32,9 +35,15 @@ METHODS: dict[enums.HintType, Callable[..., Awaitable[Message]]] = {
 class HintSender:
     SLEEP: timedelta = timedelta(seconds=1)
 
-    def __init__(self, bot: Bot, resolver: HintContentResolver) -> None:
+    def __init__(
+        self,
+        bot: Bot,
+        resolver: HintContentResolver,
+        session_pool: async_sessionmaker[AsyncSession],
+    ) -> None:
         self.bot = bot
         self.resolver = resolver
+        self.session_pool = session_pool
         self.methods: dict[enums.HintType, Callable[..., Awaitable[Message]]] = {
             t: partial(m, bot) for t, m in METHODS.items()
         }
@@ -45,12 +54,28 @@ class HintSender:
     async def send_hint(self, hint_container: hints.BaseHint, chat_id: int) -> Message:
         method = self.method(enums.HintType[hint_container.type])
         hint_link = await self.resolver.resolve_link(hint_container)
-        try:
-            return await method(chat_id=chat_id, **hint_link.kwargs())
-        except TelegramAPIError:
-            logger.warning("cant send hint by file_id %s", hint_link)
-            hint_content = await self.resolver.resolve_content(hint_container)
-            return await method(chat_id=chat_id, **hint_content.kwargs())
+        if hint_link.is_sendable():
+            try:
+                return await method(chat_id=chat_id, **hint_link.kwargs())
+            except TelegramAPIError:
+                logger.warning("cant send hint by file_id %s", hint_link)
+        else:
+            logger.info("no file_id to send hint %s, sending by content", hint_container)
+        hint_content = await self.resolver.resolve_content(hint_container)
+        message = await method(chat_id=chat_id, **hint_content.kwargs())
+        await self._save_new_file_id(hint_container, message)
+        return message
+
+    async def _save_new_file_id(self, hint_container: hints.BaseHint, message: Message) -> None:
+        file_guid = getattr(hint_container, "file_guid", None)
+        if file_guid is None or not isinstance(message, Message):
+            return
+        tg_link = parse_message(message)
+        if tg_link is None:
+            return
+        async with self.session_pool() as session:
+            await FileInfoDao(session).update_file_id(file_guid, tg_link.file_id)
+            await session.commit()
 
     async def send_hints(
         self,

--- a/tests/fixtures/file_storage.py
+++ b/tests/fixtures/file_storage.py
@@ -15,6 +15,13 @@ FILE_META = hints.FileMeta(
     file_content_link=hints.FileContentLink(file_path=GUID + ".jpg"),
     original_filename="файло",
 )
+NO_FILE_ID_META = hints.FileMeta(
+    guid=GUID,
+    tg_link=hints.TgLink(file_id=None, content_type=enums.HintType.photo),
+    extension=".jpg",
+    file_content_link=hints.FileContentLink(file_path=GUID + ".jpg"),
+    original_filename="файло",
+)
 
 
 class MemoryFileStorageProvider(Provider):

--- a/tests/integration/bot_full/test_hint_sender.py
+++ b/tests/integration/bot_full/test_hint_sender.py
@@ -1,4 +1,5 @@
 import typing
+from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import MagicMock
 
@@ -19,6 +20,9 @@ from aiogram.methods import (
     SendSticker,
 )
 from aiogram.methods.base import TelegramType
+from aiogram.types import Chat, Message, PhotoSize
+from dishka import AsyncContainer
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from shvatka.core.interfaces.clients.file_storage import FileStorage
 from shvatka.core.models import dto
@@ -37,7 +41,7 @@ from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.config.models.main import TgBotConfig
 from shvatka.tgbot.views.hint_factory.hint_content_resolver import HintContentResolver
 from shvatka.tgbot.views.hint_sender import HintSender
-from tests.fixtures.file_storage import FILE_ID, CHAT_ID, FILE_META
+from tests.fixtures.file_storage import FILE_ID, CHAT_ID, FILE_META, NO_FILE_ID_META
 from tests.fixtures.scn_fixtures import GUID
 
 BAD_REQUEST_DESC = (
@@ -57,11 +61,18 @@ PARAMETERS = [
 
 @pytest_asyncio.fixture
 async def hint_sender(
-    dao: HolderDao, file_storage: FileStorage, bot_session: BaseSession, bot_config: TgBotConfig
+    dao: HolderDao,
+    file_storage: FileStorage,
+    bot_session: BaseSession,
+    bot_config: TgBotConfig,
+    dishka_request: AsyncContainer,
 ):
     bot = Bot(token=bot_config.bot.token, session=bot_session)
+    session_pool = await dishka_request.get(async_sessionmaker[AsyncSession])
     return HintSender(
-        bot=bot, resolver=HintContentResolver(dao=dao.file_info, file_storage=file_storage)
+        bot=bot,
+        resolver=HintContentResolver(dao=dao.file_info, file_storage=file_storage),
+        session_pool=session_pool,
     )
 
 
@@ -142,6 +153,37 @@ async def test_send_photo_by_id(
 @pytest.mark.parametrize(
     ("tg_method", "hint", "method_name", "content_type"), tuple(PARAMETERS[:-1])
 )  # we don't send sticker by content
+async def test_send_by_content_when_file_id_is_missing(
+    hint_sender: HintSender,
+    harry: dto.Player,
+    hint: BaseHint,
+    tg_method: TelegramMethod[TelegramType],
+    method_name: str,
+    content_type: str,
+    bot_session: BaseSession,
+):
+    await hint_sender.resolver.storage.put_content(
+        NO_FILE_ID_META.local_file_name, BytesIO(b"12345")
+    )
+    await hint_sender.resolver.dao.upsert(file=NO_FILE_ID_META, author=harry)
+    await hint_sender.resolver.dao.commit()
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [{}]
+
+    await hint_sender.send_hint(hint, CHAT_ID)
+
+    # no file_id -> we go straight to content, no failed attempt by file_id first
+    assert 1 == session.call_count
+    call = session.mock_calls.pop()
+    request = call.args[1]
+    assert request.__api_method__ == method_name
+    assert getattr(request, content_type) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tg_method", "hint", "method_name", "content_type"), tuple(PARAMETERS[:-1])
+)  # we don't send sticker by content
 async def test_send_photo_by_content(
     hint_sender: HintSender,
     harry: dto.Player,
@@ -173,3 +215,31 @@ async def test_send_photo_by_content(
     request = call.args[1]
     assert request.__api_method__ == method_name
     assert getattr(request, content_type) == FILE_ID
+
+
+@pytest.mark.asyncio
+async def test_send_by_content_saves_new_file_id(
+    hint_sender: HintSender,
+    harry: dto.Player,
+    bot_session: BaseSession,
+):
+    new_file_id = "brand-new-file-id"
+    hint = PhotoHint(file_guid=GUID)
+    await hint_sender.resolver.storage.put_content(FILE_META.local_file_name, BytesIO(b"12345"))
+    await hint_sender.resolver.dao.upsert(file=FILE_META, author=harry)
+    await hint_sender.resolver.dao.commit()
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        TelegramAPIError(message="", method=SendPhoto),
+        Message(
+            message_id=1,
+            date=datetime.now(timezone.utc),
+            chat=Chat(id=CHAT_ID, type="private"),
+            photo=[PhotoSize(file_id=new_file_id, file_unique_id="unique", width=10, height=10)],
+        ),
+    ]
+
+    await hint_sender.send_hint(hint, CHAT_ID)
+
+    saved = await hint_sender.resolver.dao.get_by_guid(GUID)
+    assert saved.tg_link.file_id == new_file_id


### PR DESCRIPTION
## Summary
- `HintSender.send_hint` previously only fell back to sending raw content when Telegram rejected a `file_id` (`TelegramAPIError`). If `file_id` was `null` (e.g. never uploaded to Telegram), the fallback never triggered because the request failed before reaching Telegram at all.
- Link views (`PhotoLinkView`, `AudioLinkView`, etc.) now expose `is_sendable()` (via a new `FileIdLinkViewMixin`), which `HintSender` checks before attempting a by-`file_id` send. If there is no `file_id`, it goes straight to sending by content.
- After a successful send by content, `HintSender` parses the resulting message for the new `file_id` and persists it via a separate, independently-committed DB session (`session_pool`), so the update isn't tied to whatever transaction the request-scoped session is using.

## Test plan
- [x] `pytest tests/unit` passes
- [x] `mypy shvatka` passes with no issues
- [x] `ruff check` / `ruff format --check` pass on changed files
- [x] Added `tests/integration/bot_full/test_hint_sender.py::test_send_by_content_when_file_id_is_missing` covering the null-`file_id` fallback
- [x] Added `tests/integration/bot_full/test_hint_sender.py::test_send_by_content_saves_new_file_id` covering the new-`file_id` persistence
- [ ] Could not execute the DB-backed integration tests in this sandbox (no network access to pull the Postgres test-container image); relied on `mypy`/`ruff`/unit tests instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0117tcBcuiS7gg3iVgEesaxb)_