### PR TITLE
Add global search across games, levels, teams and players

### DIFF
--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -854,10 +854,13 @@ class LevelSearchResult:
     game_id: int
     game_name: str
     game_number: int | None
-    found_in: typing.Literal["name_id", "hint"]
+    found_in: typing.Literal["name_id", "hint", "key"]
     hint_number: int | None
     hint_time: int | None
     hint_part_number: int | None
+    condition_key: Sequence[str] = ()
+    condition_timer: int | None = None
+    key: str | None = None
     snippet: str
     type: typing.Literal["level"] = "level"
 
@@ -870,10 +873,13 @@ class LevelSearchResult:
             game_id=hit.game.id,
             game_name=hit.game.name,
             game_number=hit.game.number,
-            found_in=typing.cast(typing.Literal["name_id", "hint"], hit.found_in.value),
+            found_in=typing.cast(typing.Literal["name_id", "hint", "key"], hit.found_in.value),
             hint_number=hit.hint_number,
             hint_time=hit.hint_time,
             hint_part_number=hit.hint_part_number,
+            condition_key=hit.condition_key,
+            condition_timer=hit.condition_timer,
+            key=hit.key,
             snippet=hit.snippet,
         )
 

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -19,6 +19,7 @@ from shvatka.core.teams.dto import TeamPlayerWithStat as TeamPlayerWithStatDto
 from shvatka.core.models.dto import action
 from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
+from shvatka.core.search import dto as search_dto
 
 T = typing.TypeVar("T")
 
@@ -825,3 +826,100 @@ class ActionRequest:
             created_at=core.created_at,
             responded_at=core.responded_at,
         )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class GameSearchResult:
+    game_id: int
+    game_name: str
+    game_number: int | None
+    snippet: str
+    type: typing.Literal["game"] = "game"
+
+    @classmethod
+    def from_core(cls, hit: search_dto.GameHit) -> "GameSearchResult":
+        return cls(
+            game_id=hit.game.id,
+            game_name=hit.game.name,
+            game_number=hit.game.number,
+            snippet=hit.snippet,
+        )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class LevelSearchResult:
+    level_id: int
+    level_name_id: str
+    level_number: int | None
+    game_id: int
+    game_name: str
+    game_number: int | None
+    found_in: typing.Literal["name_id", "hint"]
+    hint_number: int | None
+    hint_time: int | None
+    hint_part_number: int | None
+    snippet: str
+    type: typing.Literal["level"] = "level"
+
+    @classmethod
+    def from_core(cls, hit: search_dto.LevelHit) -> "LevelSearchResult":
+        return cls(
+            level_id=hit.level.db_id,
+            level_name_id=hit.level.name_id,
+            level_number=hit.level.number_in_game,
+            game_id=hit.game.id,
+            game_name=hit.game.name,
+            game_number=hit.game.number,
+            found_in=typing.cast(typing.Literal["name_id", "hint"], hit.found_in.value),
+            hint_number=hit.hint_number,
+            hint_time=hit.hint_time,
+            hint_part_number=hit.hint_part_number,
+            snippet=hit.snippet,
+        )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class TeamSearchResult:
+    team_id: int
+    team_name: str
+    snippet: str
+    type: typing.Literal["team"] = "team"
+
+    @classmethod
+    def from_core(cls, hit: search_dto.TeamHit) -> "TeamSearchResult":
+        return cls(team_id=hit.team.id, team_name=hit.team.name, snippet=hit.snippet)
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class PlayerSearchResult:
+    player_id: int
+    player_name: str
+    found_in: typing.Literal["username", "tg_username", "tg_name", "forum_name"]
+    snippet: str
+    type: typing.Literal["player"] = "player"
+
+    @classmethod
+    def from_core(cls, hit: search_dto.PlayerHit) -> "PlayerSearchResult":
+        return cls(
+            player_id=hit.player.id,
+            player_name=hit.player.name_mention,
+            found_in=typing.cast(
+                typing.Literal["username", "tg_username", "tg_name", "forum_name"],
+                hit.found_in.value,
+            ),
+            snippet=hit.snippet,
+        )
+
+
+SearchResult: typing.TypeAlias = (
+    GameSearchResult | LevelSearchResult | TeamSearchResult | PlayerSearchResult
+)
+
+
+def search_results_to_page(results: search_dto.SearchResults) -> Page[SearchResult]:
+    content: list[SearchResult] = []
+    content.extend(GameSearchResult.from_core(hit) for hit in results.games)
+    content.extend(LevelSearchResult.from_core(hit) for hit in results.levels)
+    content.extend(TeamSearchResult.from_core(hit) for hit in results.teams)
+    content.extend(PlayerSearchResult.from_core(hit) for hit in results.players)
+    return Page(content)

--- a/shvatka/api/routes/__init__.py
+++ b/shvatka/api/routes/__init__.py
@@ -1,6 +1,19 @@
 from fastapi import APIRouter
 
-from . import team, version, auth, waivers, cdn, user, game, push, admin, notifications, requests
+from . import (
+    team,
+    version,
+    auth,
+    waivers,
+    cdn,
+    user,
+    game,
+    push,
+    admin,
+    notifications,
+    requests,
+    search,
+)
 
 
 def setup() -> APIRouter:
@@ -10,6 +23,7 @@ def setup() -> APIRouter:
     router.include_router(game.setup())
     router.include_router(waivers.setup())
     router.include_router(team.setup())
+    router.include_router(search.setup())
     router.include_router(push.setup())
     router.include_router(notifications.setup())
     router.include_router(requests.setup())

