### PR TITLE
Add API to create a team without telegram chat (web-only play)

### DIFF
--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -72,6 +72,12 @@ class TeamSettings:
 
 
 @dataclass
+class NewTeam:
+    name: str
+    description: str | None = None
+
+
+@dataclass
 class WaiverVote:
     player_id: int
     played: Played = Played.yes

--- a/shvatka/api/routes/team.py
+++ b/shvatka/api/routes/team.py
@@ -10,6 +10,7 @@ from shvatka.api.models import req, responses
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.teams.interactors import (
     AddPlayerToTeamInteractor,
+    CreateTeamInteractor,
     EditTeamInteractor,
     GetTeamInteractor,
     RemovePlayerFromTeamInteractor,
@@ -71,6 +72,20 @@ async def get_team(
 
 
 @inject
+async def create_team(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[CreateTeamInteractor],
+    body: Annotated[req.NewTeam, Body()],
+) -> responses.Team:
+    team = await interactor(
+        identity=identity,
+        name=body.name,
+        description=body.description,
+    )
+    return responses.Team.from_core(team)
+
+
+@inject
 async def edit_team(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[EditTeamInteractor],
@@ -126,6 +141,7 @@ async def update_team_player(
 def setup() -> APIRouter:
     router = APIRouter(prefix="/teams", tags=["teams"])
     router.add_api_route("", get_teams, methods=["GET"])
+    router.add_api_route("", create_team, methods=["POST"], status_code=201)
     router.add_api_route("/my", get_my_team, methods=["GET"])
     router.add_api_route("/{id}/stat", get_team_stat, methods=["GET"])
     router.add_api_route("/{id}", get_team, methods=["GET"])

--- a/shvatka/core/models/dto/team.py
+++ b/shvatka/core/models/dto/team.py
@@ -35,9 +35,8 @@ class Team:
         return f"<Team id={self.id} name={self.name}>"
 
     def get_chat_id(self) -> int | None:
-        if self.is_dummy:
+        if self._chat is None:
             return None
-        assert self._chat
         return self._chat.tg_id
 
     def has_chat(self) -> bool:

--- a/shvatka/core/teams/adapters.py
+++ b/shvatka/core/teams/adapters.py
@@ -14,6 +14,16 @@ from shvatka.core.interfaces.dal.team import (
     TeamRenamer,
     TeamsGetter,
 )
+from shvatka.core.models import dto
+
+
+class ChatlessTeamCreator(TeamJoiner, Protocol):
+    """DAO contract for creating a team that is not bound to any telegram chat."""
+
+    async def create_no_chat(
+        self, name: str, description: str | None, captain: dto.Player
+    ) -> dto.Team:
+        raise NotImplementedError
 
 
 class TeamPlayerAdder(TeamJoiner, TeamPlayerEmojiChanger, Protocol):

--- a/shvatka/core/teams/interactors.py
+++ b/shvatka/core/teams/interactors.py
@@ -22,6 +22,7 @@ from shvatka.core.interfaces.dal.team import (
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto, enums
 from shvatka.core.players.player import (
+    check_allow_be_author,
     check_can_manage_players,
     get_full_team_player,
     get_team_players,
@@ -35,6 +36,7 @@ from shvatka.core.services.team import (
     get_teams,
 )
 from shvatka.core.teams.adapters import (
+    ChatlessTeamCreator,
     PlayerPlayedGamesCounter,
     TeamEditor,
     TeamPlayerAdder,
@@ -42,8 +44,9 @@ from shvatka.core.teams.adapters import (
     TeamsWithStatGetter,
 )
 from shvatka.core.teams.dto import TeamPlayerWithStat, TeamWithStat
-from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
-from shvatka.core.utils.exceptions import PlayerRestoredInTeam
+from shvatka.core.utils.defaults_constants import CAPTAIN_ROLE, DEFAULT_ROLE
+from shvatka.core.utils.exceptions import PlayerRestoredInTeam, TeamError
+from shvatka.core.views.game import GameLogEvent, GameLogType, GameLogWriter
 from shvatka.core.views.team import TeamNotifier
 
 
@@ -59,6 +62,49 @@ class TeamsListInteractor:
         return [
             TeamWithStat(team=team, played_games_count=counts.get(team.id, 0)) for team in teams
         ]
+
+
+@dataclass
+class CreateTeamInteractor:
+    """Creates a team without a telegram chat, so it can play only via web.
+
+    A chat can be linked later in the tgbot captain's bridge (the "move team to
+    another chat" flow).
+    """
+
+    dao: ChatlessTeamCreator
+    game_log: GameLogWriter
+
+    async def __call__(
+        self,
+        identity: IdentityProvider,
+        name: str,
+        description: str | None = None,
+    ) -> dto.Team:
+        captain = await identity.get_required_player()
+        name = name.strip()
+        if not name:
+            raise TeamError(
+                player=captain,
+                text="can't create team with empty name",
+                notify_user="Название команды не может быть пустым",
+            )
+        check_allow_be_author(captain)
+        await self.dao.check_player_free(captain)
+        team = await self.dao.create_no_chat(name=name, description=description, captain=captain)
+        with contextlib.suppress(PlayerRestoredInTeam):
+            await self.dao.join_team(captain, team, CAPTAIN_ROLE, as_captain=True)
+        await self.dao.commit()
+        await self.game_log.log(
+            GameLogEvent(
+                GameLogType.TEAM_CREATED,
+                data={
+                    "team": team.name,
+                    "captain": captain.name_mention,
+                },
+            )
+        )
+        return team
 
 
 @dataclass

--- a/shvatka/infrastructure/db/dao/complex/team.py
+++ b/shvatka/infrastructure/db/dao/complex/team.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from shvatka.core.interfaces.dal.complex import TeamMerger
 from shvatka.core.interfaces.dal.player import TeamLeaver
 from shvatka.core.interfaces.dal.team import TeamCreator
+from shvatka.core.teams.adapters import ChatlessTeamCreator
 from shvatka.core.models import dto
 
 if typing.TYPE_CHECKING:
@@ -11,7 +12,7 @@ if typing.TYPE_CHECKING:
 
 
 @dataclass
-class TeamCreatorImpl(TeamCreator):
+class TeamCreatorImpl(TeamCreator, ChatlessTeamCreator):
     dao: "HolderDao"
 
     async def check_no_team_in_chat(self, chat: dto.Chat) -> None:
@@ -19,6 +20,11 @@ class TeamCreatorImpl(TeamCreator):
 
     async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.Team:
         return await self.dao.team.create(chat, captain)
+
+    async def create_no_chat(
+        self, name: str, description: str | None, captain: dto.Player
+    ) -> dto.Team:
+        return await self.dao.team.create_no_chat(name, description, captain)
 
     async def join_team(
         self, player: dto.Player, team: dto.Team, role: str, as_captain: bool = False

--- a/shvatka/infrastructure/db/dao/rdb/chat.py
+++ b/shvatka/infrastructure/db/dao/rdb/chat.py
@@ -31,9 +31,10 @@ class ChatDao(BaseDAO[models.Chat]):
             raise exceptions.ChatNotFound(chat_id=tg_id) from e
 
     async def change_team_chat(self, team: dto.Team, chat: dto.Chat) -> None:
-        await self.session.execute(
-            update(models.Chat).where(models.Chat.tg_id == team.get_chat_id()).values(team_id=None)
-        )
+        if (old_chat_id := team.get_chat_id()) is not None:
+            await self.session.execute(
+                update(models.Chat).where(models.Chat.tg_id == old_chat_id).values(team_id=None)
+            )
         await self.session.execute(
             update(models.Chat).where(models.Chat.tg_id == chat.tg_id).values(team_id=team.id)
         )

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -48,6 +48,31 @@ class TeamDao(BaseDAO[models.Team]):
             is_dummy=team.is_dummy,
         )
 
+    async def create_no_chat(
+        self, name: str, description: str | None, captain: dto.Player
+    ) -> dto.Team:
+        team = models.Team(
+            captain_id=captain.id,
+            name=name,
+            description=description,
+        )
+        self.session.add(team)
+        try:
+            await self._flush(team)
+        except IntegrityError as e:
+            raise TeamError(
+                player=captain,
+                text="can't create team",
+            ) from e
+        return dto.Team(
+            id=team.id,
+            chat=None,
+            name=team.name,
+            description=team.description,
+            captain=captain,
+            is_dummy=team.is_dummy,
+        )
+
     async def create_by_forum(self, forum: dto.ForumTeam, captain: dto.Player | None) -> dto.Team:
         forum_team_db = await self.session.get(models.ForumTeam, forum.id)
         assert forum_team_db

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -35,6 +35,7 @@ from shvatka.core.players.interactors import (
 from shvatka.core.services.one_time_link import GenerateOneTimeLoginLinkInteractor
 from shvatka.core.teams.interactors import (
     AddPlayerToTeamInteractor,
+    CreateTeamInteractor,
     EditTeamInteractor,
     GetTeamInteractor,
     RemovePlayerFromTeamInteractor,
@@ -43,6 +44,7 @@ from shvatka.core.teams.interactors import (
     TeamsListInteractor,
     UpdateTeamPlayerInteractor,
 )
+from shvatka.core.teams.adapters import ChatlessTeamCreator
 from shvatka.core.views.game import GameLogWriter
 from shvatka.core.views.team import TeamNotifier
 from shvatka.core.interfaces.clients.file_storage import FileStorage
@@ -86,6 +88,7 @@ from shvatka.infrastructure.db.dao.complex.game import (
     GamePlayDaoImpl,
 )
 from shvatka.infrastructure.db.dao.complex.game_play import GamePlayerDaoImpl
+from shvatka.infrastructure.db.dao.complex.team import TeamCreatorImpl
 from shvatka.infrastructure.db.dao.complex.key_log import GameKeysReaderImpl
 from shvatka.infrastructure.db.dao.complex.level_times import GameStatReaderImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -311,3 +314,13 @@ class TeamProvider(Provider):
     @provide
     def edit_team(self, dao: HolderDao) -> EditTeamInteractor:
         return EditTeamInteractor(dao=dao.team, team_player_dao=dao.team_player)
+
+    @provide
+    def chatless_team_creator(self, dao: HolderDao) -> ChatlessTeamCreator:
+        return TeamCreatorImpl(dao=dao)
+
+    @provide
+    def create_team(
+        self, dao: ChatlessTeamCreator, game_log: GameLogWriter
+    ) -> CreateTeamInteractor:
+        return CreateTeamInteractor(dao=dao, game_log=game_log)

--- a/shvatka/tgbot/dialogs/team_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/team_manage/handlers.py
@@ -195,12 +195,16 @@ async def gotten_chat_request(m: Message, widget: Any, manager: DialogManager):
             text=f"‼️Другая команда уже находится в чате " f"({hd.quote(chat.name)}).\n",
         )
         return
-    await bot.send_message(
-        chat_id=captain.get_chat_id(),  # type: ignore[arg-type]
-        text=(
+    if old_chat_id is None:
+        text = f"Команда {hd.bold(team.name)} привязана к чату {hd.bold(chat.name)}"
+    else:
+        text = (
             f"Команда {hd.bold(team.name)} перенесена в чат {hd.bold(chat.name)}\n"
             f"{old_chat_id}➡️{chat.tg_id}"
-        ),
+        )
+    await bot.send_message(
+        chat_id=captain.get_chat_id(),  # type: ignore[arg-type]
+        text=text,
     )
     await total_remove_msg(
         bot, chat_id=m.chat.id, msg_id=manager.dialog_data.pop("chat_request_message")

--- a/shvatka/tgbot/views/game.py
+++ b/shvatka/tgbot/views/game.py
@@ -107,6 +107,8 @@ class BotView(GameViewPreparer, GameView):
     ) -> None:
         # TODO set bot commands for orgs, hide bot commands for players
         for team in teams:
+            if team.get_chat_id() is None:
+                continue
             try:
                 await self.bot.edit_message_reply_markup(
                     chat_id=team.get_chat_id(),
@@ -140,8 +142,10 @@ class BotView(GameViewPreparer, GameView):
 
     async def send_puzzle(self, team: dto.Team, level: dto.Level) -> None:
         assert level.number_in_game is not None
+        if (chat_id := team.get_chat_id()) is None:
+            return
         await self.hint_sender.send_hints(
-            chat_id=team.get_chat_id(),  # type: ignore[arg-type]
+            chat_id=chat_id,
             hint_containers=level.get_hint(0).hint,
             caption=hd.bold(f"Уровень № {level.number_in_game + 1}"),
         )
@@ -155,14 +159,17 @@ class BotView(GameViewPreparer, GameView):
             )
         else:
             hint_caption = f"Уровень №{level.number_in_game + 1}. Подсказка ({hint.time} мин.):\n"
+        if (chat_id := team.get_chat_id()) is None:
+            return
         await self.hint_sender.send_hints(
-            chat_id=team.get_chat_id(),  # type: ignore[arg-type]
+            chat_id=chat_id,
             hint_containers=hint.hint,
             caption=hint_caption,
         )
 
     async def duplicate_key(self, key: dto.KeyTime, input_container: InputContainer) -> None:
-        chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := key.team.get_chat_id()) is None:
+            return
         reply_to = await get_message_id(input_container)
         try:
             await self.bot.send_message(
@@ -182,7 +189,8 @@ class BotView(GameViewPreparer, GameView):
             )
 
     async def correct_key(self, key: dto.KeyTime, input_container: InputContainer) -> None:
-        chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := key.team.get_chat_id()) is None:
+            return
         reply_to = await get_message_id(input_container)
         try:
             await self.bot.send_message(
@@ -194,7 +202,8 @@ class BotView(GameViewPreparer, GameView):
             logger.exception("can't send view about correct key", exc_info=e)
 
     async def wrong_key(self, key: dto.KeyTime, input_container: InputContainer) -> None:
-        chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := key.team.get_chat_id()) is None:
+            return
         reply_to = await get_message_id(input_container)
         try:
             await self.bot.send_message(
@@ -219,7 +228,8 @@ class BotView(GameViewPreparer, GameView):
             await self.bonus_hint_key(key, effects.hints_, input_container)
 
         if (reply_to := await get_message_id(input_container)) is not None:
-            chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+            if (chat_id := key.team.get_chat_id()) is None:
+                return
             if reaction := map_effect_to_reaction(effects):
                 try:
                     await self.bot.set_message_reaction(
@@ -231,7 +241,8 @@ class BotView(GameViewPreparer, GameView):
     async def bonus_key(
         self, key: dto.KeyTime, bonus: float, input_container: InputContainer
     ) -> None:
-        chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := key.team.get_chat_id()) is None:
+            return
         reply_to = await get_message_id(input_container)
         try:
             await self.bot.send_message(
@@ -248,7 +259,8 @@ class BotView(GameViewPreparer, GameView):
         bonus_hint: Sequence[hints.AnyHint],
         input_container: InputContainer,
     ):
-        chat_id: int = key.team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := key.team.get_chat_id()) is None:
+            return
         reply_to = await get_message_id(input_container)
         try:
             await self.bot.send_message(
@@ -266,7 +278,8 @@ class BotView(GameViewPreparer, GameView):
         )
 
     async def game_finished(self, team: dto.Team, input_container: InputContainer) -> None:
-        chat_id: int = team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := team.get_chat_id()) is None:
+            return
         try:
             await self.bot.send_message(
                 chat_id=chat_id,
@@ -282,7 +295,8 @@ class BotView(GameViewPreparer, GameView):
     async def hint(
         self, team: dto.Team, hint: Sequence[hints.AnyHint], input_container: InputContainer
     ):
-        chat_id: int = team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := team.get_chat_id()) is None:
+            return
         try:
             await self.bot.send_message(
                 chat_id=chat_id,
@@ -297,7 +311,8 @@ class BotView(GameViewPreparer, GameView):
         )
 
     async def bonus(self, team: dto.Team, bonus: float, input_container: InputContainer) -> None:
-        chat_id: int = team.get_chat_id()  # type: ignore[assignment]
+        if (chat_id := team.get_chat_id()) is None:
+            return
         try:
             await self.bot.send_message(
                 reply_to_message_id=await get_message_id(input_container),

--- a/tests/integration/api_full/test_team.py
+++ b/tests/integration/api_full/test_team.py
@@ -46,6 +46,64 @@ async def test_get_team(
 
 
 @pytest.mark.asyncio
+async def test_create_team_without_chat(
+    client: AsyncClient,
+    harry: dto.Player,
+    token: Token,
+    check_dao: HolderDao,
+):
+    resp = await client.post(
+        "/teams",
+        cookies=auth_cookies(token),
+        json={"name": "Web Team", "description": "plays only via web"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 201
+    resp.read()
+    body = resp.json()
+    assert body["name"] == "Web Team"
+    assert body["description"] == "plays only via web"
+    assert body["captain"]["id"] == harry.id
+    team = await check_dao.team.get_by_id(body["id"])
+    assert not team.has_chat()
+    assert team.get_chat_id() is None
+    assert not team.is_dummy
+    team_player = await get_full_team_player(harry, team, check_dao.team_player)
+    assert team_player.role == CAPTAIN_ROLE
+
+
+@pytest.mark.asyncio
+async def test_create_team_when_already_in_team(
+    client: AsyncClient,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+    token: Token,
+):
+    resp = await client.post(
+        "/teams",
+        cookies=auth_cookies(token),
+        json={"name": "Second Team"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422  # PlayerAlreadyInTeam -> SHError
+
+
+@pytest.mark.asyncio
+async def test_create_team_with_empty_name(
+    client: AsyncClient,
+    harry: dto.Player,
+    token: Token,
+):
+    resp = await client.post(
+        "/teams",
+        cookies=auth_cookies(token),
+        json={"name": "   "},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_get_all_teams(
     client: AsyncClient,
     gryffindor: dto.Team,

--- a/tests/integration/test_save_team.py
+++ b/tests/integration/test_save_team.py
@@ -1,12 +1,15 @@
 import pytest
 
 from shvatka.core.services.chat import upsert_chat
-from shvatka.core.players.player import upsert_player
-from shvatka.core.services.team import create_team, get_by_chat
+from shvatka.core.players.player import get_full_team_player, upsert_player
+from shvatka.core.services.team import change_chat, create_team, get_by_chat
 from shvatka.core.services.user import upsert_user
+from shvatka.core.teams.interactors import CreateTeamInteractor
 from shvatka.core.views.game import GameLogWriter
+from shvatka.infrastructure.db.dao.complex.team import TeamCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.chat_constants import create_gryffindor_dto_chat
+from tests.fixtures.identity import MockIdentityProvider
 from tests.fixtures.player import promote
 from tests.fixtures.user_constants import create_dto_harry
 
@@ -33,3 +36,41 @@ async def test_get_team(dao: HolderDao, game_log: GameLogWriter):
     assert team is not None
     assert team.id is not None
     assert team.name == chat.title
+
+
+@pytest.mark.asyncio
+async def test_save_team_no_chat(dao: HolderDao, game_log: GameLogWriter):
+    user = await upsert_user(create_dto_harry(), dao.user)
+    player = await upsert_player(user, dao.player)
+    await promote(player, dao)
+    interactor = CreateTeamInteractor(dao=TeamCreatorImpl(dao=dao), game_log=game_log)
+    team = await interactor(
+        identity=MockIdentityProvider(player=player),
+        name="Web team",
+        description="plays only via web",
+    )
+    assert team.id is not None
+    assert team.name == "Web team"
+    assert not team.has_chat()
+    assert team.get_chat_id() is None
+    assert not team.is_dummy
+    saved = await dao.team.get_by_id(team.id)
+    assert not saved.has_chat()
+
+
+@pytest.mark.asyncio
+async def test_link_chat_to_team_without_chat(dao: HolderDao, game_log: GameLogWriter):
+    """The captain's bridge "move team to another chat" flow must also work
+    when the team has no chat yet: it links the team to its first chat."""
+    user = await upsert_user(create_dto_harry(), dao.user)
+    player = await upsert_player(user, dao.player)
+    await promote(player, dao)
+    interactor = CreateTeamInteractor(dao=TeamCreatorImpl(dao=dao), game_log=game_log)
+    team = await interactor(identity=MockIdentityProvider(player=player), name="Web team")
+    chat = await upsert_chat(create_gryffindor_dto_chat(), dao.chat)
+    captain = await get_full_team_player(player, team, dao.team_player)
+    await change_chat(team, captain, chat, dao.chat)
+    saved = await dao.team.get_by_id(team.id)
+    assert saved.has_chat()
+    assert saved.get_chat_id() == chat.tg_id
+    assert await get_by_chat(chat, dao.team) == team


### PR DESCRIPTION
## What

Adds `POST /teams` — creates a team that is not bound to any telegram chat, so it can play only via web. The authenticated player becomes the captain. A chat can be linked later through the tgbot captain's bridge ("move team to another chat" now also handles the "no chat yet → first chat" case).

## Changes

### API / core
- `POST /teams` (201) with `{"name": ..., "description": ...}` → `CreateTeamInteractor`: validates non-empty name, requires `can_be_author`, checks the player is not already in a team, creates the team, joins the captain with the captain role, writes the `TEAM_CREATED` game-log event.
- New `ChatlessTeamCreator` adapter protocol in `core/teams/adapters.py`, implemented by `TeamCreatorImpl` via new `TeamDao.create_no_chat`, wired with dishka (no new `HolderDao` properties).

### Teams without chat are now tolerated everywhere
- `dto.Team.get_chat_id()` returns `None` instead of `assert`-crashing when the team has no chat (previously only dummy teams got `None`).
- `BotView` game views (`prepare_game_view`, puzzle/hints, key results, bonuses, game finished) skip teams without a chat — such teams are served by the web view and push notifications. `BotTeamNotifier` already guarded this.
- Web play/waiver paths don't touch team chat, so nothing else needed there.

### Linking a chat via captain's bridge
- `ChatDao.change_team_chat` skips unlinking the old chat when there is none, so "move team to another chat" doubles as "link team to its first chat".
- The captain's confirmation message says "привязана к чату" instead of "перенесена ... None➡️id" when the team had no chat.

## Tests
- `tests/integration/api_full/test_team.py`: create team via API (captain joined, no chat, not dummy), 422 when already in a team, 422 on empty name.
- `tests/integration/test_save_team.py`: interactor-level creation, and linking a chat to a chatless team via `change_chat` (the captain's-bridge flow).

Lint (`ruff format --check`, `ruff check`, `mypy`) and `pytest tests/unit` pass locally; integration tests rely on CI (no Docker in the dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJ5q4evpMfTMp7PZMvE2y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ5q4evpMfTMp7PZMvE2y6)_