### PR TITLE
Add bot delivery for action requests

### DIFF
--- a/shvatka/core/interfaces/bus.py
+++ b/shvatka/core/interfaces/bus.py
@@ -15,7 +15,6 @@ class OneTimeTokenUsed(Event):
 @dataclass(kw_only=True, frozen=True, slots=True)
 class ActionRequestResolved(Event):
     request_id: int
-    bot_messages: tuple[dict[str, int], ...]
 
 
 class Bus(Protocol):

--- a/shvatka/core/interfaces/bus.py
+++ b/shvatka/core/interfaces/bus.py
@@ -12,6 +12,12 @@ class OneTimeTokenUsed(Event):
     player_id: int
 
 
+@dataclass(kw_only=True, frozen=True, slots=True)
+class ActionRequestResolved(Event):
+    request_id: int
+    bot_messages: tuple[dict[str, int], ...]
+
+
 class Bus(Protocol):
     async def submit(self, event: Event) -> None:
         pass

--- a/shvatka/core/notifications/adapters.py
+++ b/shvatka/core/notifications/adapters.py
@@ -114,7 +114,8 @@ class RequestStorage(Committer, Protocol):
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
         raise NotImplementedError
 
-    async def add_bot_message(
-        self, request_id: int, *, chat_id: int, message_id: int
-    ) -> dto.ActionRequest:
+    async def add_bot_message(self, request_id: int, *, chat_id: int, message_id: int) -> None:
+        raise NotImplementedError
+
+    async def get_bot_messages(self, request_id: int) -> Sequence[tuple[int, int]]:
         raise NotImplementedError

--- a/shvatka/core/notifications/adapters.py
+++ b/shvatka/core/notifications/adapters.py
@@ -59,6 +59,11 @@ class NotificationWriter(Committer, Protocol):
         raise NotImplementedError
 
 
+class RequestNotifier(Protocol):
+    async def notify_created(self, request: dto.ActionRequest) -> None:
+        raise NotImplementedError
+
+
 class RequestStorage(Committer, Protocol):
     async def create(
         self,
@@ -107,4 +112,9 @@ class RequestStorage(Committer, Protocol):
         raise NotImplementedError
 
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
+        raise NotImplementedError
+
+    async def add_bot_message(
+        self, request_id: int, *, chat_id: int, message_id: int
+    ) -> dto.ActionRequest:
         raise NotImplementedError

--- a/shvatka/core/notifications/dto.py
+++ b/shvatka/core/notifications/dto.py
@@ -54,7 +54,6 @@ class ActionRequest:
     responder_id: int | None = None
     responded_at: datetime | None = None
     expires_at: datetime | None = None
-    bot_messages: list[dict[str, int]] = field(default_factory=list)
 
     @property
     def is_pending(self) -> bool:

--- a/shvatka/core/notifications/dto.py
+++ b/shvatka/core/notifications/dto.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from shvatka.core.models.enums.notification import NotificationType, NotificationSeverity
 from shvatka.core.models.enums.request import RequestType, RequestStatus
 
-T = TypeVar("T")
-
 
 @dataclass
-class Page(Generic[T]):
+class Page[T]:
     """A slice of a listing: the fetched items plus the applied window and filters."""
 
     items: Sequence[T]
@@ -56,6 +54,7 @@ class ActionRequest:
     responder_id: int | None = None
     responded_at: datetime | None = None
     expires_at: datetime | None = None
+    bot_messages: list[dict[str, int]] = field(default_factory=list)
 
     @property
     def is_pending(self) -> bool:

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -95,7 +95,7 @@ class CreateTeamJoinInviteInteractor:
         )
         await self.notifier.notify_created(request)
         await self.requests.commit()
-        return await self.requests.get_by_id(request.id)
+        return request
 
 
 @dataclass
@@ -139,7 +139,7 @@ class CreateTeamJoinRequestInteractor:
         )
         await self.notifier.notify_created(request)
         await self.requests.commit()
-        return await self.requests.get_by_id(request.id)
+        return request
 
     async def _manager_ids(self, team: dto.Team) -> set[int]:
         players = await self.team_players_dao.get_players(team)
@@ -193,7 +193,7 @@ class CreateOrgInviteInteractor:
         )
         await self.notifier.notify_created(request)
         await self.requests.commit()
-        return await self.requests.get_by_id(request.id)
+        return request
 
 
 @dataclass
@@ -298,7 +298,6 @@ class AcceptRequestInteractor:
         await self.bus.submit(
             ActionRequestResolved(
                 request_id=request.id,
-                bot_messages=tuple(request.bot_messages),
             )
         )
 
@@ -344,7 +343,6 @@ class DeclineRequestInteractor:
         await self.bus.submit(
             ActionRequestResolved(
                 request_id=updated.id,
-                bot_messages=tuple(updated.bot_messages),
             )
         )
         return updated
@@ -379,7 +377,6 @@ class CancelRequestInteractor:
         await self.bus.submit(
             ActionRequestResolved(
                 request_id=updated.id,
-                bot_messages=tuple(updated.bot_messages),
             )
         )
         return updated

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -24,7 +24,8 @@ from shvatka.core.models import dto
 from shvatka.core.models.enums.notification import NotificationType, NotificationSeverity
 from shvatka.core.models.enums.request import RequestType, RequestStatus
 from shvatka.core.notifications import dto as ndto
-from shvatka.core.notifications.adapters import NotificationWriter, RequestStorage
+from shvatka.core.interfaces.bus import ActionRequestResolved, Bus
+from shvatka.core.notifications.adapters import NotificationWriter, RequestNotifier, RequestStorage
 from shvatka.core.players.player import check_can_add_players, join_team
 from shvatka.core.services.game import get_game
 from shvatka.core.services.organizers import check_allow_manage_orgs, get_orgs