--- a/shvatka/api/routes/search.py
+++ b/shvatka/api/routes/search.py
@@ -1,0 +1,32 @@
+from typing import Annotated
+
+from dishka.integrations.fastapi import FromDishka
+from dishka.integrations.fastapi import inject
+from fastapi import APIRouter
+from fastapi.params import Query
+
+from shvatka.api.models import responses
+from shvatka.core.search.dto import SearchFilters
+from shvatka.core.search.interactors import GlobalSearchInteractor
+
+
+@inject
+async def global_search(
+    interactor: FromDishka[GlobalSearchInteractor],
+    query: Annotated[str, Query(min_length=1)],
+    games: Annotated[bool, Query()] = True,
+    levels: Annotated[bool, Query()] = True,
+    teams: Annotated[bool, Query()] = True,
+    players: Annotated[bool, Query()] = True,
+) -> responses.Page[responses.SearchResult]:
+    results = await interactor(
+        query=query,
+        filters=SearchFilters(games=games, levels=levels, teams=teams, players=players),
+    )
+    return responses.search_results_to_page(results)
+
+
+def setup() -> APIRouter:
+    router = APIRouter(prefix="/search", tags=["search"])
+    router.add_api_route("", global_search, methods=["GET"])
+    return router

--- a/shvatka/core/models/dto/action/timer.py
+++ b/shvatka/core/models/dto/action/timer.py
@@ -101,6 +101,7 @@ class LevelTimerEffectsCondition(LevelTimerCondition, EffectsCondition):
     """
 
     action_time: int
+    """minutes"""
     effects: Effects
     type: Literal["EFFECTS_TIMER"] = ConditionType.EFFECTS_TIMER.name
 

--- a/shvatka/core/models/dto/hints/__init__.py
+++ b/shvatka/core/models/dto/hints/__init__.py
@@ -13,6 +13,7 @@ from .hint_part import (
     AnyHint,
     BaseHint,
     FileMixin,
+    CaptionMixin,
     TextHint,
     GPSHint,
     VenueHint,

--- a/shvatka/core/models/dto/player.py
+++ b/shvatka/core/models/dto/player.py
@@ -57,6 +57,11 @@ class Player:
             return None
         return self._user.username
 
+    def get_tg_fullname(self) -> str | None:
+        if self._user is None:
+            return None
+        return self._user.fullname or None
+
     def get_forum_name(self) -> str | None:
         if self._forum_user is None:
             return None

--- a/shvatka/core/search/adapters.py
+++ b/shvatka/core/search/adapters.py
@@ -1,0 +1,26 @@
+from typing import Protocol
+
+from shvatka.core.models import dto
+from shvatka.core.search.dto import LevelWithGame
+
+
+class GlobalSearchDao(Protocol):
+    async def search_completed_games(self, text: str) -> list[dto.Game]:
+        """Завершённые игры, чьё название содержит text (без учёта регистра)."""
+        raise NotImplementedError
+
+    async def search_levels_of_completed_games(self, text: str) -> list[LevelWithGame]:
+        """Уровни завершённых игр, у которых text встречается в name_id или в сценарии.
+
+        Это грубый SQL-фильтр по всему json сценария: точное место совпадения
+        определяет уже интерактор, обходя сценарий в памяти.
+        """
+        raise NotImplementedError
+
+    async def search_teams(self, text: str) -> list[dto.Team]:
+        """Команды (включая архивные форумные), чьё название содержит text."""
+        raise NotImplementedError
+
+    async def search_players(self, text: str) -> list[dto.Player]:
+        """Игроки, у которых text встречается в username, имени в tg или имени на форуме."""
+        raise NotImplementedError

--- a/shvatka/core/search/dto.py
+++ b/shvatka/core/search/dto.py
@@ -1,0 +1,75 @@
+import enum
+from dataclasses import dataclass, field
+
+from shvatka.core.models import dto
+
+
+@dataclass(frozen=True, kw_only=True)
+class SearchFilters:
+    """Где искать. По умолчанию — везде."""
+
+    games: bool = True
+    levels: bool = True
+    teams: bool = True
+    players: bool = True
+
+
+@dataclass(frozen=True, kw_only=True)
+class LevelWithGame:
+    """Кандидат для поиска по уровням: уровень вместе с игрой, к которой он привязан."""
+
+    level: dto.Level
+    game: dto.Game
+
+
+class LevelMatchField(enum.Enum):
+    name_id = "name_id"
+    hint = "hint"
+
+
+class PlayerMatchField(enum.Enum):
+    username = "username"
+    tg_username = "tg_username"
+    tg_name = "tg_name"
+    forum_name = "forum_name"
+
+
+@dataclass(frozen=True, kw_only=True)
+class GameHit:
+    game: dto.Game
+    snippet: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class LevelHit:
+    level: dto.Level
+    game: dto.Game
+    found_in: LevelMatchField
+    snippet: str
+    hint_number: int | None = None
+    """Номер временнОй подсказки в списке подсказок уровня (с нуля)."""
+    hint_time: int | None = None
+    """Время выхода подсказки, минуты."""
+    hint_part_number: int | None = None
+    """Номер части внутри временнОй подсказки (с нуля)."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class TeamHit:
+    team: dto.Team
+    snippet: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class PlayerHit:
+    player: dto.Player
+    found_in: PlayerMatchField
+    snippet: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class SearchResults:
+    games: list[GameHit] = field(default_factory=list)
+    levels: list[LevelHit] = field(default_factory=list)
+    teams: list[TeamHit] = field(default_factory=list)
+    players: list[PlayerHit] = field(default_factory=list)

--- a/shvatka/core/search/dto.py
+++ b/shvatka/core/search/dto.py
@@ -1,7 +1,9 @@
 import enum
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 
 from shvatka.core.models import dto
+from shvatka.core.models.dto import action
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -25,6 +27,7 @@ class LevelWithGame:
 class LevelMatchField(enum.Enum):
     name_id = "name_id"
     hint = "hint"
+    key = "key"
 
 
 class PlayerMatchField(enum.Enum):
@@ -47,11 +50,16 @@ class LevelHit:
     found_in: LevelMatchField
     snippet: str
     hint_number: int | None = None
-    """Номер временнОй подсказки в списке подсказок уровня (с нуля)."""
+    """Номер подсказки в списке подсказок уровня (с нуля)."""
     hint_time: int | None = None
     """Время выхода подсказки, минуты."""
     hint_part_number: int | None = None
-    """Номер части внутри временнОй подсказки (с нуля)."""
+    """Номер части внутри подсказки (с нуля)."""
+    condition_key: Sequence[str] = ()
+    """Ключи которые выводят такую подсказку"""
+    condition_timer: int | None = None
+    """Таймер в минутах"""
+    key: action.SHKey | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/shvatka/core/search/interactors.py
+++ b/shvatka/core/search/interactors.py
@@ -1,0 +1,130 @@
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from shvatka.core.models import dto
+from shvatka.core.models.dto import hints
+from shvatka.core.search.adapters import GlobalSearchDao
+from shvatka.core.search.dto import (
+    GameHit,
+    LevelHit,
+    LevelMatchField,
+    LevelWithGame,
+    PlayerHit,
+    PlayerMatchField,
+    SearchFilters,
+    SearchResults,
+    TeamHit,
+)
+
+SNIPPET_RADIUS = 40
+
+
+def make_snippet(text: str, query: str, radius: int = SNIPPET_RADIUS) -> str | None:
+    """Кусочек текста вокруг найденного вхождения (без учёта регистра) или None."""
+    index = text.lower().find(query.lower())
+    if index < 0:
+        return None
+    start = max(0, index - radius)
+    end = min(len(text), index + len(query) + radius)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(text) else ""
+    return prefix + text[start:end] + suffix
+
+
+def iter_hint_texts(hint: hints.AnyHint) -> Iterator[str]:
+    """Все текстовые поля подсказки, в которых имеет смысл искать."""
+    if isinstance(hint, hints.TextHint):
+        yield hint.text
+    elif isinstance(hint, hints.VenueHint):
+        yield hint.title
+        yield hint.address
+    elif isinstance(hint, hints.ContactHint):
+        yield hint.first_name
+        if hint.last_name:
+            yield hint.last_name
+        yield hint.phone_number
+    if isinstance(hint, hints.CaptionMixin) and hint.caption:
+        yield hint.caption
+
+
+def find_level_hits(candidate: LevelWithGame, query: str) -> list[LevelHit]:
+    """Точные места совпадений внутри уровня: name_id и текстовые части подсказок."""
+    result: list[LevelHit] = []
+    level = candidate.level
+    if snippet := make_snippet(level.name_id, query):
+        result.append(
+            LevelHit(
+                level=level,
+                game=candidate.game,
+                found_in=LevelMatchField.name_id,
+                snippet=snippet,
+            )
+        )
+    for hint_number, time_hint in enumerate(level.scenario.time_hints):
+        for part_number, hint_part in enumerate(time_hint.hint):
+            for text in iter_hint_texts(hint_part):
+                if snippet := make_snippet(text, query):
+                    result.append(
+                        LevelHit(
+                            level=level,
+                            game=candidate.game,
+                            found_in=LevelMatchField.hint,
+                            hint_number=hint_number,
+                            hint_time=time_hint.time,
+                            hint_part_number=part_number,
+                            snippet=snippet,
+                        )
+                    )
+                    break
+    return result
+
+
+def classify_player_hit(player: dto.Player, query: str) -> PlayerHit | None:
+    if player.username and (snippet := make_snippet(player.username, query)):
+        return PlayerHit(player=player, found_in=PlayerMatchField.username, snippet=snippet)
+    tg_username = player.get_tg_username()
+    if tg_username and (snippet := make_snippet(tg_username, query)):
+        return PlayerHit(player=player, found_in=PlayerMatchField.tg_username, snippet=snippet)
+    tg_name = player.get_tg_fullname()
+    if tg_name and (snippet := make_snippet(tg_name, query)):
+        return PlayerHit(player=player, found_in=PlayerMatchField.tg_name, snippet=snippet)
+    forum_name = player.get_forum_name()
+    if forum_name and (snippet := make_snippet(forum_name, query)):
+        return PlayerHit(player=player, found_in=PlayerMatchField.forum_name, snippet=snippet)
+    return None
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class GlobalSearchInteractor:
+    dao: GlobalSearchDao
+
+    async def __call__(self, *, query: str, filters: SearchFilters | None = None) -> SearchResults:
+        if filters is None:
+            filters = SearchFilters()
+        query = query.strip()
+        if not query:
+            return SearchResults()
+        games: list[GameHit] = []
+        levels: list[LevelHit] = []
+        teams: list[TeamHit] = []
+        players: list[PlayerHit] = []
+        if filters.games:
+            games = [
+                GameHit(game=game, snippet=make_snippet(game.name, query) or game.name)
+                for game in await self.dao.search_completed_games(query)
+            ]
+        if filters.levels:
+            for candidate in await self.dao.search_levels_of_completed_games(query):
+                levels.extend(find_level_hits(candidate, query))
+        if filters.teams:
+            teams = [
+                TeamHit(team=team, snippet=make_snippet(team.name, query) or team.name)
+                for team in await self.dao.search_teams(query)
+            ]
+        if filters.players:
+            players = [
+                hit
+                for player in await self.dao.search_players(query)
+                if (hit := classify_player_hit(player, query))
+            ]
+        return SearchResults(games=games, levels=levels, teams=teams, players=players)

--- a/shvatka/core/search/interactors.py
+++ b/shvatka/core/search/interactors.py
@@ -1,8 +1,8 @@
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 
 from shvatka.core.models import dto