@@ -48,6 +49,7 @@ class CreateTeamJoinInviteInteractor:
     team_dao: TeamByIdGetter
     player_dao: PlayerByIdGetter
     team_player_dao: TeamPlayerGetter
+    notifier: RequestNotifier
 
     async def __call__(
         self,
@@ -91,8 +93,9 @@ class CreateTeamJoinInviteInteractor:
             payload=payload,
             request_id=request.id,
         )
+        await self.notifier.notify_created(request)
         await self.requests.commit()
-        return request
+        return await self.requests.get_by_id(request.id)
 
 
 @dataclass
@@ -103,6 +106,7 @@ class CreateTeamJoinRequestInteractor:
     notifications: NotificationWriter
     team_dao: TeamByIdGetter
     team_players_dao: TeamPlayersGetter
+    notifier: RequestNotifier
 
     async def __call__(self, identity: IdentityProvider, team_id: int) -> ndto.ActionRequest:
         player = await identity.get_required_player()
@@ -133,8 +137,9 @@ class CreateTeamJoinRequestInteractor:
             payload=payload,
             request_id=request.id,
         )
+        await self.notifier.notify_created(request)
         await self.requests.commit()
-        return request
+        return await self.requests.get_by_id(request.id)
 
     async def _manager_ids(self, team: dto.Team) -> set[int]:
         players = await self.team_players_dao.get_players(team)
@@ -149,6 +154,7 @@ class CreateOrgInviteInteractor:
     notifications: NotificationWriter
     player_dao: PlayerByIdGetter
     org_adder: OrgAdder
+    notifier: RequestNotifier
 
     async def __call__(
         self, identity: IdentityProvider, game_id: int, player_id: int
@@ -185,8 +191,9 @@ class CreateOrgInviteInteractor:
             payload=payload,
             request_id=request.id,
         )
+        await self.notifier.notify_created(request)
         await self.requests.commit()
-        return request
+        return await self.requests.get_by_id(request.id)
 
 
 @dataclass
@@ -200,6 +207,7 @@ class AcceptRequestInteractor:
     org_adder: OrgAdder
     team_notifier: TeamNotifier
     org_notifier: OrgNotifier
+    bus: Bus
 
     async def __call__(self, identity: IdentityProvider, request_id: int) -> ndto.ActionRequest:
         actor = await identity.get_required_player()
@@ -228,6 +236,7 @@ class AcceptRequestInteractor:
         await self._join(
             actor, team, manager, request.payload.get("role"), request.payload.get("emoji")
         )
+        await self._submit_resolved(updated)
         return updated
 
     async def _accept_team_join_request(
@@ -242,6 +251,7 @@ class AcceptRequestInteractor:
         await self._join(
             joining, team, actor, request.payload.get("role"), request.payload.get("emoji")
         )
+        await self._submit_resolved(updated)
         return updated
 
     async def _accept_org_invite(
@@ -257,6 +267,7 @@ class AcceptRequestInteractor:
         org = await self.org_adder.add_new_org(game, actor)
         await self.requests.commit()
         await self.org_notifier.notify(NewOrg(orgs_list=notify_orgs, game=game, org=org))
+        await self._submit_resolved(updated)
         return updated
 
     async def _join(
@@ -283,6 +294,14 @@ class AcceptRequestInteractor:
     ) -> ndto.ActionRequest:
         return await self.requests.set_status(request.id, status, responder_id=actor.id)
 
+    async def _submit_resolved(self, request: ndto.ActionRequest) -> None:
+        await self.bus.submit(
+            ActionRequestResolved(
+                request_id=request.id,
+                bot_messages=tuple(request.bot_messages),
+            )
+        )
+
     async def _notify_initiator(
         self, request: ndto.ActionRequest, type_: NotificationType, actor: dto.Player
     ) -> None:
@@ -302,6 +321,7 @@ class DeclineRequestInteractor:
     notifications: NotificationWriter
     team_dao: TeamByIdGetter
     team_player_dao: TeamPlayerGetter
+    bus: Bus
 
     async def __call__(self, identity: IdentityProvider, request_id: int) -> ndto.ActionRequest:
         actor = await identity.get_required_player()
@@ -321,6 +341,12 @@ class DeclineRequestInteractor:
             request_id=request.id,
         )
         await self.requests.commit()
+        await self.bus.submit(
+            ActionRequestResolved(
+                request_id=updated.id,
+                bot_messages=tuple(updated.bot_messages),
+            )
+        )
         return updated
 
     async def _check_can_respond(self, actor: dto.Player, request: ndto.ActionRequest) -> None:
@@ -337,6 +363,7 @@ class CancelRequestInteractor:
     """The initiator withdraws their own pending request."""
 
     requests: RequestStorage
+    bus: Bus
 
     async def __call__(self, identity: IdentityProvider, request_id: int) -> ndto.ActionRequest:
         actor = await identity.get_required_player()
@@ -349,6 +376,12 @@ class CancelRequestInteractor:
             request.id, RequestStatus.cancelled, responder_id=actor.id
         )
         await self.requests.commit()
+        await self.bus.submit(
+            ActionRequestResolved(
+                request_id=updated.id,
+                bot_messages=tuple(updated.bot_messages),
+            )
+        )
         return updated
 
 

--- a/shvatka/infrastructure/bus/in_memory.py
+++ b/shvatka/infrastructure/bus/in_memory.py
@@ -3,7 +3,10 @@ from abc import abstractmethod, ABCMeta
 from dataclasses import dataclass
 from typing import Protocol
 
-from shvatka.core.interfaces.bus import Bus, Event, OneTimeTokenUsed
+from aiogram import Bot
+
+from shvatka.core.interfaces.bus import ActionRequestResolved, Bus, Event, OneTimeTokenUsed
+from shvatka.tgbot.views.utils import total_remove_msg
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +20,19 @@ class UsedOneTimeTokenInteractor(Protocol, metaclass=ABCMeta):
 @dataclass(kw_only=True)
 class InMemoryBus(Bus):
     one_time_token: UsedOneTimeTokenInteractor