-from shvatka.core.models.dto import hints
+from shvatka.core.models.dto import hints, Level, action
 from shvatka.core.search.adapters import GlobalSearchDao
 from shvatka.core.search.dto import (
     GameHit,
@@ -48,7 +48,6 @@ def iter_hint_texts(hint: hints.AnyHint) -> Iterator[str]:
 
 
 def find_level_hits(candidate: LevelWithGame, query: str) -> list[LevelHit]:
-    """Точные места совпадений внутри уровня: name_id и текстовые части подсказок."""
     result: list[LevelHit] = []
     level = candidate.level
     if snippet := make_snippet(level.name_id, query):
@@ -61,21 +60,65 @@ def find_level_hits(candidate: LevelWithGame, query: str) -> list[LevelHit]:
             )
         )
     for hint_number, time_hint in enumerate(level.scenario.time_hints):
-        for part_number, hint_part in enumerate(time_hint.hint):
-            for text in iter_hint_texts(hint_part):
-                if snippet := make_snippet(text, query):
-                    result.append(
-                        LevelHit(
-                            level=level,
-                            game=candidate.game,
-                            found_in=LevelMatchField.hint,
-                            hint_number=hint_number,
-                            hint_time=time_hint.time,
-                            hint_part_number=part_number,
-                            snippet=snippet,
-                        )
+        result.extend(
+            make_hint_part_snippet(
+                candidate=candidate,
+                level=level,
+                query=query,
+                hint_=time_hint.hint,
+                hint_time=time_hint.time,
+                hint_number=hint_number,
+            )
+        )
+    for condition in level.scenario.conditions:
+        if isinstance(condition, action.EffectsCondition):
+            result.extend(
+                make_hint_part_snippet(
+                    candidate=candidate,
+                    level=level,
+                    query=query,
+                    hint_=condition.effects.hints_,
+                    condition_key=condition.get_keys()
+                    if isinstance(condition, action.KeyEffectsCondition)
+                    else (),
+                    condition_timer=condition.action_time
+                    if isinstance(condition, action.LevelTimerEffectsCondition)
+                    else None,
+                )
+            )
+    for key in level.scenario.get_keys():
+        if snippet := make_snippet(key, query):
+            result.append(  # noqa: PERF401
+                LevelHit(
+                    level=level,
+                    game=candidate.game,
+                    found_in=LevelMatchField.key,
+                    snippet=snippet,
+                    key=key,
+                )
+            )
+
+    return result
+
+
+def make_hint_part_snippet(
+    candidate: LevelWithGame, level: Level, query: str, hint_: Sequence[hints.AnyHint], **kwargs
+) -> list[LevelHit]:
+    result: list[LevelHit] = []
+    for part_number, hint_part in enumerate(hint_):
+        for text in iter_hint_texts(hint_part):
+            if snippet := make_snippet(text, query):
+                result.append(
+                    LevelHit(
+                        level=level,
+                        game=candidate.game,
+                        found_in=LevelMatchField.hint,
+                        hint_part_number=part_number,
+                        snippet=snippet,
+                        **kwargs,
                     )
-                    break
+                )
+                break
     return result
 
 

--- a/shvatka/infrastructure/db/dao/complex/search.py
+++ b/shvatka/infrastructure/db/dao/complex/search.py
@@ -1,0 +1,26 @@
+import typing
+from dataclasses import dataclass
+
+from shvatka.core.models import dto
+from shvatka.core.search.adapters import GlobalSearchDao
+from shvatka.core.search.dto import LevelWithGame
+
+if typing.TYPE_CHECKING:
+    from shvatka.infrastructure.db.dao.holder import HolderDao
+
+
+@dataclass
+class GlobalSearchDaoImpl(GlobalSearchDao):
+    dao: "HolderDao"
+
+    async def search_completed_games(self, text: str) -> list[dto.Game]:
+        return await self.dao.game.search_completed(text)
+
+    async def search_levels_of_completed_games(self, text: str) -> list[LevelWithGame]:
+        return await self.dao.level.search_in_completed_games(text)
+
+    async def search_teams(self, text: str) -> list[dto.Team]:
+        return await self.dao.team.search_by_name(text)
+
+    async def search_players(self, text: str) -> list[dto.Player]:
+        return await self.dao.player.search_by_any_name(text)

--- a/shvatka/infrastructure/db/dao/rdb/base.py
+++ b/shvatka/infrastructure/db/dao/rdb/base.py
@@ -14,6 +14,19 @@ from shvatka.infrastructure.db.models import Base
 Model_co = TypeVar("Model_co", bound=Base, covariant=True, contravariant=False)
 
 
+ILIKE_ESCAPE = "!"
+
+
+def ilike_pattern(text: str) -> str:
+    """Паттерн для ilike(..., escape=ILIKE_ESCAPE): ищем подстроку, спецсимволы экранированы."""
+    escaped = (
+        text.replace(ILIKE_ESCAPE, ILIKE_ESCAPE * 2)
+        .replace("%", ILIKE_ESCAPE + "%")
+        .replace("_", ILIKE_ESCAPE + "_")
+    )
+    return f"%{escaped}%"
+
+
 class BaseDAO(Generic[Model_co]):
     def __init__(
         self,

--- a/shvatka/infrastructure/db/dao/rdb/game.py
+++ b/shvatka/infrastructure/db/dao/rdb/game.py
@@ -15,7 +15,7 @@ from shvatka.core.models.enums.game_status import ACTIVE_STATUSES
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.exceptions import GameHasAnotherAuthor
 from shvatka.infrastructure.db import models
-from .base import BaseDAO
+from .base import BaseDAO, ILIKE_ESCAPE, ilike_pattern
 
 
 class GameDao(BaseDAO[models.Game]):
@@ -123,6 +123,25 @@ class GameDao(BaseDAO[models.Game]):
                 models.Game.number.is_not(None),
             )
             .order_by(models.Game.number.desc(), models.Game.start_at.desc())
+        )
+        games: Sequence[models.Game] = result.all()
+        return [game.to_dto(game.author.to_dto_user_prefetched()) for game in games]
+
+    async def search_completed(self, text: str) -> list[dto.Game]:
+        result = await self.session.scalars(
+            select(models.Game)
+            .options(
+                joinedload(models.Game.author).options(
+                    joinedload(models.Player.user),
+                    joinedload(models.Player.forum_user),
+                )
+            )
+            .where(
+                models.Game.status == GameStatus.complete,
+                models.Game.number.is_not(None),
+                models.Game.name.ilike(ilike_pattern(text), escape=ILIKE_ESCAPE),
+            )
+            .order_by(models.Game.number.desc())
         )
         games: Sequence[models.Game] = result.all()
         return [game.to_dto(game.author.to_dto_user_prefetched()) for game in games]

--- a/shvatka/infrastructure/db/dao/rdb/level.py
+++ b/shvatka/infrastructure/db/dao/rdb/level.py
@@ -1,17 +1,19 @@
 from datetime import datetime, tzinfo
 import typing
-from sqlalchemy import select, ScalarResult
+from sqlalchemy import select, ScalarResult, Text, cast, or_
 from sqlalchemy import update
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import contains_eager, joinedload
 
 from shvatka.core.models import dto
 from shvatka.core.models.dto.scn.level import LevelScenario
+from shvatka.core.models.enums import GameStatus
 from shvatka.core.rules.game import check_game_editable
 from shvatka.core.rules.level import check_can_link_to_game
+from shvatka.core.search.dto import LevelWithGame
 from shvatka.infrastructure.db import models
-from .base import BaseDAO
+from .base import BaseDAO, ILIKE_ESCAPE, ilike_pattern
 
 
 class LevelDao(BaseDAO[models.Level]):
@@ -95,6 +97,48 @@ class LevelDao(BaseDAO[models.Level]):
             ),
         )
         return level.to_dto(level.author.to_dto_user_prefetched())
+
+    async def search_in_completed_games(self, text: str) -> list[LevelWithGame]:
+        """Уровни завершённых игр с вхождением text в name_id или где-то внутри сценария.
+
+        Фильтр по сценарию грубый (ilike по json-тексту): точное место совпадения
+        ищет вызывающая сторона, обходя загруженный сценарий.
+        """
+        pattern = ilike_pattern(text)
+        result: ScalarResult[models.Level] = await self.session.scalars(
+            select(models.Level)
+            .join(models.Level.game)
+            .options(
+                contains_eager(models.Level.game)
+                .joinedload(models.Game.author)
+                .options(
+                    joinedload(models.Player.user),
+                    joinedload(models.Player.forum_user),
+                ),
+                joinedload(models.Level.author).options(
+                    joinedload(models.Player.user),
+                    joinedload(models.Player.forum_user),
+                ),
+            )
+            .where(
+                models.Game.status == GameStatus.complete,
+                or_(
+                    models.Level.name_id.ilike(pattern, escape=ILIKE_ESCAPE),
+                    cast(models.Level.scenario, Text).ilike(pattern, escape=ILIKE_ESCAPE),
+                ),
+            )
+            .order_by(models.Game.number, models.Level.number_in_game)
+        )
+        found: list[LevelWithGame] = []
+        for level in result.unique().all():
+            game = level.game.to_dto(level.game.author.to_dto_user_prefetched())
+            found.append(
+                LevelWithGame(
+                    level=level.to_dto(level.author.to_dto_user_prefetched()),
+                    game=game,
+                )
+            )
+        return found
 
     async def unlink(self, level: dto.Level):
         await self.session.execute(

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import joinedload, selectinload, contains_eager
 from shvatka.core.models import dto, enums
 from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db import models
-from .base import BaseDAO
+from .base import BaseDAO, ILIKE_ESCAPE, ilike_pattern
 
 
 class PlayerDao(BaseDAO[models.Player]):
@@ -202,6 +202,30 @@ class PlayerDao(BaseDAO[models.Player]):
             query = query.order_by(models.Player.id)
 
         result: ScalarResult[models.Player] = await self.session.scalars(query)
+        return [player.to_dto_user_prefetched() for player in result.unique().all()]
+
+    async def search_by_any_name(self, text: str) -> list[dto.Player]:
+        """Поиск по любому имени: username, tg-username, имени в tg и имени на форуме."""
+        pattern = ilike_pattern(text)
+        tg_name = func.concat_ws(" ", models.User.first_name, models.User.last_name)
+        result: ScalarResult[models.Player] = await self.session.scalars(
+            select(models.Player)
+            .outerjoin(models.Player.user)
+            .outerjoin(models.Player.forum_user)
+            .options(
+                contains_eager(models.Player.user),
+                contains_eager(models.Player.forum_user),
+            )
+            .where(
+                or_(
+                    models.Player.username.ilike(pattern, escape=ILIKE_ESCAPE),
+                    models.User.username.ilike(pattern, escape=ILIKE_ESCAPE),
+                    tg_name.ilike(pattern, escape=ILIKE_ESCAPE),
+                    models.ForumUser.name.ilike(pattern, escape=ILIKE_ESCAPE),
+                )
+            )
+            .order_by(models.Player.id)
+        )
         return [player.to_dto_user_prefetched() for player in result.unique().all()]
 
     async def get_by_forum_player_name(self, name: str) -> dto.Player | None:

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.interfaces import ORMOption
 from shvatka.core.models import dto
 from shvatka.core.utils.exceptions import TeamError, AnotherTeamInChat
 from shvatka.infrastructure.db import models
-from .base import BaseDAO
+from .base import BaseDAO, ILIKE_ESCAPE, ilike_pattern
 
 
 class TeamDao(BaseDAO[models.Team]):
@@ -174,6 +174,16 @@ class TeamDao(BaseDAO[models.Team]):
         if name:
             query = query.where(models.Team.name.ilike(f"%{name}%"))
         teams: ScalarResult[models.Team] = await self.session.scalars(query)
+        return [team.to_dto_chat_prefetched() for team in teams]
+
+    async def search_by_name(self, text: str) -> list[dto.Team]:
+        """Поиск по названию среди всех команд, включая архивные (форумные)."""
+        teams: ScalarResult[models.Team] = await self.session.scalars(
+            select(models.Team)
+            .options(*get_team_options())
+            .where(models.Team.name.ilike(ilike_pattern(text), escape=ILIKE_ESCAPE))
+            .order_by(models.Team.id)
+        )
         return [team.to_dto_chat_prefetched() for team in teams]
 
     async def get_played_games(self, team: dto.Team) -> list[dto.Game]:

--- a/shvatka/infrastructure/di/__init__.py
+++ b/shvatka/infrastructure/di/__init__.py
@@ -5,7 +5,12 @@ from shvatka.infrastructure.di.db import DbProvider, RedisProvider, DAOProvider
 from shvatka.infrastructure.di.files import FileClientProvider
 from shvatka.infrastructure.di.mail import MailProvider, EmailInteractorProvider
 from shvatka.infrastructure.di.interactors import GamePlayProvider, ContextProvider
-from shvatka.infrastructure.di.interactors import WaiverProvider, PlayerProvider, TeamProvider
+from shvatka.infrastructure.di.interactors import (
+    WaiverProvider,
+    PlayerProvider,
+    TeamProvider,
+    SearchProvider,
+)
 from shvatka.infrastructure.di.interactors import NotificationProvider, RequestProvider
 from shvatka.infrastructure.di.printer import PrinterProvider
 from shvatka.infrastructure.db.factory import LockProvider
@@ -31,6 +36,7 @@ def get_providers(paths_env):
         TeamProvider(),
         NotificationProvider(),
         RequestProvider(),
+        SearchProvider(),
         PrinterProvider(),
         LockProvider(),
         SchedulerProvider(),

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -114,6 +114,8 @@ from shvatka.core.scenario.interactors import (
     AllGameKeysReaderInteractor,
     GameScenarioTransitionsInteractor,
 )
+from shvatka.core.search.adapters import GlobalSearchDao
+from shvatka.core.search.interactors import GlobalSearchInteractor
 from shvatka.core.services.key import KeyProcessor, TimerProcessor
 from shvatka.core.waiver.interactors import (
     TeamWaiversDraftReaderInteractor,
@@ -147,6 +149,7 @@ from shvatka.infrastructure.db.dao.complex.game_play import GamePlayerDaoImpl
 from shvatka.infrastructure.db.dao.complex.team import TeamCreatorImpl, AdminTeamMergerImpl
 from shvatka.infrastructure.db.dao.complex.key_log import GameKeysReaderImpl
 from shvatka.infrastructure.db.dao.complex.level_times import GameStatReaderImpl
+from shvatka.infrastructure.db.dao.complex.search import GlobalSearchDaoImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
@@ -392,6 +395,16 @@ class TeamProvider(Provider):
         self, dao: ChatlessTeamCreator, game_log: GameLogWriter
     ) -> CreateTeamInteractor:
         return CreateTeamInteractor(dao=dao, game_log=game_log)
+
+
+class SearchProvider(Provider):
+    scope = Scope.REQUEST
+
+    @provide
+    def global_search_dao(self, dao: HolderDao) -> GlobalSearchDao:
+        return GlobalSearchDaoImpl(dao)
+
+    global_search = provide(GlobalSearchInteractor)
 
 
 class AdminProvider(Provider):

--- a/tests/integration/api_full/test_search.py
+++ b/tests/integration/api_full/test_search.py
@@ -1,0 +1,121 @@
+import pytest
+from httpx import AsyncClient
+
+from shvatka.core.models import dto
+from shvatka.infrastructure.db.dao.holder import HolderDao
+
+
+async def complete_game(game: dto.FullGame, dao: HolderDao) -> None:
+    await dao.game.set_completed(game)
+    await dao.game.set_number(game, 1)
+    await dao.commit()
+
+
+@pytest.mark.asyncio
+async def test_search_levels_by_hint_text(
+    finished_game: dto.FullGame, dao: HolderDao, client: AsyncClient
+):
+    await complete_game(finished_game, dao)
+    resp = await client.get("/search", params={"query": "загадка"})
+    assert resp.is_success
+    content = resp.json()["content"]
+    level_hits = [c for c in content if c["type"] == "level"]
+    assert len(level_hits) == 2
+
+    first = level_hits[0]
+    assert first["game_id"] == finished_game.id
+    assert first["game_name"] == finished_game.name
+    assert first["level_number"] == 0
+    assert first["level_name_id"] == "first"
+    assert first["found_in"] == "hint"
+    assert first["hint_number"] == 0
+    assert first["hint_time"] == 0
+    assert first["hint_part_number"] == 0
+    assert "загадка" in first["snippet"]
+
+    second = level_hits[1]
+    assert second["level_name_id"] == "second"
+    assert second["hint_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_search_levels_by_name_id(
+    finished_game: dto.FullGame, dao: HolderDao, client: AsyncClient
+):
+    await complete_game(finished_game, dao)
+    resp = await client.get("/search", params={"query": "first", "players": False})
+    assert resp.is_success
+    content = resp.json()["content"]
+    level_hits = [c for c in content if c["type"] == "level"]
+    assert len(level_hits) == 1
+    assert level_hits[0]["found_in"] == "name_id"
+    assert level_hits[0]["level_name_id"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_search_game_by_name(
+    finished_game: dto.FullGame, dao: HolderDao, client: AsyncClient
+):
+    await complete_game(finished_game, dao)
+    resp = await client.get("/search", params={"query": "new game"})
+    assert resp.is_success
+    content = resp.json()["content"]
+    game_hits = [c for c in content if c["type"] == "game"]
+    assert len(game_hits) == 1
+    assert game_hits[0]["game_id"] == finished_game.id
+    assert game_hits[0]["game_name"] == finished_game.name
+    assert game_hits[0]["game_number"] == 1
+    assert "new game" in game_hits[0]["snippet"]
+
+
+@pytest.mark.asyncio
+async def test_search_hides_not_completed_games(
+    game: dto.FullGame, dao: HolderDao, client: AsyncClient
+):
+    resp = await client.get("/search", params={"query": "загадка"})
+    assert resp.is_success
+    assert resp.json()["content"] == []
+
+    resp = await client.get("/search", params={"query": "new game"})
+    assert resp.is_success
+    assert resp.json()["content"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_team(gryffindor: dto.Team, client: AsyncClient):
+    resp = await client.get("/search", params={"query": "gryffindor"})
+    assert resp.is_success
+    content = resp.json()["content"]
+    team_hits = [c for c in content if c["type"] == "team"]
+    assert len(team_hits) == 1
+    assert team_hits[0]["team_id"] == gryffindor.id
+    assert team_hits[0]["team_name"] == gryffindor.name
+
+
+@pytest.mark.asyncio
+async def test_search_player_by_tg_name(harry: dto.Player, client: AsyncClient):
+    resp = await client.get("/search", params={"query": "Potter"})
+    assert resp.is_success
+    content = resp.json()["content"]
+    player_hits = [c for c in content if c["type"] == "player"]
+    assert len(player_hits) == 1
+    assert player_hits[0]["player_id"] == harry.id
+    assert player_hits[0]["found_in"] == "tg_name"
+    assert player_hits[0]["snippet"] == "Harry Potter"
+
+
+@pytest.mark.asyncio
+async def test_search_filters(finished_game: dto.FullGame, dao: HolderDao, client: AsyncClient):
+    await complete_game(finished_game, dao)
+    resp = await client.get("/search", params={"query": "загадка", "levels": False})
+    assert resp.is_success
+    assert resp.json()["content"] == []
+
+    resp = await client.get(
+        "/search",
+        params={"query": "загадка", "games": False, "teams": False, "players": False},
+    )
+    assert resp.is_success
+    content = resp.json()["content"]
+    assert content
+    assert all(c["type"] == "level" for c in content)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,8 @@ from shvatka.infrastructure.di import (
     MailProvider,
     EmailInteractorProvider,
     NotificationProvider,
-    RequestProvider, SearchProvider,
+    RequestProvider,
+    SearchProvider,
 )
 from shvatka.infrastructure.di.interactors import GameEditProvider
 from shvatka.main_factory import ComplexOnlyProvider

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,7 @@ from shvatka.infrastructure.di import (
     MailProvider,
     EmailInteractorProvider,
     NotificationProvider,
-    RequestProvider,
+    RequestProvider, SearchProvider,
 )
 from shvatka.infrastructure.di.interactors import GameEditProvider
 from shvatka.main_factory import ComplexOnlyProvider
@@ -103,6 +103,7 @@ async def dishka():
         BotIdpProvider(),
         ComplexOnlyProvider(),
         TestDbProvider(),
+        SearchProvider(),
         mock_provider,
     )
     yield container

--- a/tests/unit/services/global_search_test.py
+++ b/tests/unit/services/global_search_test.py
@@ -1,0 +1,162 @@
+import uuid
+
+from shvatka.core.models import dto
+from shvatka.core.models.dto import action, hints, scn
+from shvatka.core.models.enums import GameStatus
+from shvatka.core.search.dto import LevelMatchField, LevelWithGame, PlayerMatchField
+from shvatka.core.search.interactors import (
+    classify_player_hit,
+    find_level_hits,
+    iter_hint_texts,
+    make_snippet,
+)
+
+
+def test_make_snippet_found_case_insensitive():
+    assert make_snippet("Съешь ещё этих мягких булок", "БУЛОК") == "Съешь ещё этих мягких булок"
+
+
+def test_make_snippet_not_found():
+    assert make_snippet("совсем другой текст", "булок") is None
+
+
+def test_make_snippet_cuts_long_text():
+    text = "а" * 100 + "иголка" + "б" * 100
+    snippet = make_snippet(text, "иголка", radius=10)
+    assert snippet == "…" + "а" * 10 + "иголка" + "б" * 10 + "…"
+
+
+def test_iter_hint_texts():
+    assert list(iter_hint_texts(hints.TextHint(text="загадка"))) == ["загадка"]
+    assert list(
+        iter_hint_texts(hints.PhotoHint(file_guid=str(uuid.uuid4()), caption="подпись"))
+    ) == ["подпись"]
+    assert list(iter_hint_texts(hints.PhotoHint(file_guid=str(uuid.uuid4())))) == []
+    assert list(
+        iter_hint_texts(
+            hints.VenueHint(latitude=1.0, longitude=1.0, title="кафе", address="улица")
+        )
+    ) == ["кафе", "улица"]
+    assert list(iter_hint_texts(hints.GPSHint(latitude=1.0, longitude=1.0))) == []
+
+
+def _make_author() -> dto.Player:
+    return dto.Player(id=1, can_be_author=True, is_dummy=False, username="author")
+
+
+def _make_game(author: dto.Player) -> dto.Game:
+    return dto.Game(
+        id=10,
+        author=author,
+        name="Ночной дозор",
+        status=GameStatus.complete,
+        manage_token="",
+        start_at=None,
+        number=5,
+        results=dto.GameResults(
+            published_chanel_id=None,
+            results_picture_file_id=None,
+            keys_url=None,
+        ),
+    )
+
+
+def _make_candidate() -> LevelWithGame:
+    author = _make_author()
+    scenario = scn.LevelScenario(
+        id="arena",
+        time_hints=scn.HintsList(
+            [
+                hints.TimeHint(time=0, hint=[hints.TextHint(text="загадка про arena")]),
+                hints.TimeHint(
+                    time=5,
+                    hint=[
+                        hints.TextHint(text="ничего интересного"),
+                        hints.PhotoHint(file_guid=str(uuid.uuid4()), caption="это Arena цирка"),
+                    ],
+                ),
+            ]
+        ),
+        conditions=scn.Conditions([action.KeyWinCondition({"SH123"})]),
+        __model_version__=1,
+    )
+    level = dto.Level(
+        db_id=100,
+        name_id="arena",
+        author=author,
+        scenario=scenario,
+        game_id=10,
+        number_in_game=2,
+    )
+    return LevelWithGame(level=level, game=_make_game(author))
+
+
+def test_find_level_hits_in_name_id_and_hints():
+    candidate = _make_candidate()
+    hits_found = find_level_hits(candidate, "arena")
+    assert len(hits_found) == 3
+
+    name_id_hit = hits_found[0]
+    assert name_id_hit.found_in == LevelMatchField.name_id
+    assert name_id_hit.snippet == "arena"
+    assert name_id_hit.hint_number is None
+
+    first_hint_hit = hits_found[1]
+    assert first_hint_hit.found_in == LevelMatchField.hint
+    assert first_hint_hit.hint_number == 0
+    assert first_hint_hit.hint_time == 0
+    assert first_hint_hit.hint_part_number == 0
+    assert first_hint_hit.snippet == "загадка про arena"
+
+    caption_hit = hits_found[2]
+    assert caption_hit.hint_number == 1
+    assert caption_hit.hint_time == 5
+    assert caption_hit.hint_part_number == 1
+    assert caption_hit.snippet == "это Arena цирка"
+
+
+def test_find_level_hits_nothing():
+    candidate = _make_candidate()
+    assert find_level_hits(candidate, "иголка") == []
+
+
+def test_classify_player_hit_priority():
+    player = dto.Player(
+        id=2,
+        can_be_author=False,
+        is_dummy=False,
+        username="harry",
+        user=dto.User(tg_id=666, username="harry_tg", first_name="Harry", last_name="Potter"),
+        forum_user=dto.ForumUser(
+            db_id=3, forum_id=3, name="HarryForum", registered=None, player_id=2
+        ),
+    )
+    hit = classify_player_hit(player, "harry")
+    assert hit is not None
+    assert hit.found_in == PlayerMatchField.username
+
+    hit = classify_player_hit(player, "harry_tg")
+    assert hit is not None
+    assert hit.found_in == PlayerMatchField.tg_username
+
+    hit = classify_player_hit(player, "Potter")
+    assert hit is not None
+    assert hit.found_in == PlayerMatchField.tg_name
+    assert hit.snippet == "Harry Potter"
+
+    hit = classify_player_hit(player, "HarryForum")
+    assert hit is not None
+    assert hit.found_in == PlayerMatchField.forum_name
+
+    assert classify_player_hit(player, "hermione") is None
+
+
+def test_get_tg_fullname():
+    player = dto.Player(
+        id=2,
+        can_be_author=False,
+        is_dummy=False,
+        user=dto.User(tg_id=666, first_name="Harry", last_name="Potter"),
+    )
+    assert player.get_tg_fullname() == "Harry Potter"
+    assert _make_author().get_tg_fullname() is None


### PR DESCRIPTION
## What

New `GET /search` endpoint that searches everywhere at once with per-category filters (`games`, `levels`, `teams`, `players` — all `true` by default):

```
GET /search?query=загадка
GET /search?query=загадка&teams=false&players=false
```

Response is a `Page` with a flat list of typed results (`type: game | level | team | player`), each carrying meta info so the UI can render a friendly result and navigate on click:

- **level** — `game_id`, `game_name`, `game_number`, `level_number`, `level_name_id`, `found_in` (`name_id` / `hint`), `hint_number` (position in the hints list), `hint_time` (minutes), `hint_part_number` (position inside the time-hint), and a `snippet` of text around the match;
- **game** — id, name, number, snippet;
- **team** — id, name, snippet;
- **player** — id, display name, `found_in` (`username` / `tg_username` / `tg_name` / `forum_name`), snippet.

## How

Matching is a case-insensitive substring search (`ILIKE '%…%'` with `!`-escaped `%`/`_`, so a literal `%` in the query doesn't act as a wildcard).

For level scenarios the search is two-phase: a coarse SQL prefilter (`CAST(scenario AS TEXT) ILIKE …` on the JSONB column, plus `name_id`) narrows the candidate levels, then `GlobalSearchInteractor` walks the loaded `LevelScenario` in memory to find the exact hint/part and build the snippet. This keeps the SQL simple while producing precise positions; full-text search (`pg_trgm`/`tsvector`) can be added later behind the same `GlobalSearchDao` protocol if the ILIKE scan ever gets slow.

Visibility follows the existing scenario rule (`check_can_view_scenario`): only levels and names of **completed** games are searchable. Teams include archived (forum) ones; players are matched by `player.username`, tg username, tg full name (`first + last` concatenated in SQL, so a query spanning both matches) and forum name.

Structure follows the interactor convention: `core/search/` (dto, `GlobalSearchDao` protocol, `GlobalSearchInteractor` + pure match/snippet helpers), per-table SELECTs in the rdb DAOs, one `dao/complex/search.py` adapter behind the protocol, dishka `SearchProvider`.

Not covered (possible follow-ups): bonus hints inside level conditions (they have no time/number position in the hints list), and key values.

## Tests

- Unit: snippet builder, hint-text extraction, level-scenario walking (exact hint/part positions), player match classification.
- Integration (`tests/integration/api_full/test_search.py`): search by hint text and by `name_id` with meta assertions, game-name search, invisibility of non-completed games, team and player search, and category filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Y72cePrNbWYGmvc8ua44e

---
_Generated by [Claude Code](https://claude.ai/code/session_014Y72cePrNbWYGmvc8ua44e)_