+    bot: Bot
 
     async def submit(self, event: Event) -> None:
         try:
             match event:
                 case OneTimeTokenUsed(player_id=player_id):
                     await self.one_time_token(player_id=player_id)
+                case ActionRequestResolved(bot_messages=bot_messages):
+                    for bot_message in bot_messages:
+                        await total_remove_msg(
+                            self.bot,
+                            chat_id=bot_message["chat_id"],
+                            msg_id=bot_message["message_id"],
+                        )
         except Exception as e:
             logger.error("error while processing event %s", event, exc_info=e)

--- a/shvatka/infrastructure/bus/in_memory.py
+++ b/shvatka/infrastructure/bus/in_memory.py
@@ -3,36 +3,35 @@ from abc import abstractmethod, ABCMeta
 from dataclasses import dataclass
 from typing import Protocol
 
-from aiogram import Bot
 
 from shvatka.core.interfaces.bus import ActionRequestResolved, Bus, Event, OneTimeTokenUsed
-from shvatka.tgbot.views.utils import total_remove_msg
 
 logger = logging.getLogger(__name__)
 
 
 class UsedOneTimeTokenInteractor(Protocol, metaclass=ABCMeta):
     @abstractmethod
-    async def __call__(self, player_id):
+    async def __call__(self, player_id: int) -> None:
+        pass
+
+
+class ActionResolvedInteractor(Protocol, metaclass=ABCMeta):
+    @abstractmethod
+    async def __call__(self, request_id: int) -> None:
         pass
 
 
 @dataclass(kw_only=True)
 class InMemoryBus(Bus):
     one_time_token: UsedOneTimeTokenInteractor
-    bot: Bot
+    action_resolved: ActionResolvedInteractor
 
     async def submit(self, event: Event) -> None:
         try:
             match event:
                 case OneTimeTokenUsed(player_id=player_id):
                     await self.one_time_token(player_id=player_id)
-                case ActionRequestResolved(bot_messages=bot_messages):
-                    for bot_message in bot_messages:
-                        await total_remove_msg(
-                            self.bot,
-                            chat_id=bot_message["chat_id"],
-                            msg_id=bot_message["message_id"],
-                        )
+                case ActionRequestResolved(request_id=request_id):
+                    await self.action_resolved(request_id=request_id)
         except Exception as e:
             logger.error("error while processing event %s", event, exc_info=e)

--- a/shvatka/infrastructure/db/dao/rdb/action_request.py
+++ b/shvatka/infrastructure/db/dao/rdb/action_request.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from datetime import datetime, tzinfo
 from typing import Any
 
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, ScalarResult
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -114,16 +114,19 @@ class ActionRequestDAO(BaseDAO[ActionRequest]):
         result = await self.session.scalars(stmt)
         return [request.to_dto() for request in result.all()]
 
-    async def add_bot_message(
-        self, request_id: int, *, chat_id: int, message_id: int
-    ) -> dto.ActionRequest:
+    async def add_bot_message(self, request_id: int, *, chat_id: int, message_id: int) -> None:
         request = await self._get_by_id(request_id)
         request.bot_messages = [
             *(request.bot_messages or []),
             {"chat_id": chat_id, "message_id": message_id},
         ]
         await self._flush(request)
-        return request.to_dto()
+
+    async def get_bot_messages(self, request_id: int) -> Sequence[tuple[int, int]]:
+        result: ScalarResult[list[dict[str, int]]] = await self.session.scalars(
+            select(ActionRequest.bot_messages).where(ActionRequest.id == request_id)
+        )
+        return [(d["chat_id"], d["message_id"]) for d in result.one()]
 
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
         """Pending team-join requests answerable by managers of the given teams."""

--- a/shvatka/infrastructure/db/dao/rdb/action_request.py
+++ b/shvatka/infrastructure/db/dao/rdb/action_request.py
@@ -114,6 +114,17 @@ class ActionRequestDAO(BaseDAO[ActionRequest]):
         result = await self.session.scalars(stmt)
         return [request.to_dto() for request in result.all()]
 
+    async def add_bot_message(
+        self, request_id: int, *, chat_id: int, message_id: int
+    ) -> dto.ActionRequest:
+        request = await self._get_by_id(request_id)
+        request.bot_messages = [
+            *(request.bot_messages or []),
+            {"chat_id": chat_id, "message_id": message_id},
+        ]
+        await self._flush(request)
+        return request.to_dto()
+
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
         """Pending team-join requests answerable by managers of the given teams."""
         if not team_ids:

--- a/shvatka/infrastructure/db/migrations/versions/20260709-120000_a1b2c3d4e5f6_add_action_request_bot_message.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260709-120000_a1b2c3d4e5f6_add_action_request_bot_message.py
@@ -10,7 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "a1b2c3d4e5f6"
+revision = "a3b5c1d9e7f6"
 down_revision = "f6a1b2c3d4e5"
 branch_labels = None
 depends_on = None

--- a/shvatka/infrastructure/db/migrations/versions/20260709-120000_a1b2c3d4e5f6_add_action_request_bot_message.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260709-120000_a1b2c3d4e5f6_add_action_request_bot_message.py
@@ -1,0 +1,27 @@
+"""add action request bot message ids
+
+Revision ID: a1b2c3d4e5f6
+Revises: f6a1b2c3d4e5
+Create Date: 2026-07-09 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1b2c3d4e5f6"
+down_revision = "f6a1b2c3d4e5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "action_requests",
+        sa.Column("bot_messages", sa.JSON(), server_default="[]", nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column("action_requests", "bot_messages")

--- a/shvatka/infrastructure/db/models/action_request.py
+++ b/shvatka/infrastructure/db/models/action_request.py
@@ -44,6 +44,9 @@ class ActionRequest(Base):
     )
     responded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    bot_messages: Mapped[list[dict[str, int]]] = mapped_column(
+        JSONB, nullable=False, server_default="[]", default=list
+    )
 
     def to_dto(self) -> dto.ActionRequest:
         return dto.ActionRequest(
@@ -59,4 +62,5 @@ class ActionRequest(Base):
             responder_id=self.responder_id,
             responded_at=self.responded_at,
             expires_at=self.expires_at,
+            bot_messages=list(self.bot_messages or []),
         )

--- a/shvatka/infrastructure/db/models/action_request.py
+++ b/shvatka/infrastructure/db/models/action_request.py
@@ -62,5 +62,4 @@ class ActionRequest(Base):
             responder_id=self.responder_id,
             responded_at=self.responded_at,
             expires_at=self.expires_at,
-            bot_messages=list(self.bot_messages or []),
         )

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -1,3 +1,4 @@
+from aiogram import Bot
 from adaptix import Retort
 from dishka import Provider, Scope, provide
 
@@ -42,7 +43,8 @@ from shvatka.core.notifications.request_interactors import (
     CancelRequestInteractor,
     ListRequestsInteractor,
 )
-from shvatka.core.notifications.adapters import RequestStorage, NotificationWriter
+from shvatka.core.notifications.adapters import RequestNotifier, RequestStorage, NotificationWriter
+from shvatka.tgbot.views.action_request import BotRequestNotifier
 from shvatka.core.players.interactors import (
     GetPlayerInteractor,
     GetPlayerStatInteractor,
@@ -152,6 +154,18 @@ class ContextProvider(Provider):
     scope = Scope.REQUEST
     current_game = provide(CurrentGameProviderImpl, provides=CurrentGameProvider)
     bus = provide(InMemoryBus, provides=Bus)
+
+    @provide
+    def request_notifier(
+        self, bot: Bot, dao: HolderDao, requests: RequestStorage
+    ) -> RequestNotifier:
+        return BotRequestNotifier(
+            bot=bot,
+            requests=requests,
+            player_dao=dao.player,
+            team_dao=dao.team,
+            team_players_dao=dao.team_player,
+        )
 
 
 class GamePlayProvider(Provider):
@@ -450,7 +464,11 @@ class RequestProvider(Provider):
 
     @provide
     def create_team_join_invite(
-        self, dao: HolderDao, requests: RequestStorage, notifications: NotificationWriter
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        notifier: RequestNotifier,
     ) -> CreateTeamJoinInviteInteractor:
         return CreateTeamJoinInviteInteractor(
             requests=requests,
@@ -458,28 +476,39 @@ class RequestProvider(Provider):
             team_dao=dao.team,
             player_dao=dao.player,
             team_player_dao=dao.team_player,
+            notifier=notifier,
         )
 
     @provide
     def create_team_join_request(
-        self, dao: HolderDao, requests: RequestStorage, notifications: NotificationWriter
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        notifier: RequestNotifier,
     ) -> CreateTeamJoinRequestInteractor:
         return CreateTeamJoinRequestInteractor(
             requests=requests,
             notifications=notifications,
             team_dao=dao.team,
             team_players_dao=dao.team_player,
+            notifier=notifier,
         )
 
     @provide
     def create_org_invite(
-        self, dao: HolderDao, requests: RequestStorage, notifications: NotificationWriter
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        notifier: RequestNotifier,
     ) -> CreateOrgInviteInteractor:
         return CreateOrgInviteInteractor(
             requests=requests,
             notifications=notifications,
             player_dao=dao.player,
             org_adder=dao.org_adder,
+            notifier=notifier,
         )
 
     @provide
@@ -490,6 +519,7 @@ class RequestProvider(Provider):
         notifications: NotificationWriter,
         team_notifier: TeamNotifier,
         org_notifier: OrgNotifier,
+        bus: Bus,
     ) -> AcceptRequestInteractor:
         return AcceptRequestInteractor(
             requests=requests,
@@ -501,22 +531,24 @@ class RequestProvider(Provider):
             org_adder=dao.org_adder,
             team_notifier=team_notifier,
             org_notifier=org_notifier,
+            bus=bus,
         )
 
     @provide
     def decline_request(
-        self, dao: HolderDao, requests: RequestStorage, notifications: NotificationWriter
+        self, dao: HolderDao, requests: RequestStorage, notifications: NotificationWriter, bus: Bus
     ) -> DeclineRequestInteractor:
         return DeclineRequestInteractor(
             requests=requests,
             notifications=notifications,
             team_dao=dao.team,
             team_player_dao=dao.team_player,
+            bus=bus,
         )
 
     @provide
-    def cancel_request(self, requests: RequestStorage) -> CancelRequestInteractor:
-        return CancelRequestInteractor(requests=requests)
+    def cancel_request(self, requests: RequestStorage, bus: Bus) -> CancelRequestInteractor:
+        return CancelRequestInteractor(requests=requests, bus=bus)
 
     @provide
     def list_requests(self, requests: RequestStorage) -> ListRequestsInteractor:

--- a/shvatka/tgbot/handlers/__init__.py
+++ b/shvatka/tgbot/handlers/__init__.py
@@ -17,6 +17,7 @@ from shvatka.tgbot.handlers import (
     superuser,
     base,
     team,
+    action_request,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ def setup_handlers(
     dp.include_router(superuser.setup(bot_config))
     dp.include_router(player.setup())
     dp.include_router(team.setup())
+    dp.include_router(action_request.setup())
     dp.include_router(merge.setup(bot_config))
     dp.include_router(game.setup())
     dp.include_router(waivers.setup())

--- a/shvatka/tgbot/handlers/action_request.py
+++ b/shvatka/tgbot/handlers/action_request.py
@@ -1,0 +1,41 @@
+from aiogram import Router, F, Bot
+from aiogram.types import CallbackQuery
+from dishka.integrations.aiogram import FromDishka, inject
+
+from shvatka.core.notifications.request_interactors import (
+    AcceptRequestInteractor,
+    DeclineRequestInteractor,
+)
+from shvatka.tgbot.keyboards.action_request import ActionRequestCD
+from shvatka.tgbot.services.identity import TgBotIdentityProvider
+from shvatka.tgbot.views.utils import total_remove_msg
+
+
+@inject
+async def resolve_action_request(
+    callback: CallbackQuery,
+    callback_data: ActionRequestCD,
+    identity: FromDishka[TgBotIdentityProvider],
+    accept_interactor: FromDishka[AcceptRequestInteractor],
+    decline_interactor: FromDishka[DeclineRequestInteractor],
+    bot: FromDishka[Bot],
+) -> None:
+    if callback_data.accept:
+        await accept_interactor(identity=identity, request_id=callback_data.request_id)
+        text = "Запрос принят"
+    else:
+        await decline_interactor(identity=identity, request_id=callback_data.request_id)
+        text = "Запрос отклонён"
+    if callback.message is not None:
+        await total_remove_msg(
+            bot, chat_id=callback.message.chat.id, msg_id=callback.message.message_id
+        )
+    await callback.answer(text)
+
+
+def setup() -> Router:
+    router = Router(name=__name__)
+    router.callback_query.register(
+        resolve_action_request, ActionRequestCD.filter(F.accept.in_({True, False}))
+    )
+    return router

--- a/shvatka/tgbot/keyboards/action_request.py
+++ b/shvatka/tgbot/keyboards/action_request.py
@@ -1,0 +1,20 @@
+from aiogram.filters.callback_data import CallbackData
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+class ActionRequestCD(CallbackData, prefix="act_req"):
+    request_id: int
+    accept: bool
+
+
+def get_action_request_kb(request_id: int) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(
+        text="Принять", callback_data=ActionRequestCD(request_id=request_id, accept=True)
+    )
+    builder.button(
+        text="Отклонить", callback_data=ActionRequestCD(request_id=request_id, accept=False)
+    )
+    builder.adjust(2)
+    return builder.as_markup()

--- a/shvatka/tgbot/main_factory.py
+++ b/shvatka/tgbot/main_factory.py
@@ -29,7 +29,10 @@ from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.views.game import GameLogWriter, GameView, GameViewPreparer, OrgNotifier
 from shvatka.core.views.level import LevelView
 from shvatka.core.views.team import TeamNotifier
-from shvatka.infrastructure.bus.in_memory import UsedOneTimeTokenInteractor
+from shvatka.infrastructure.bus.in_memory import (
+    UsedOneTimeTokenInteractor,
+    ActionResolvedInteractor,
+)
 from shvatka.infrastructure.db.config.models.storage import StorageConfig, StorageType
 from shvatka.infrastructure.db.dao import FileInfoDao
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -41,6 +44,7 @@ from shvatka.infrastructure.picture import ResultsPainter
 from shvatka.tgbot.config.models.bot import BotConfig, TgClientConfig
 from shvatka.tgbot.handlers import setup_handlers
 from shvatka.tgbot.middlewares import setup_middlewares
+from shvatka.tgbot.services.action_requests import ActionResolvedInteractorImpl
 from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.services.used_one_time_token import UsedOneTimeTokenInteractorImpl
 from shvatka.tgbot.username_resolver.user_getter import UserGetter
@@ -155,6 +159,9 @@ class DpProvider(Provider):
 
     used_one_time_token_interactor = provide(
         UsedOneTimeTokenInteractorImpl, provides=UsedOneTimeTokenInteractor, scope=Scope.REQUEST
+    )
+    action_request_interactor = provide(
+        ActionResolvedInteractorImpl, provides=ActionResolvedInteractor, scope=Scope.REQUEST
     )
 
 

--- a/shvatka/tgbot/services/action_requests.py
+++ b/shvatka/tgbot/services/action_requests.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+from aiogram import Bot
+
+from shvatka.core.notifications.adapters import RequestStorage
+from shvatka.infrastructure.bus.in_memory import ActionResolvedInteractor
+from shvatka.tgbot.views.utils import total_remove_msg
+
+
+@dataclass
+class ActionResolvedInteractorImpl(ActionResolvedInteractor):
+    bot: Bot
+    requests: RequestStorage
+
+    async def __call__(self, request_id: int) -> None:
+        bot_messages = await self.requests.get_bot_messages(request_id)
+        for chat_id, message_id in bot_messages:
+            await total_remove_msg(
+                self.bot,
+                chat_id=chat_id,
+                msg_id=message_id,
+            )

--- a/shvatka/tgbot/views/action_request.py
+++ b/shvatka/tgbot/views/action_request.py
@@ -1,0 +1,75 @@
+import logging
+from dataclasses import dataclass
+
+from aiogram import Bot
+from aiogram.exceptions import AiogramError
+
+from shvatka.core.models.enums.request import RequestType
+from shvatka.core.notifications import dto as ndto
+from shvatka.core.notifications.adapters import RequestNotifier, RequestStorage
+from shvatka.core.interfaces.dal.player import PlayerByIdGetter, TeamPlayersGetter
+from shvatka.core.interfaces.dal.team import TeamByIdGetter
+from shvatka.tgbot.keyboards.action_request import get_action_request_kb
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BotRequestNotifier(RequestNotifier):
+    bot: Bot
+    requests: RequestStorage
+    player_dao: PlayerByIdGetter
+    team_dao: TeamByIdGetter
+    team_players_dao: TeamPlayersGetter
+
+    async def notify_created(self, request: ndto.ActionRequest) -> None:
+        for player_id in await self._recipient_ids(request):
+            player = await self.player_dao.get_by_id(player_id)
+            chat_id = player.get_chat_id()
+            if chat_id is None:
+                continue
+            try:
+                message = await self.bot.send_message(
+                    chat_id=chat_id,
+                    text=self._render(request),
+                    reply_markup=get_action_request_kb(request.id),
+                    disable_notification=False,
+                )
+            except AiogramError as e:
+                logger.warning(
+                    "failed to send action request %s to %s", request.id, chat_id, exc_info=e
+                )
+                continue
+            await self.requests.add_bot_message(
+                request.id, chat_id=message.chat.id, message_id=message.message_id
+            )
+
+    async def _recipient_ids(self, request: ndto.ActionRequest) -> set[int]:
+        if request.target_player_id is not None:
+            return {request.target_player_id}
+        if request.type == RequestType.team_join_request and request.team_id is not None:
+            # A join request is answerable by every manager, so bot delivery fans out to all
+            # managers and stores every message for web-side cleanup.
+            team = await self.team_dao.get_by_id(request.team_id)
+            players = await self.team_players_dao.get_players(team)
+            return {tp.player.id for tp in players if tp.is_captain or tp.can_add_players}
+        return set()
+
+    def _render(self, request: ndto.ActionRequest) -> str:
+        payload = request.payload
+        match request.type:
+            case RequestType.team_join_invite:
+                return (
+                    f"{payload.get('inviter_name', 'Игрок')} приглашает вас в команду "
+                    f"{payload.get('team_name', '')}."
+                )
+            case RequestType.team_join_request:
+                return (
+                    f"{payload.get('player_name', 'Игрок')} просит принять его в команду "
+                    f"{payload.get('team_name', '')}."
+                )
+            case RequestType.org_invite:
+                author_name = payload.get("author_name", "Автор")
+                game_name = payload.get("game_name", "")
+                return f"{author_name} приглашает вас стать организатором игры {game_name}."
+        return "Новый запрос"

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -85,6 +86,7 @@ async def test_game_card(
     ]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Does not run on Windows")
 @pytest.mark.asyncio
 async def test_game_file(
     finished_game: dto.FullGame,
@@ -186,6 +188,7 @@ async def test_game_file_uploaded_not_referenced(
     assert resp.is_success, resp.text
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Does not run on Windows")
 @pytest.mark.asyncio
 async def test_game_file_view_scenario_org(
     game: dto.FullGame,

--- a/tests/integration/api_full/test_notifications.py
+++ b/tests/integration/api_full/test_notifications.py
@@ -4,15 +4,15 @@ from unittest.mock import MagicMock
 
 import pytest
 from aiogram.client.session.base import BaseSession
-from aiogram.types import Message, Chat
+from aiogram.types import Message
 from httpx import AsyncClient
 
 from shvatka.api.dependencies.auth import AuthProperties
 from shvatka.api.models.auth import Token
 from shvatka.core.models import dto
-from shvatka.core.models.dto import chat
+from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from tests.fixtures.chat_constants import chat_to_full_chat, create_tg_chat
+from tests.fixtures.chat_constants import create_tg_chat
 
 
 def auth_cookies(token: Token) -> dict[str, str]:
@@ -110,7 +110,7 @@ async def test_team_join_invite_and_accept(
 ):
     session = typing.cast(MagicMock, bot_session)
     session.side_effect = [
-        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
     ]
     invite = await client.post(
         "/requests/team-join-invite",
@@ -167,7 +167,7 @@ async def test_team_join_invite_accept_forbidden_for_stranger(
 ):
     session = typing.cast(MagicMock, bot_session)
     session.side_effect = [
-        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
     ]
     invite = await client.post(
         "/requests/team-join-invite",
@@ -200,7 +200,7 @@ async def test_join_request_and_accept_by_captain(
 ):
     session = typing.cast(MagicMock, bot_session)
     session.side_effect = [
-        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
     ]
     ask = await client.post(
         "/requests/team-join",
@@ -234,7 +234,7 @@ async def test_cancel_own_invite(
 ):
     session = typing.cast(MagicMock, bot_session)
     session.side_effect = [
-        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
     ]
     invite = await client.post(
         "/requests/team-join-invite",

--- a/tests/integration/api_full/test_notifications.py
+++ b/tests/integration/api_full/test_notifications.py
@@ -1,10 +1,18 @@
+import typing
+from datetime import datetime
+from unittest.mock import MagicMock
+
 import pytest
+from aiogram.client.session.base import BaseSession
+from aiogram.types import Message, Chat
 from httpx import AsyncClient
 
 from shvatka.api.dependencies.auth import AuthProperties
 from shvatka.api.models.auth import Token
 from shvatka.core.models import dto
+from shvatka.core.models.dto import chat
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from tests.fixtures.chat_constants import chat_to_full_chat, create_tg_chat
 
 
 def auth_cookies(token: Token) -> dict[str, str]:
@@ -98,7 +106,12 @@ async def test_team_join_invite_and_accept(
     harry_token: Token,
     hermione_token: Token,
     check_dao: HolderDao,
+    bot_session: BaseSession,
 ):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+    ]
     invite = await client.post(
         "/requests/team-join-invite",
         cookies=auth_cookies(harry_token),
@@ -150,7 +163,12 @@ async def test_team_join_invite_accept_forbidden_for_stranger(
     gryffindor: dto.Team,
     harry_token: Token,
     auth: AuthProperties,
+    bot_session: BaseSession,
 ):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+    ]
     invite = await client.post(
         "/requests/team-join-invite",
         cookies=auth_cookies(harry_token),
@@ -178,7 +196,12 @@ async def test_join_request_and_accept_by_captain(
     harry_token: Token,
     hermione_token: Token,
     check_dao: HolderDao,
+    bot_session: BaseSession,
 ):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+    ]
     ask = await client.post(
         "/requests/team-join",
         cookies=auth_cookies(hermione_token),
@@ -207,7 +230,12 @@ async def test_cancel_own_invite(
     hermione: dto.Player,
     gryffindor: dto.Team,
     harry_token: Token,
+    bot_session: BaseSession,
 ):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now()),
+    ]
     invite = await client.post(
         "/requests/team-join-invite",
         cookies=auth_cookies(harry_token),

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, UTC
+from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +15,7 @@ from shvatka.core.notifications.request_interactors import (
     DeclineRequestInteractor,
     AcceptRequestInteractor,
 )
+from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.exceptions import RequestNotPending, RequestPermissionError
 
 
@@ -58,7 +59,7 @@ class FakeRequests:
             type=kwargs["type_"],
             status=RequestStatus.pending,
             initiator_id=kwargs["initiator_id"],
-            created_at=datetime.now(tz=UTC),
+            created_at=datetime.now(tz=tz_utc),
             payload=kwargs.get("payload") or {},
             target_player_id=kwargs.get("target_player_id"),
             team_id=kwargs.get("team_id"),
@@ -185,7 +186,7 @@ async def test_create_team_join_invite_is_idempotent() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.pending,
         initiator_id=1,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     requests.pending = existing
     notifications = FakeNotifications()
@@ -237,7 +238,7 @@ async def test_cancel_only_by_initiator() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.pending,
         initiator_id=1,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     interactor = CancelRequestInteractor(requests=requests, bus=FakeBus())
     with pytest.raises(RequestPermissionError):
@@ -254,7 +255,7 @@ async def test_cancel_rejects_non_pending() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.accepted,
         initiator_id=1,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     with pytest.raises(RequestNotPending):
         await CancelRequestInteractor(requests=requests, bus=FakeBus())(
@@ -272,7 +273,7 @@ async def test_decline_invite_notifies_initiator() -> None:
         status=RequestStatus.pending,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     notifications = FakeNotifications()
     interactor = DeclineRequestInteractor(
@@ -296,7 +297,7 @@ async def test_decline_invite_wrong_actor_forbidden() -> None:
         status=RequestStatus.pending,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     interactor = DeclineRequestInteractor(
         requests=requests,
@@ -318,7 +319,7 @@ async def test_accept_rejects_non_pending() -> None:
         status=RequestStatus.cancelled,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     interactor = AcceptRequestInteractor(
         requests=requests,
@@ -346,7 +347,7 @@ async def test_accept_invite_wrong_actor_forbidden() -> None:
         initiator_id=1,
         target_player_id=2,
         team_id=1,
-        created_at=datetime.now(tz=UTC),
+        created_at=datetime.now(tz=tz_utc),
     )
     interactor = AcceptRequestInteractor(
         requests=requests,

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from types import SimpleNamespace
 
 import pytest
@@ -58,7 +58,7 @@ class FakeRequests:
             type=kwargs["type_"],
             status=RequestStatus.pending,
             initiator_id=kwargs["initiator_id"],
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=datetime.now(tz=UTC),
             payload=kwargs.get("payload") or {},
             target_player_id=kwargs.get("target_player_id"),
             team_id=kwargs.get("team_id"),
@@ -82,6 +82,29 @@ class FakeRequests:
 
     async def commit(self) -> None:
         self.commits += 1
+
+    async def add_bot_message(
+        self, request_id: int, *, chat_id: int, message_id: int
+    ) -> ndto.ActionRequest:
+        request = self.rows[request_id]
+        request.bot_messages.append({"chat_id": chat_id, "message_id": message_id})
+        return request
+
+
+class FakeNotifier:
+    def __init__(self) -> None:
+        self.created: list[ndto.ActionRequest] = []
+
+    async def notify_created(self, request: ndto.ActionRequest) -> None:
+        self.created.append(request)
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    async def submit(self, event: object) -> None:
+        self.events.append(event)
 
 
 class FakeNotifications:
@@ -141,6 +164,7 @@ async def test_create_team_join_invite() -> None:
         team_dao=FakeTeamDao(team),
         player_dao=FakePlayerDao({2: target}),
         team_player_dao=SimpleNamespace(),
+        notifier=FakeNotifier(),
     )
     request = await interactor(FakeIdentity(cap), team_id=1, player_id=2, role="chaser")
     assert request.type == RequestType.team_join_invite
@@ -161,7 +185,7 @@ async def test_create_team_join_invite_is_idempotent() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.pending,
         initiator_id=1,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     requests.pending = existing
     notifications = FakeNotifications()
@@ -171,6 +195,7 @@ async def test_create_team_join_invite_is_idempotent() -> None:
         team_dao=FakeTeamDao(team),
         player_dao=FakePlayerDao({2: target}),
         team_player_dao=SimpleNamespace(),
+        notifier=FakeNotifier(),
     )
     request = await interactor(FakeIdentity(cap), team_id=1, player_id=2)
     assert request.id == 99
@@ -197,6 +222,7 @@ async def test_create_team_join_request_notifies_managers_only() -> None:
         notifications=notifications,
         team_dao=FakeTeamDao(team),
         team_players_dao=FakeTeamPlayersDao(members),
+        notifier=FakeNotifier(),
     )
     request = await interactor(FakeIdentity(asker), team_id=1)
     assert request.type == RequestType.team_join_request
@@ -211,9 +237,9 @@ async def test_cancel_only_by_initiator() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.pending,
         initiator_id=1,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
-    interactor = CancelRequestInteractor(requests=requests)
+    interactor = CancelRequestInteractor(requests=requests, bus=FakeBus())
     with pytest.raises(RequestPermissionError):
         await interactor(FakeIdentity(_player(2)), request_id=1)
     updated = await interactor(FakeIdentity(_player(1)), request_id=1)
@@ -228,10 +254,12 @@ async def test_cancel_rejects_non_pending() -> None:
         type=RequestType.team_join_invite,
         status=RequestStatus.accepted,
         initiator_id=1,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     with pytest.raises(RequestNotPending):
-        await CancelRequestInteractor(requests=requests)(FakeIdentity(_player(1)), request_id=1)
+        await CancelRequestInteractor(requests=requests, bus=FakeBus())(
+            FakeIdentity(_player(1)), request_id=1
+        )
 
 
 @pytest.mark.asyncio
@@ -244,7 +272,7 @@ async def test_decline_invite_notifies_initiator() -> None:
         status=RequestStatus.pending,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     notifications = FakeNotifications()
     interactor = DeclineRequestInteractor(
@@ -252,6 +280,7 @@ async def test_decline_invite_notifies_initiator() -> None:
         notifications=notifications,
         team_dao=SimpleNamespace(),
         team_player_dao=SimpleNamespace(),
+        bus=FakeBus(),
     )
     updated = await interactor(FakeIdentity(target), request_id=1)
     assert updated.status == RequestStatus.declined
@@ -267,13 +296,14 @@ async def test_decline_invite_wrong_actor_forbidden() -> None:
         status=RequestStatus.pending,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     interactor = DeclineRequestInteractor(
         requests=requests,
         notifications=FakeNotifications(),
         team_dao=SimpleNamespace(),
         team_player_dao=SimpleNamespace(),
+        bus=FakeBus(),
     )
     with pytest.raises(RequestPermissionError):
         await interactor(FakeIdentity(_player(7)), request_id=1)
@@ -288,7 +318,7 @@ async def test_accept_rejects_non_pending() -> None:
         status=RequestStatus.cancelled,
         initiator_id=1,
         target_player_id=2,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     interactor = AcceptRequestInteractor(
         requests=requests,
@@ -300,6 +330,7 @@ async def test_accept_rejects_non_pending() -> None:
         org_adder=SimpleNamespace(),
         team_notifier=SimpleNamespace(),
         org_notifier=SimpleNamespace(),
+        bus=FakeBus(),
     )
     with pytest.raises(RequestNotPending):
         await interactor(FakeIdentity(_player(2)), request_id=1)
@@ -315,7 +346,7 @@ async def test_accept_invite_wrong_actor_forbidden() -> None:
         initiator_id=1,
         target_player_id=2,
         team_id=1,
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
     )
     interactor = AcceptRequestInteractor(
         requests=requests,
@@ -327,6 +358,7 @@ async def test_accept_invite_wrong_actor_forbidden() -> None:
         org_adder=SimpleNamespace(),
         team_notifier=SimpleNamespace(),
         org_notifier=SimpleNamespace(),
+        bus=FakeBus(),
     )
     with pytest.raises(RequestPermissionError):
         await interactor(FakeIdentity(_player(7)), request_id=1)

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -84,9 +84,7 @@ class FakeRequests:
     async def commit(self) -> None:
         self.commits += 1
 
-    async def add_bot_message(
-        self, request_id: int, *, chat_id: int, message_id: int
-    ) -> ndto.ActionRequest:
+    async def add_bot_message(self, request_id: int, *, chat_id: int, message_id: int) -> None:
         pass
 
 

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -87,9 +87,7 @@ class FakeRequests:
     async def add_bot_message(
         self, request_id: int, *, chat_id: int, message_id: int
     ) -> ndto.ActionRequest:
-        request = self.rows[request_id]
-        request.bot_messages.append({"chat_id": chat_id, "message_id": message_id})
-        return request
+        pass
 
 
 class FakeNotifier:


### PR DESCRIPTION
### Motivation
- Deliver actionable `action_requests` to users via Telegram in addition to persisting web `notifications` so invite/requests are visible and actionable in the bot (§9/Phase 2 gap). 
- Ensure web/API resolution (accept/decline/cancel) cleans up corresponding bot messages by recording sent message references and emitting a bus event. 
- Keep request lifecycle and delivery idempotent and best-effort: persist requests, push web notifications, then fan-out bot DMs and record message ids.

### Description
- Added a `RequestNotifier` Protocol and implemented `BotRequestNotifier` that sends Telegram DMs with inline Accept/Decline buttons and records every sent bot message for the request. (`shvatka/tgbot/views/action_request.py`, `shvatka/tgbot/keyboards/action_request.py`)
- Persisted bot message references on `action_requests` as `bot_messages` (JSON array) in the DB and added DAO method to append entries; added an Alembic migration for the new column. (`shvatka/infrastructure/db/models/action_request.py`, `shvatka/infrastructure/db/dao/rdb/action_request.py`, `shvatka/infrastructure/db/migrations/versions/20260709-120000_a1b2c3d4e5f6_add_action_request_bot_message.py`)
- Emit `ActionRequestResolved` bus event (with recorded bot message refs) when a request is accepted/declined/cancelled, and make the in-memory `Bus` handler delete those Telegram messages using the existing `total_remove_msg` helper. (`shvatka/core/interfaces/bus.py`, `shvatka/infrastructure/bus/in_memory.py`, `shvatka/core/notifications/request_interactors.py`)
- Reused existing accept/decline `Interactor`s from bot callbacks so the bot and web/API share the same business logic; added a bot callback handler that calls those interactors and removes the clicked message. (`shvatka/tgbot/handlers/action_request.py`)
- Wired the new notifier and bus dependencies through DI so API and bot deployments provide appropriate `RequestNotifier` and `Bus` instances; updated request interactor constructors to accept `notifier`/`bus`. (`shvatka/infrastructure/di/interactors.py`, `shvatka/core/notifications/request_interactors.py`)
- Updated unit-test fakes and tests for request interactors to cover the new notifier/bus/storage behavior. (`tests/unit/services/request_interactors_test.py`)

### Testing
- Lint/format checks: ran `ruff format` and `ruff check` across modified files and fixed issues; checks passed for the changed modules.
- Static/compile smoke: ran `python -m py_compile` over the changed modules and test file and it succeeded (no syntax errors).
- Unit tests: attempted `pytest tests/unit -q` locally but run was blocked by missing local `pytest_asyncio` in the environment (so full unit test run was not completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fe3b89864832a80fe0b370291cd31)