### PR TITLE
Merge proposals as action requests: resolvable from web admin panel and bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,5 +267,16 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   you choose the log level.
 - Some docstrings/comments are in Russian — that's expected; keep the existing
   language of the file you're editing.
+- **In aiogram / aiogram_dialog handlers, take dependencies from DI**
+  (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
+  into `manager.middleware_data` / event middleware data. That includes
+  `dao: FromDishka[HolderDao]`.
+- **Superuser rights resolve through `SuperusersResolver`**
+  (`core/interfaces/superusers.py`) — the single source for who the configured
+  admins are. `IdentityProvider` derives `get_superuser` / `is_superuser` from
+  one `_get_optional_superuser` hook; per-edge providers override only that hook.
+  Don't re-read `config.superusers` at a new call site.
+- **Log admin/superuser actions with the acting admin's id** so there's an
+  audit trail, e.g. `logger.warning("admin %s accepted merge request %s", admin.id, request.id)`.
 </content>
 </invoke>

--- a/shvatka/api/dependencies/auth.py
+++ b/shvatka/api/dependencies/auth.py
@@ -14,11 +14,11 @@ from starlette import status
 from starlette.requests import Request
 
 from shvatka.api.config.models.auth import AuthConfig
-from shvatka.api.config.models.main import ApiConfig
 from shvatka.api.models.auth import UserTgAuth, Token
 from shvatka.api.utils.cookie_auth import OAuth2PasswordBearerWithCookie
 from shvatka.core.interfaces.hasher import PasswordHasher
 from shvatka.core.interfaces.identity import IdentityProvider
+from shvatka.core.interfaces.superusers import SuperusersResolver
 from shvatka.core.models import dto
 from shvatka.core.players.player import (
     get_my_team,
@@ -177,29 +177,24 @@ class ApiIdentityProvider(IdentityProvider):
         cookie_auth: OAuth2PasswordBearerWithCookie,
         auth_properties: AuthProperties,
         dao: HolderDao,
-        config: ApiConfig,
+        superusers: SuperusersResolver,
     ):
         self.request = request
         self.cookie_auth = cookie_auth
         self.auth_properties = auth_properties
         self.dao = dao
-        self.config = config
+        self.superusers = superusers
         self.cache = LoadedData()
         self.cache["organizer"] = {}
 
-    async def get_superuser(self) -> dto.Player:
-        player = await self.get_required_player()
+    async def _get_optional_superuser(self) -> dto.Player | None:
+        player = await self.get_player()
+        if player is None:
+            return None
         user = await self.get_user()
-        if user is None or user.tg_id not in self.config.superusers:
-            logger.warning("player %s tried to use admin panel without rights", player.id)
-            raise exceptions.NotAuthorizedForAdmin(player=player, user=user)
+        if user is None or not self.superusers.is_superuser(user):
+            return None
         return player
-
-    async def is_superuser(self) -> bool:
-        if await self.get_player() is None:
-            return False
-        user = await self.get_user()
-        return user is not None and user.tg_id in self.config.superusers
 
     async def get_user(self) -> dto.User | None:
         if "user" in self.cache:

--- a/shvatka/api/dependencies/auth.py
+++ b/shvatka/api/dependencies/auth.py
@@ -195,6 +195,12 @@ class ApiIdentityProvider(IdentityProvider):
             raise exceptions.NotAuthorizedForAdmin(player=player, user=user)
         return player
 
+    async def is_superuser(self) -> bool:
+        if await self.get_player() is None:
+            return False
+        user = await self.get_user()
+        return user is not None and user.tg_id in self.config.superusers
+
     async def get_user(self) -> dto.User | None:
         if "user" in self.cache:
             return self.cache["user"]

--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -142,6 +142,18 @@ class MergePlayersRequest(MergeRequest):
         return [item.to_core() for item in self.timeline]
 
 
+@dataclass
+class AcceptRequest:
+    timeline: list[TimelineItem] | None = None
+    """only for player merge requests: manually built team history replacing
+    both players' histories when they are not compatible."""
+
+    def core_timeline(self) -> list[CoreTimelineItem] | None:
+        if self.timeline is None:
+            return None
+        return [item.to_core() for item in self.timeline]
+
+
 @dataclass(frozen=True, slots=True)
 class PushKeys:
     p256dh: str

--- a/shvatka/api/routes/requests.py
+++ b/shvatka/api/routes/requests.py
@@ -57,8 +57,14 @@ async def accept_request(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[AcceptRequestInteractor],
     id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.AcceptRequest | None, Body()] = None,
 ) -> responses.ActionRequest:
-    return responses.ActionRequest.from_core(await interactor(identity=identity, request_id=id_))
+    request = await interactor(
+        identity=identity,
+        request_id=id_,
+        timeline=body.core_timeline() if body is not None else None,
+    )
+    return responses.ActionRequest.from_core(request)
 
 
 @inject

--- a/shvatka/core/interfaces/identity.py
+++ b/shvatka/core/interfaces/identity.py
@@ -34,6 +34,14 @@ class IdentityProvider(Protocol):
         """
         raise exceptions.NotAuthorizedForAdmin(player=await self.get_player())
 
+    async def is_superuser(self) -> bool:
+        """Quiet check of admin rights: no logging, no exceptions.
+
+        By default nobody is a superuser; edges that expose the admin panel
+        override this consistently with :meth:`get_superuser`.
+        """
+        return False
+
     async def get_required_user(self) -> dto.User:
         user = await self.get_user()
         if user is None:

--- a/shvatka/core/interfaces/identity.py
+++ b/shvatka/core/interfaces/identity.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Protocol
 
 
 from shvatka.core.models import dto
 from shvatka.core.utils import exceptions
+
+logger = logging.getLogger(__name__)
 
 
 class IdentityProvider(Protocol):
@@ -24,23 +27,35 @@ class IdentityProvider(Protocol):
     async def get_org(self, game: dto.Game) -> dto.Organizer | None:
         raise NotImplementedError
 
+    async def _get_optional_superuser(self) -> dto.Player | None:
+        """Return the acting player if they may use the admin panel, else ``None``.
+
+        This is the single per-edge hook for admin rights: edges that expose the
+        admin panel override it (checking the player against the configured
+        superusers); everything else derives from it. By default nobody is a
+        superuser.
+        """
+        return None
+
     async def get_superuser(self) -> dto.Player:
         """Resolve the acting player and ensure they may use the admin panel.
 
-        By default nobody is a superuser; edges that expose the admin panel
-        override this to check the player against the configured superusers, log
-        the attempt, and return the player. Non-superusers always raise
-        :class:`exceptions.NotAuthorizedForAdmin`.
+        Non-superusers always raise :class:`exceptions.NotAuthorizedForAdmin`;
+        the attempt is logged.
         """
-        raise exceptions.NotAuthorizedForAdmin(player=await self.get_player())
+        player = await self._get_optional_superuser()
+        if player is None:
+            actor = await self.get_player()
+            logger.warning(
+                "player %s tried to use admin panel without rights",
+                actor.id if actor is not None else None,
+            )
+            raise exceptions.NotAuthorizedForAdmin(player=actor, user=await self.get_user())
+        return player
 
     async def is_superuser(self) -> bool:
-        """Quiet check of admin rights: no logging, no exceptions.
-
-        By default nobody is a superuser; edges that expose the admin panel
-        override this consistently with :meth:`get_superuser`.
-        """
-        return False
+        """Quiet check of admin rights: no logging, no exceptions."""
+        return await self._get_optional_superuser() is not None
 
     async def get_required_user(self) -> dto.User:
         user = await self.get_user()

--- a/shvatka/core/interfaces/superusers.py
+++ b/shvatka/core/interfaces/superusers.py
@@ -1,0 +1,21 @@
+from typing import Protocol
+
+from shvatka.core.models import dto
+
+
+class SuperusersResolver(Protocol):
+    """Single source of truth for who the configured superusers (admins) are.
+
+    Exposes the same set of superusers as tg ids, as player ids, and as a
+    membership check, so every edge (api auth, bot, notifications) resolves
+    admin rights the same way instead of re-reading the config on its own.
+    """
+
+    def is_superuser(self, user: dto.User) -> bool:
+        raise NotImplementedError
+
+    async def get_superuser_user_ids(self) -> set[int]:
+        raise NotImplementedError
+
+    async def get_superuser_player_ids(self) -> set[int]:
+        raise NotImplementedError

--- a/shvatka/core/models/enums/notification.py
+++ b/shvatka/core/models/enums/notification.py
@@ -13,6 +13,8 @@ class NotificationType(enum.Enum):
     team_join_invite = enum.auto()
     team_join_request = enum.auto()
     org_invite = enum.auto()
+    team_merge_request = enum.auto()
+    player_merge_request = enum.auto()
     request_accepted = enum.auto()
     request_declined = enum.auto()
 

--- a/shvatka/core/models/enums/request.py
+++ b/shvatka/core/models/enums/request.py
@@ -10,6 +10,10 @@ class RequestType(enum.Enum):
     """A player asks to join a team; answered by any authorized team member."""
     org_invite = enum.auto()
     """A game author invites a player to become an organizer."""
+    team_merge = enum.auto()
+    """A captain asks admins to merge their team with its forum copy."""
+    player_merge = enum.auto()
+    """A player asks admins to merge their achievements with a forum copy."""
 
 
 class RequestStatus(enum.Enum):

--- a/shvatka/core/notifications/adapters.py
+++ b/shvatka/core/notifications/adapters.py
@@ -64,13 +64,6 @@ class RequestNotifier(Protocol):
         raise NotImplementedError
 
 
-class SuperusersResolver(Protocol):
-    """Resolves the configured superusers (admins) to their player ids."""
-
-    async def get_superuser_player_ids(self) -> set[int]:
-        raise NotImplementedError
-
-
 class RequestStorage(Committer, Protocol):
     async def create(
         self,

--- a/shvatka/core/notifications/adapters.py
+++ b/shvatka/core/notifications/adapters.py
@@ -64,6 +64,13 @@ class RequestNotifier(Protocol):
         raise NotImplementedError
 
 
+class SuperusersResolver(Protocol):
+    """Resolves the configured superusers (admins) to their player ids."""
+
+    async def get_superuser_player_ids(self) -> set[int]:
+        raise NotImplementedError
+
+
 class RequestStorage(Committer, Protocol):
     async def create(
         self,
@@ -112,6 +119,11 @@ class RequestStorage(Committer, Protocol):
         raise NotImplementedError
 
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
+        raise NotImplementedError
+
+    async def get_pending_by_types(
+        self, types: Collection[RequestType]
+    ) -> Sequence[dto.ActionRequest]:
         raise NotImplementedError
 
     async def add_bot_message(self, request_id: int, *, chat_id: int, message_id: int) -> None:

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -1,16 +1,24 @@
 """Interactors for user-to-user action requests: team-join invites, ask-to-join
-requests and org invites, plus accept / decline / cancel and listing.
+requests, org invites and merge requests, plus accept / decline / cancel and
+listing.
 
 Creating a request is the primary business operation (errors surface). Accepting
 one that performs a real change reuses the existing domain services
-(:func:`join_team`, org adding) so the membership change and the request
-resolution commit together.
+(:func:`join_team`, org adding, :func:`merge_teams`, :func:`merge_players`) so
+the change and the request resolution commit together.
+
+Merge requests (team/player with their forum copies) target no particular
+player: they are answered by any superuser, either from the web admin panel or
+from the game-log channel message the bot posts. Resolving one emits
+:class:`ActionRequestResolved` so every bot message for the request is removed,
+and the merge itself writes the usual game-log entry.
 """
 
 import contextlib
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from shvatka.core.interfaces.dal.complex import TeamMerger
 from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
@@ -25,19 +33,27 @@ from shvatka.core.models.enums.notification import NotificationType, Notificatio
 from shvatka.core.models.enums.request import RequestType, RequestStatus
 from shvatka.core.notifications import dto as ndto
 from shvatka.core.interfaces.bus import ActionRequestResolved, Bus
-from shvatka.core.notifications.adapters import NotificationWriter, RequestNotifier, RequestStorage
-from shvatka.core.players.player import check_can_add_players, join_team
+from shvatka.core.notifications.adapters import (
+    NotificationWriter,
+    RequestNotifier,
+    RequestStorage,
+    SuperusersResolver,
+)
+from shvatka.core.players.interfaces import PlayerMerger
+from shvatka.core.players.player import check_can_add_players, join_team, merge_players
 from shvatka.core.services.game import get_game
 from shvatka.core.services.organizers import check_allow_manage_orgs, get_orgs
-from shvatka.core.services.team import get_team_by_id
+from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.core.utils.exceptions import (
     PlayerRestoredInTeam,
     RequestNotPending,
     RequestPermissionError,
 )
-from shvatka.core.views.game import OrgNotifier, NewOrg
+from shvatka.core.views.game import GameLogWriter, OrgNotifier, NewOrg
 from shvatka.core.views.team import TeamNotifier
+
+MERGE_REQUEST_TYPES = (RequestType.team_merge, RequestType.player_merge)
 
 
 @dataclass
@@ -197,6 +213,115 @@ class CreateOrgInviteInteractor:
 
 
 @dataclass
+class CreateTeamMergeRequestInteractor:
+    """A captain asks the admins to merge their team with its forum copy."""
+
+    requests: RequestStorage
+    notifications: NotificationWriter
+    team_dao: TeamByIdGetter
+    superusers: SuperusersResolver
+    notifier: RequestNotifier
+
+    async def __call__(
+        self, identity: IdentityProvider, primary_team_id: int, secondary_team_id: int
+    ) -> ndto.ActionRequest:
+        captain = await identity.get_required_player()
+        primary = await get_team_by_id(primary_team_id, self.team_dao)
+        secondary = await get_team_by_id(secondary_team_id, self.team_dao)
+        if primary.captain is None or primary.captain.id != captain.id:
+            raise RequestPermissionError(player=captain, team=primary)
+        existing = await self.requests.get_pending(
+            type_=RequestType.team_merge, team_id=primary.id
+        )
+        if existing is not None:
+            return existing
+        payload = {
+            "primary_team_id": primary.id,
+            "primary_team_name": primary.name,
+            "secondary_team_id": secondary.id,
+            "secondary_team_name": secondary.name,
+            "captain_id": captain.id,
+            "captain_name": captain.name_mention,
+        }
+        request = await self.requests.create(
+            type_=RequestType.team_merge,
+            initiator_id=captain.id,
+            team_id=primary.id,
+            payload=payload,
+        )
+        await self.notifications.create_for_recipients(
+            recipient_ids=await self.superusers.get_superuser_player_ids(),
+            type_=NotificationType.team_merge_request,
+            severity=NotificationSeverity.normal,
+            actor_id=captain.id,
+            payload=payload,
+            request_id=request.id,
+        )
+        await self.notifier.notify_created(request)
+        await self.requests.commit()
+        return request
+
+
+@dataclass
+class CreatePlayerMergeRequestInteractor:
+    """A player asks the admins to merge their achievements with a forum copy.
+
+    An admin may also file the request on behalf of another player (``primary``
+    differs from the actor), mirroring the old superuser-only bot command.
+    """
+
+    requests: RequestStorage
+    notifications: NotificationWriter
+    player_dao: PlayerByIdGetter
+    superusers: SuperusersResolver
+    notifier: RequestNotifier
+
+    async def __call__(
+        self,
+        identity: IdentityProvider,
+        secondary_player_id: int,
+        primary_player_id: int | None = None,
+    ) -> ndto.ActionRequest:
+        actor = await identity.get_required_player()
+        if primary_player_id is None or primary_player_id == actor.id:
+            primary = actor
+        else:
+            await identity.get_superuser()
+            primary = await self.player_dao.get_by_id(primary_player_id)
+        secondary = await self.player_dao.get_by_id(secondary_player_id)
+        existing = await self.requests.get_pending(
+            type_=RequestType.player_merge, target_player_id=primary.id
+        )
+        if existing is not None:
+            return existing
+        payload = {
+            "primary_player_id": primary.id,
+            "primary_player_name": primary.name_mention,
+            "secondary_player_id": secondary.id,
+            "secondary_player_name": secondary.name_mention,
+            "initiator_id": actor.id,
+            "initiator_name": actor.name_mention,
+        }
+        request = await self.requests.create(
+            type_=RequestType.player_merge,
+            initiator_id=actor.id,
+            target_player_id=primary.id,
+            payload=payload,
+        )
+        await self.notifications.create_for_recipients(
+            recipient_ids=await self.superusers.get_superuser_player_ids(),
+            type_=NotificationType.player_merge_request,
+            severity=NotificationSeverity.normal,
+            actor_id=actor.id,
+            payload=payload,
+            request_id=request.id,
+        )
+        await self.notifier.notify_created(request)
+        await self.requests.commit()
+        return request
+
+
+@dataclass
 class AcceptRequestInteractor:
     requests: RequestStorage
     notifications: NotificationWriter
@@ -205,6 +330,9 @@ class AcceptRequestInteractor:
     team_player_dao: TeamPlayerGetter
     player_dao: PlayerByIdGetter
     org_adder: OrgAdder
+    team_merger: TeamMerger
+    player_merger: PlayerMerger
+    game_log: GameLogWriter
     team_notifier: TeamNotifier
     org_notifier: OrgNotifier
     bus: Bus
@@ -221,6 +349,10 @@ class AcceptRequestInteractor:
                 return await self._accept_team_join_request(actor, request)
             case RequestType.org_invite:
                 return await self._accept_org_invite(actor, request)
+            case RequestType.team_merge:
+                return await self._accept_team_merge(identity, request)
+            case RequestType.player_merge:
+                return await self._accept_player_merge(identity, request)
         raise RequestNotPending(player=actor)  # pragma: no cover - exhaustive match
 
     async def _accept_team_join_invite(
@@ -267,6 +399,34 @@ class AcceptRequestInteractor:
         org = await self.org_adder.add_new_org(game, actor)
         await self.requests.commit()
         await self.org_notifier.notify(NewOrg(orgs_list=notify_orgs, game=game, org=org))
+        await self._submit_resolved(updated)
+        return updated
+
+    async def _accept_team_merge(
+        self, identity: IdentityProvider, request: ndto.ActionRequest
+    ) -> ndto.ActionRequest:
+        admin = await identity.get_superuser()
+        assert request.team_id is not None
+        primary = await get_team_by_id(request.team_id, self.team_dao)
+        secondary = await get_team_by_id(request.payload["secondary_team_id"], self.team_dao)
+        captain = await self.player_dao.get_by_id(request.initiator_id)
+        updated = await self._resolve(request, RequestStatus.accepted, admin)
+        await self._notify_initiator(request, NotificationType.request_accepted, admin)
+        # merge_teams commits, taking the resolution and notification along
+        await merge_teams(captain, primary, secondary, self.game_log, self.team_merger)
+        await self._submit_resolved(updated)
+        return updated
+
+    async def _accept_player_merge(
+        self, identity: IdentityProvider, request: ndto.ActionRequest
+    ) -> ndto.ActionRequest:
+        admin = await identity.get_superuser()
+        primary = await self.player_dao.get_by_id(request.payload["primary_player_id"])
+        secondary = await self.player_dao.get_by_id(request.payload["secondary_player_id"])
+        updated = await self._resolve(request, RequestStatus.accepted, admin)
+        await self._notify_initiator(request, NotificationType.request_accepted, admin)
+        # merge_players commits, taking the resolution and notification along
+        await merge_players(primary, secondary, self.game_log, self.player_merger)
         await self._submit_resolved(updated)
         return updated
 
@@ -327,7 +487,7 @@ class DeclineRequestInteractor:
         request = await self.requests.get_by_id(request_id)
         if not request.is_pending:
             raise RequestNotPending(player=actor)
-        await self._check_can_respond(actor, request)
+        await self._check_can_respond(identity, actor, request)
         updated = await self.requests.set_status(
             request.id, RequestStatus.declined, responder_id=actor.id
         )
@@ -347,11 +507,18 @@ class DeclineRequestInteractor:
         )
         return updated
 
-    async def _check_can_respond(self, actor: dto.Player, request: ndto.ActionRequest) -> None:
+    async def _check_can_respond(
+        self, identity: IdentityProvider, actor: dto.Player, request: ndto.ActionRequest
+    ) -> None:
         if request.type == RequestType.team_join_request:
             assert request.team_id is not None
             team = await get_team_by_id(request.team_id, self.team_dao)
             await check_can_add_players(actor, team, self.team_player_dao)
+        elif request.type in MERGE_REQUEST_TYPES:
+            # the player whose account would be merged may refuse; otherwise only admins
+            if request.type == RequestType.player_merge and request.target_player_id == actor.id:
+                return
+            await identity.get_superuser()
         elif request.target_player_id != actor.id:
             raise RequestPermissionError(player=actor)
 
@@ -395,6 +562,14 @@ class ListRequestsInteractor:
         if team is not None:
             # team managers also answer un-targeted join requests for their team
             result.extend(await self.requests.get_pending_for_teams([team.id]))
+        if await identity.is_superuser():
+            # admins answer merge requests, which target no particular player
+            seen = {request.id for request in result}
+            result.extend(
+                request
+                for request in await self.requests.get_pending_by_types(MERGE_REQUEST_TYPES)
+                if request.id not in seen
+            )
         return result
 
     async def outgoing(

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -39,6 +39,7 @@ from shvatka.core.notifications.adapters import (
     RequestStorage,
     SuperusersResolver,
 )
+from shvatka.core.players.dto import TimelineItem
 from shvatka.core.players.interfaces import PlayerMerger
 from shvatka.core.players.player import check_can_add_players, join_team, merge_players
 from shvatka.core.services.game import get_game
@@ -337,7 +338,19 @@ class AcceptRequestInteractor:
     org_notifier: OrgNotifier
     bus: Bus
 
-    async def __call__(self, identity: IdentityProvider, request_id: int) -> ndto.ActionRequest:
+    async def __call__(
+        self,
+        identity: IdentityProvider,
+        request_id: int,
+        timeline: list[TimelineItem] | None = None,
+    ) -> ndto.ActionRequest:
+        """Accept the request.
+
+        ``timeline`` only applies to player merge requests: when the players'
+        team histories are not compatible, the admin passes a manually built
+        history which replaces both (validated against the waiver points of
+        both players).
+        """
         actor = await identity.get_required_player()
         request = await self.requests.get_by_id(request_id)
         if not request.is_pending:
@@ -352,7 +365,7 @@ class AcceptRequestInteractor:
             case RequestType.team_merge:
                 return await self._accept_team_merge(identity, request)
             case RequestType.player_merge:
-                return await self._accept_player_merge(identity, request)
+                return await self._accept_player_merge(identity, request, timeline)
         raise RequestNotPending(player=actor)  # pragma: no cover - exhaustive match
 
     async def _accept_team_join_invite(
@@ -418,7 +431,10 @@ class AcceptRequestInteractor:
         return updated
 
     async def _accept_player_merge(
-        self, identity: IdentityProvider, request: ndto.ActionRequest
+        self,
+        identity: IdentityProvider,
+        request: ndto.ActionRequest,
+        timeline: list[TimelineItem] | None = None,
     ) -> ndto.ActionRequest:
         admin = await identity.get_superuser()
         primary = await self.player_dao.get_by_id(request.payload["primary_player_id"])
@@ -426,7 +442,7 @@ class AcceptRequestInteractor:
         updated = await self._resolve(request, RequestStatus.accepted, admin)
         await self._notify_initiator(request, NotificationType.request_accepted, admin)
         # merge_players commits, taking the resolution and notification along
-        await merge_players(primary, secondary, self.game_log, self.player_merger)
+        await merge_players(primary, secondary, self.game_log, self.player_merger, timeline)
         await self._submit_resolved(updated)
         return updated
 

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -15,6 +15,7 @@ and the merge itself writes the usual game-log entry.
 """
 
 import contextlib
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -33,11 +34,11 @@ from shvatka.core.models.enums.notification import NotificationType, Notificatio
 from shvatka.core.models.enums.request import RequestType, RequestStatus
 from shvatka.core.notifications import dto as ndto
 from shvatka.core.interfaces.bus import ActionRequestResolved, Bus
+from shvatka.core.interfaces.superusers import SuperusersResolver
 from shvatka.core.notifications.adapters import (
     NotificationWriter,
     RequestNotifier,
     RequestStorage,
-    SuperusersResolver,
 )
 from shvatka.core.players.dto import TimelineItem
 from shvatka.core.players.interfaces import PlayerMerger
@@ -53,6 +54,8 @@ from shvatka.core.utils.exceptions import (
 )
 from shvatka.core.views.game import GameLogWriter, OrgNotifier, NewOrg
 from shvatka.core.views.team import TeamNotifier
+
+logger = logging.getLogger(__name__)
 
 MERGE_REQUEST_TYPES = (RequestType.team_merge, RequestType.player_merge)
 
@@ -423,6 +426,13 @@ class AcceptRequestInteractor:
         primary = await get_team_by_id(request.team_id, self.team_dao)
         secondary = await get_team_by_id(request.payload["secondary_team_id"], self.team_dao)
         captain = await self.player_dao.get_by_id(request.initiator_id)
+        logger.warning(
+            "admin %s accepted team merge request %s: merging team %s into %s",
+            admin.id,
+            request.id,
+            secondary.id,
+            primary.id,
+        )
         updated = await self._resolve(request, RequestStatus.accepted, admin)
         await self._notify_initiator(request, NotificationType.request_accepted, admin)
         # merge_teams commits, taking the resolution and notification along
@@ -439,6 +449,14 @@ class AcceptRequestInteractor:
         admin = await identity.get_superuser()
         primary = await self.player_dao.get_by_id(request.payload["primary_player_id"])
         secondary = await self.player_dao.get_by_id(request.payload["secondary_player_id"])
+        logger.warning(
+            "admin %s accepted player merge request %s: merging player %s into %s%s",
+            admin.id,
+            request.id,
+            secondary.id,
+            primary.id,
+            " with a custom timeline" if timeline is not None else "",
+        )
         updated = await self._resolve(request, RequestStatus.accepted, admin)
         await self._notify_initiator(request, NotificationType.request_accepted, admin)
         # merge_players commits, taking the resolution and notification along
@@ -504,6 +522,10 @@ class DeclineRequestInteractor:
         if not request.is_pending:
             raise RequestNotPending(player=actor)
         await self._check_can_respond(identity, actor, request)
+        if request.type in MERGE_REQUEST_TYPES:
+            logger.warning(
+                "admin %s declined %s request %s", actor.id, request.type.name, request.id
+            )
         updated = await self.requests.set_status(
             request.id, RequestStatus.declined, responder_id=actor.id
         )

--- a/shvatka/infrastructure/db/dao/rdb/action_request.py
+++ b/shvatka/infrastructure/db/dao/rdb/action_request.py
@@ -1,5 +1,5 @@
 import typing
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from datetime import datetime, tzinfo
 from typing import Any
 
@@ -127,6 +127,23 @@ class ActionRequestDAO(BaseDAO[ActionRequest]):
             select(ActionRequest.bot_messages).where(ActionRequest.id == request_id)
         )
         return [(d["chat_id"], d["message_id"]) for d in result.one()]
+
+    async def get_pending_by_types(
+        self, types: Collection[RequestType]
+    ) -> Sequence[dto.ActionRequest]:
+        """Pending requests of the given types, newest first (e.g. merges for admins)."""
+        if not types:
+            return []
+        stmt = (
+            select(ActionRequest)
+            .where(
+                ActionRequest.type.in_([type_.name for type_ in types]),
+                ActionRequest.status == RequestStatus.pending,
+            )
+            .order_by(ActionRequest.created_at.desc())
+        )
+        result = await self.session.scalars(stmt)
+        return [request.to_dto() for request in result.all()]
 
     async def get_pending_for_teams(self, team_ids: Sequence[int]) -> Sequence[dto.ActionRequest]:
         """Pending team-join requests answerable by managers of the given teams."""

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -2,6 +2,7 @@ from aiogram import Bot
 from adaptix import Retort
 from dishka import Provider, Scope, provide
 
+from shvatka.common import Config
 from shvatka.common.url_factory import UrlFactory
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
@@ -38,12 +39,21 @@ from shvatka.core.notifications.request_interactors import (
     CreateTeamJoinInviteInteractor,
     CreateTeamJoinRequestInteractor,
     CreateOrgInviteInteractor,
+    CreateTeamMergeRequestInteractor,
+    CreatePlayerMergeRequestInteractor,
     AcceptRequestInteractor,
     DeclineRequestInteractor,
     CancelRequestInteractor,
     ListRequestsInteractor,
 )
-from shvatka.core.notifications.adapters import RequestNotifier, RequestStorage, NotificationWriter
+from shvatka.core.notifications.adapters import (
+    RequestNotifier,
+    RequestStorage,
+    NotificationWriter,
+    SuperusersResolver,
+)
+from shvatka.tgbot.config.models.bot import BotConfig
+from shvatka.tgbot.services.action_requests import ActionResolvedInteractorImpl
 from shvatka.tgbot.views.action_request import BotRequestNotifier
 from shvatka.core.players.interactors import (
     GetPlayerInteractor,
@@ -126,7 +136,8 @@ from shvatka.core.waiver.interactors import (
     AllWaiversDraftReaderInteractor,
     ReplaceTeamWaiversInteractor,
 )
-from shvatka.infrastructure.bus.in_memory import InMemoryBus
+from shvatka.infrastructure.bus.in_memory import ActionResolvedInteractor, InMemoryBus
+from shvatka.infrastructure.superusers import ConfigSuperusersResolver
 from shvatka.infrastructure.db.dao.complex2.waiver import (
     WaiverVoteAdderImpl,
     WaiverVoteGetterImpl,
@@ -160,10 +171,11 @@ class ContextProvider(Provider):
     scope = Scope.REQUEST
     current_game = provide(CurrentGameProviderImpl, provides=CurrentGameProvider)
     bus = provide(InMemoryBus, provides=Bus)
+    action_resolved = provide(ActionResolvedInteractorImpl, provides=ActionResolvedInteractor)
 
     @provide
     def request_notifier(
-        self, bot: Bot, dao: HolderDao, requests: RequestStorage
+        self, bot: Bot, dao: HolderDao, requests: RequestStorage, bot_config: BotConfig
     ) -> RequestNotifier:
         return BotRequestNotifier(
             bot=bot,
@@ -171,7 +183,12 @@ class ContextProvider(Provider):
             player_dao=dao.player,
             team_dao=dao.team,
             team_players_dao=dao.team_player,
+            game_log_chat=bot_config.game_log_chat,
         )
+
+    @provide
+    def superusers_resolver(self, config: Config, dao: HolderDao) -> SuperusersResolver:
+        return ConfigSuperusersResolver(config=config, player_dao=dao.player)
 
 
 class GamePlayProvider(Provider):
@@ -533,6 +550,40 @@ class RequestProvider(Provider):
         )
 
     @provide
+    def create_team_merge_request(
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        superusers: SuperusersResolver,
+        notifier: RequestNotifier,
+    ) -> CreateTeamMergeRequestInteractor:
+        return CreateTeamMergeRequestInteractor(
+            requests=requests,
+            notifications=notifications,
+            team_dao=dao.team,
+            superusers=superusers,
+            notifier=notifier,
+        )
+
+    @provide
+    def create_player_merge_request(
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        superusers: SuperusersResolver,
+        notifier: RequestNotifier,
+    ) -> CreatePlayerMergeRequestInteractor:
+        return CreatePlayerMergeRequestInteractor(
+            requests=requests,
+            notifications=notifications,
+            player_dao=dao.player,
+            superusers=superusers,
+            notifier=notifier,
+        )
+
+    @provide
     def accept_request(
         self,
         dao: HolderDao,
@@ -540,6 +591,7 @@ class RequestProvider(Provider):
         notifications: NotificationWriter,
         team_notifier: TeamNotifier,
         org_notifier: OrgNotifier,
+        game_log: GameLogWriter,
         bus: Bus,
     ) -> AcceptRequestInteractor:
         return AcceptRequestInteractor(
@@ -550,6 +602,9 @@ class RequestProvider(Provider):
             team_player_dao=dao.team_player,
             player_dao=dao.player,
             org_adder=dao.org_adder,
+            team_merger=dao.team_merger,
+            player_merger=dao.player_merger,
+            game_log=game_log,
             team_notifier=team_notifier,
             org_notifier=org_notifier,
             bus=bus,

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -46,11 +46,11 @@ from shvatka.core.notifications.request_interactors import (
     CancelRequestInteractor,
     ListRequestsInteractor,
 )
+from shvatka.core.interfaces.superusers import SuperusersResolver
 from shvatka.core.notifications.adapters import (
     RequestNotifier,
     RequestStorage,
     NotificationWriter,
-    SuperusersResolver,
 )
 from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.services.action_requests import ActionResolvedInteractorImpl

--- a/shvatka/infrastructure/superusers.py
+++ b/shvatka/infrastructure/superusers.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from shvatka.common import Config
+from shvatka.core.notifications.adapters import SuperusersResolver
+from shvatka.core.utils import exceptions
+from shvatka.infrastructure.db.dao import PlayerDao
+
+
+@dataclass
+class ConfigSuperusersResolver(SuperusersResolver):
+    """Maps the configured superuser tg ids onto player ids, skipping unknown ones."""
+
+    config: Config
+    player_dao: PlayerDao
+
+    async def get_superuser_player_ids(self) -> set[int]:
+        player_ids = set()
+        for tg_id in self.config.superusers:
+            try:
+                player = await self.player_dao.get_by_user_id(tg_id)
+            except exceptions.PlayerNotFoundError:
+                continue
+            player_ids.add(player.id)
+        return player_ids

--- a/shvatka/infrastructure/superusers.py
+++ b/shvatka/infrastructure/superusers.py
@@ -1,17 +1,25 @@
 from dataclasses import dataclass
 
 from shvatka.common import Config
-from shvatka.core.notifications.adapters import SuperusersResolver
+from shvatka.core.interfaces.superusers import SuperusersResolver
+from shvatka.core.models import dto
 from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db.dao import PlayerDao
 
 
 @dataclass
 class ConfigSuperusersResolver(SuperusersResolver):
-    """Maps the configured superuser tg ids onto player ids, skipping unknown ones."""
+    """Reads the configured superuser tg ids and exposes them as the single
+    source of admin rights (as tg ids, as player ids, and as a membership check)."""
 
     config: Config
     player_dao: PlayerDao
+
+    def is_superuser(self, user: dto.User) -> bool:
+        return user.tg_id in self.config.superusers
+
+    async def get_superuser_user_ids(self) -> set[int]:
+        return set(self.config.superusers)
 
     async def get_superuser_player_ids(self) -> set[int]:
         player_ids = set()

--- a/shvatka/tgbot/dialogs/merge/handlers.py
+++ b/shvatka/tgbot/dialogs/merge/handlers.py
@@ -3,12 +3,18 @@ import urllib.parse
 from typing import Any
 
 from aiogram.types import CallbackQuery, Message
-from aiogram.utils.text_decorations import html_decoration as hd
 from aiogram_dialog import DialogManager
+from dishka import FromDishka
+from dishka.integrations.aiogram_dialog import inject
 
-from shvatka.core.services.team import get_team_by_id, get_team_by_forum_team_id
+from shvatka.core.interfaces.identity import IdentityProvider
+from shvatka.core.notifications.request_interactors import (
+    CreatePlayerMergeRequestInteractor,
+    CreateTeamMergeRequestInteractor,
+)
+from shvatka.core.services.team import get_team_by_forum_team_id
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.tgbot import states, keyboards as kb
+from shvatka.tgbot import states
 from shvatka.tgbot.utils.data import SHMiddlewareData
 
 
@@ -19,20 +25,22 @@ async def select_forum_team(
     await manager.switch_to(states.MergeTeamsSG.confirm)
 
 
-async def confirm_merge(c: CallbackQuery, button: Any, manager: DialogManager):
+@inject
+async def confirm_merge(
+    c: CallbackQuery,
+    button: Any,
+    manager: DialogManager,
+    identity: FromDishka[IdentityProvider],
+    interactor: FromDishka[CreateTeamMergeRequestInteractor],
+):
     data = typing.cast(SHMiddlewareData, manager.middleware_data)
     dao = data["dao"]
-    captain = data["player"]
-    assert captain
     start_data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
-    primary = await get_team_by_id(start_data["team_id"], dao.team)
     secondary = await get_team_by_forum_team_id(manager.dialog_data["forum_team_id"], dao.team)
-    await data["bot"].send_message(
-        chat_id=data["config"].game_log_chat,
-        text=f"Капитан {hd.quote(captain.name_mention)} предлагает объединить "
-        f"свою команду {hd.quote(primary.name)} "
-        f"с форумной версией {hd.quote(secondary.name)}",
-        reply_markup=kb.get_team_merge_confirm_kb(primary, secondary),
+    await interactor(
+        identity=identity,
+        primary_team_id=start_data["team_id"],
+        secondary_team_id=secondary.id,
     )
     await c.answer("Заявка на объединение отправлена", show_alert=True)
     await manager.done()
@@ -48,19 +56,17 @@ async def player_link_handler(m: Message, widget: Any, manager: DialogManager):
     await manager.switch_to(states.MergePlayersSG.confirm)
 
 
-async def confirm_merge_player(c: CallbackQuery, button: Any, manager: DialogManager):
+@inject
+async def confirm_merge_player(
+    c: CallbackQuery,
+    button: Any,
+    manager: DialogManager,
+    identity: FromDishka[IdentityProvider],
+    interactor: FromDishka[CreatePlayerMergeRequestInteractor],
+):
     data = typing.cast(SHMiddlewareData, manager.middleware_data)
     dao = data["dao"]
-    primary = data["player"]
-    assert primary
     secondary_forum = await dao.forum_user.get_by_id(manager.dialog_data["forum_player_id"])
-    secondary = await dao.player.get_by_id(secondary_forum.player_id)
-    await data["bot"].send_message(
-        chat_id=data["config"].game_log_chat,
-        text=f"Игрок {hd.quote(primary.name_mention)} предлагает объединить "
-        f"свои достижения "
-        f"с форумной версией {hd.quote(secondary.name_mention)}",
-        reply_markup=kb.get_player_merge_confirm_kb(primary, secondary),
-    )
+    await interactor(identity=identity, secondary_player_id=secondary_forum.player_id)
     await c.answer("Заявка на объединение отправлена", show_alert=True)
     await manager.done()

--- a/shvatka/tgbot/dialogs/merge/handlers.py
+++ b/shvatka/tgbot/dialogs/merge/handlers.py
@@ -1,4 +1,3 @@
-import typing
 import urllib.parse
 from typing import Any
 
@@ -15,7 +14,6 @@ from shvatka.core.notifications.request_interactors import (
 from shvatka.core.services.team import get_team_by_forum_team_id
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot import states
-from shvatka.tgbot.utils.data import SHMiddlewareData
 
 
 async def select_forum_team(
@@ -30,11 +28,10 @@ async def confirm_merge(
     c: CallbackQuery,
     button: Any,
     manager: DialogManager,
+    dao: FromDishka[HolderDao],
     identity: FromDishka[IdentityProvider],
     interactor: FromDishka[CreateTeamMergeRequestInteractor],
 ):
-    data = typing.cast(SHMiddlewareData, manager.middleware_data)
-    dao = data["dao"]
     start_data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
     secondary = await get_team_by_forum_team_id(manager.dialog_data["forum_team_id"], dao.team)
     await interactor(
@@ -46,11 +43,13 @@ async def confirm_merge(
     await manager.done()
 
 
-async def player_link_handler(m: Message, widget: Any, manager: DialogManager):
+@inject
+async def player_link_handler(
+    m: Message, widget: Any, manager: DialogManager, dao: FromDishka[HolderDao]
+):
     url = urllib.parse.urlparse(m.text)
     assert isinstance(url.query, str)
     forum_id = int(urllib.parse.parse_qs(url.query)["showuser"][0])
-    dao: HolderDao = manager.middleware_data["dao"]
     forum_user = await dao.forum_user.get_by_forum_id(forum_id)
     manager.dialog_data["forum_player_id"] = forum_user.db_id
     await manager.switch_to(states.MergePlayersSG.confirm)
@@ -61,11 +60,10 @@ async def confirm_merge_player(
     c: CallbackQuery,
     button: Any,
     manager: DialogManager,
+    dao: FromDishka[HolderDao],
     identity: FromDishka[IdentityProvider],
     interactor: FromDishka[CreatePlayerMergeRequestInteractor],
 ):
-    data = typing.cast(SHMiddlewareData, manager.middleware_data)
-    dao = data["dao"]
     secondary_forum = await dao.forum_user.get_by_id(manager.dialog_data["forum_player_id"])
     await interactor(identity=identity, secondary_player_id=secondary_forum.player_id)
     await c.answer("Заявка на объединение отправлена", show_alert=True)

--- a/shvatka/tgbot/handlers/action_request.py
+++ b/shvatka/tgbot/handlers/action_request.py
@@ -6,6 +6,7 @@ from shvatka.core.notifications.request_interactors import (
     AcceptRequestInteractor,
     DeclineRequestInteractor,
 )
+from shvatka.core.utils.exceptions import NotAuthorizedForAdmin, RequestNotPending
 from shvatka.tgbot.keyboards.action_request import ActionRequestCD
 from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.views.utils import total_remove_msg
@@ -20,12 +21,23 @@ async def resolve_action_request(
     decline_interactor: FromDishka[DeclineRequestInteractor],
     bot: FromDishka[Bot],
 ) -> None:
-    if callback_data.accept:
-        await accept_interactor(identity=identity, request_id=callback_data.request_id)
-        text = "Запрос принят"
-    else:
-        await decline_interactor(identity=identity, request_id=callback_data.request_id)
-        text = "Запрос отклонён"
+    try:
+        if callback_data.accept:
+            await accept_interactor(identity=identity, request_id=callback_data.request_id)
+            text = "Запрос принят"
+        else:
+            await decline_interactor(identity=identity, request_id=callback_data.request_id)
+            text = "Запрос отклонён"
+    except NotAuthorizedForAdmin:
+        await callback.answer("Недостаточно прав, сорян", cache_time=3600)
+        return
+    except RequestNotPending:
+        await callback.answer("Запрос уже обработан", show_alert=True)
+        if callback.message is not None:
+            await total_remove_msg(
+                bot, chat_id=callback.message.chat.id, msg_id=callback.message.message_id
+            )
+        return
     if callback.message is not None:
         await total_remove_msg(
             bot, chat_id=callback.message.chat.id, msg_id=callback.message.message_id

--- a/shvatka/tgbot/handlers/admin.py
+++ b/shvatka/tgbot/handlers/admin.py
@@ -1,17 +1,16 @@
 from functools import partial
 
-from aiogram import Router, types, Bot
+from aiogram import Router, types
 from aiogram.filters import Command, CommandObject
+from dishka.integrations.aiogram import FromDishka, inject
 
-from aiogram.utils.text_decorations import html_decoration as hd
-
-from shvatka.core.models import dto
-from shvatka.tgbot import keyboards as kb
+from shvatka.core.notifications.request_interactors import CreatePlayerMergeRequestInteractor
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.views.game import GameLogWriter
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.filters import is_superuser
+from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.views.commands import MERGE_TEAMS, MERGE_PLAYERS
 
 
@@ -35,13 +34,12 @@ async def merge_teams_command(
     await message.reply(f"Успешно объединены {primary.name} и {secondary.name}")
 
 
+@inject
 async def merge_players_command(
     message: types.Message,
-    bot: Bot,
-    player: dto.Player,
-    config: BotConfig,
     command: CommandObject,
-    dao: HolderDao,
+    identity: FromDishka[TgBotIdentityProvider],
+    interactor: FromDishka[CreatePlayerMergeRequestInteractor],
 ):
     if not command.args:
         await message.reply(
@@ -50,15 +48,8 @@ async def merge_players_command(
         )
         return
     old_id, new_id = map(int, command.args.split())
-    primary = await dao.player.get_by_id(new_id)
-    secondary = await dao.player.get_by_id(old_id)
-    await bot.send_message(
-        chat_id=config.game_log_chat,
-        text=f"Админ {hd.quote(player.name_mention)} предлагает объединить "
-        f"достижения игрока {hd.quote(primary.name_mention)}"
-        f"с форумной версией {hd.quote(secondary.name_mention)}",
-        reply_markup=kb.get_player_merge_confirm_kb(primary, secondary),
-    )
+    await interactor(identity=identity, primary_player_id=new_id, secondary_player_id=old_id)
+    await message.reply("Заявка на объединение отправлена")
 
 
 def setup(bot_config: BotConfig) -> Router:

--- a/shvatka/tgbot/handlers/admin.py
+++ b/shvatka/tgbot/handlers/admin.py
@@ -47,7 +47,8 @@ async def merge_players_command(
             "Сначала id игрока в новом движке, а потом id игрока с форума."
         )
         return
-    old_id, new_id = map(int, command.args.split())
+    # help above: first the id in the new engine (kept, primary), then the forum id
+    new_id, old_id = map(int, command.args.split())
     await interactor(identity=identity, primary_player_id=new_id, secondary_player_id=old_id)
     await message.reply("Заявка на объединение отправлена")
 

--- a/shvatka/tgbot/keyboards/__init__.py
+++ b/shvatka/tgbot/keyboards/__init__.py
@@ -5,8 +5,6 @@ from .invite_test_level import (
 from .merge import (
     TeamMergeCD,
     PlayerMergeCD,
-    get_team_merge_confirm_kb,
-    get_player_merge_confirm_kb,
 )
 from .organizer import (
     AddGameOrgID,

--- a/shvatka/tgbot/keyboards/merge.py
+++ b/shvatka/tgbot/keyboards/merge.py
@@ -1,8 +1,7 @@
 from aiogram.filters.callback_data import CallbackData
-from aiogram.types import InlineKeyboardMarkup
-from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-from shvatka.core.models import dto
+# New merge requests use the generic action-request keyboard; these callback data
+# classes remain so the buttons on messages posted before that change keep working.
 
 
 class TeamMergeCD(CallbackData, prefix="team_merge"):
@@ -13,23 +12,3 @@ class TeamMergeCD(CallbackData, prefix="team_merge"):
 class PlayerMergeCD(CallbackData, prefix="player_merge"):
     primary_player_id: int
     secondary_player_id: int
-
-
-def get_team_merge_confirm_kb(primary: dto.Team, secondary: dto.Team) -> InlineKeyboardMarkup:
-    builder = InlineKeyboardBuilder()
-    builder.button(
-        text="Подтвердить слияние",
-        callback_data=TeamMergeCD(primary_team_id=primary.id, secondary_team_id=secondary.id),
-    )
-    return builder.as_markup()
-
-
-def get_player_merge_confirm_kb(primary: dto.Player, secondary: dto.Player):
-    builder = InlineKeyboardBuilder()
-    builder.button(
-        text="Подтвердить слияние",
-        callback_data=PlayerMergeCD(
-            primary_player_id=primary.id, secondary_player_id=secondary.id
-        ),
-    )
-    return builder.as_markup()

--- a/shvatka/tgbot/main_factory.py
+++ b/shvatka/tgbot/main_factory.py
@@ -29,10 +29,7 @@ from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.views.game import GameLogWriter, GameView, GameViewPreparer, OrgNotifier
 from shvatka.core.views.level import LevelView
 from shvatka.core.views.team import TeamNotifier
-from shvatka.infrastructure.bus.in_memory import (
-    UsedOneTimeTokenInteractor,
-    ActionResolvedInteractor,
-)
+from shvatka.infrastructure.bus.in_memory import UsedOneTimeTokenInteractor
 from shvatka.infrastructure.db.config.models.storage import StorageConfig, StorageType
 from shvatka.infrastructure.db.dao import FileInfoDao
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -44,7 +41,6 @@ from shvatka.infrastructure.picture import ResultsPainter
 from shvatka.tgbot.config.models.bot import BotConfig, TgClientConfig
 from shvatka.tgbot.handlers import setup_handlers
 from shvatka.tgbot.middlewares import setup_middlewares
-from shvatka.tgbot.services.action_requests import ActionResolvedInteractorImpl
 from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.services.used_one_time_token import UsedOneTimeTokenInteractorImpl
 from shvatka.tgbot.username_resolver.user_getter import UserGetter
@@ -159,9 +155,6 @@ class DpProvider(Provider):
 
     used_one_time_token_interactor = provide(
         UsedOneTimeTokenInteractorImpl, provides=UsedOneTimeTokenInteractor, scope=Scope.REQUEST
-    )
-    action_request_interactor = provide(
-        ActionResolvedInteractorImpl, provides=ActionResolvedInteractor, scope=Scope.REQUEST
     )
 
 

--- a/shvatka/tgbot/services/identity.py
+++ b/shvatka/tgbot/services/identity.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TypedDict, cast
 
 from aiogram import types
@@ -15,8 +16,12 @@ from shvatka.core.players.player import (
 )
 from shvatka.core.services.team import get_by_chat
 from shvatka.core.services.user import upsert_user
+from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.utils.data import SHMiddlewareData
+
+logger = logging.getLogger(__name__)
 
 
 class LoadedData(TypedDict, total=False):
@@ -35,12 +40,28 @@ class TgBotIdentityProvider(IdentityProvider):
         dao: HolderDao,
         event: TelegramObject,
         aiogram_data: AiogramMiddlewareData,
+        bot_config: BotConfig,
     ) -> None:
         self.dao = dao
         self.event = event
         self.aiogram_data = aiogram_data
+        self.bot_config = bot_config
         self.cache = LoadedData()
         self.cache["organizer"] = {}
+
+    async def get_superuser(self) -> dto.Player:
+        player = await self.get_required_player()
+        user = await self.get_user()
+        if user is None or user.tg_id not in self.bot_config.superusers:
+            logger.warning("player %s tried to use admin actions without rights", player.id)
+            raise exceptions.NotAuthorizedForAdmin(player=player, user=user)
+        return player
+
+    async def is_superuser(self) -> bool:
+        if await self.get_player() is None:
+            return False
+        user = await self.get_user()
+        return user is not None and user.tg_id in self.bot_config.superusers
 
     async def get_user(self) -> dto.User | None:
         data = cast(SHMiddlewareData, self.aiogram_data)

--- a/shvatka/tgbot/services/identity.py
+++ b/shvatka/tgbot/services/identity.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TypedDict, cast
 
 from aiogram import types
@@ -7,6 +6,7 @@ from aiogram_dialog.api.entities import DialogUpdate
 from dishka.integrations.aiogram import AiogramMiddlewareData
 
 from shvatka.core.interfaces.identity import IdentityProvider
+from shvatka.core.interfaces.superusers import SuperusersResolver
 from shvatka.core.models import dto
 from shvatka.core.services.chat import upsert_chat
 from shvatka.core.players.player import (
@@ -16,12 +16,8 @@ from shvatka.core.players.player import (
 )
 from shvatka.core.services.team import get_by_chat
 from shvatka.core.services.user import upsert_user
-from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.utils.data import SHMiddlewareData
-
-logger = logging.getLogger(__name__)
 
 
 class LoadedData(TypedDict, total=False):
@@ -40,28 +36,23 @@ class TgBotIdentityProvider(IdentityProvider):
         dao: HolderDao,
         event: TelegramObject,
         aiogram_data: AiogramMiddlewareData,
-        bot_config: BotConfig,
+        superusers: SuperusersResolver,
     ) -> None:
         self.dao = dao
         self.event = event
         self.aiogram_data = aiogram_data
-        self.bot_config = bot_config
+        self.superusers = superusers
         self.cache = LoadedData()
         self.cache["organizer"] = {}
 
-    async def get_superuser(self) -> dto.Player:
-        player = await self.get_required_player()
+    async def _get_optional_superuser(self) -> dto.Player | None:
+        player = await self.get_player()
+        if player is None:
+            return None
         user = await self.get_user()
-        if user is None or user.tg_id not in self.bot_config.superusers:
-            logger.warning("player %s tried to use admin actions without rights", player.id)
-            raise exceptions.NotAuthorizedForAdmin(player=player, user=user)
+        if user is None or not self.superusers.is_superuser(user):
+            return None
         return player
-
-    async def is_superuser(self) -> bool:
-        if await self.get_player() is None:
-            return False
-        user = await self.get_user()
-        return user is not None and user.tg_id in self.bot_config.superusers
 
     async def get_user(self) -> dto.User | None:
         data = cast(SHMiddlewareData, self.aiogram_data)

--- a/shvatka/tgbot/views/action_request.py
+++ b/shvatka/tgbot/views/action_request.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from aiogram import Bot
 from aiogram.exceptions import AiogramError
+from aiogram.utils.text_decorations import html_decoration as hd
 
 from shvatka.core.models.enums.request import RequestType
 from shvatka.core.notifications import dto as ndto
@@ -13,6 +14,8 @@ from shvatka.tgbot.keyboards.action_request import get_action_request_kb
 
 logger = logging.getLogger(__name__)
 
+MERGE_REQUEST_TYPES = (RequestType.team_merge, RequestType.player_merge)
+
 
 @dataclass
 class BotRequestNotifier(RequestNotifier):
@@ -21,13 +24,10 @@ class BotRequestNotifier(RequestNotifier):
     player_dao: PlayerByIdGetter
     team_dao: TeamByIdGetter
     team_players_dao: TeamPlayersGetter
+    game_log_chat: int
 
     async def notify_created(self, request: ndto.ActionRequest) -> None:
-        for player_id in await self._recipient_ids(request):
-            player = await self.player_dao.get_by_id(player_id)
-            chat_id = player.get_chat_id()
-            if chat_id is None:
-                continue
+        for chat_id in await self._chat_ids(request):
             try:
                 message = await self.bot.send_message(
                     chat_id=chat_id,
@@ -43,6 +43,18 @@ class BotRequestNotifier(RequestNotifier):
             await self.requests.add_bot_message(
                 request.id, chat_id=message.chat.id, message_id=message.message_id
             )
+
+    async def _chat_ids(self, request: ndto.ActionRequest) -> list[int]:
+        if request.type in MERGE_REQUEST_TYPES:
+            # merge requests are answered by admins in the game-log channel
+            return [self.game_log_chat]
+        chat_ids = []
+        for player_id in await self._recipient_ids(request):
+            player = await self.player_dao.get_by_id(player_id)
+            chat_id = player.get_chat_id()
+            if chat_id is not None:
+                chat_ids.append(chat_id)
+        return chat_ids
 
     async def _recipient_ids(self, request: ndto.ActionRequest) -> set[int]:
         if request.target_player_id is not None:
@@ -72,4 +84,18 @@ class BotRequestNotifier(RequestNotifier):
                 author_name = payload.get("author_name", "Автор")
                 game_name = payload.get("game_name", "")
                 return f"{author_name} приглашает вас стать организатором игры {game_name}."
+            case RequestType.team_merge:
+                return (
+                    f"Капитан {hd.quote(payload.get('captain_name', ''))} "
+                    f"предлагает объединить свою команду "
+                    f"{hd.quote(payload.get('primary_team_name', ''))} "
+                    f"с форумной версией {hd.quote(payload.get('secondary_team_name', ''))}"
+                )
+            case RequestType.player_merge:
+                return (
+                    f"Игрок {hd.quote(payload.get('initiator_name', ''))} "
+                    f"предлагает объединить достижения игрока "
+                    f"{hd.quote(payload.get('primary_player_name', ''))} "
+                    f"с форумной версией {hd.quote(payload.get('secondary_player_name', ''))}"
+                )
         return "Новый запрос"

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -8,25 +8,34 @@ from shvatka.core.models import dto
 from shvatka.core.models.enums.chat_type import ChatType
 from shvatka.core.models.enums.request import RequestType, RequestStatus
 from shvatka.core.notifications import dto as ndto
+from shvatka.core.interfaces.bus import ActionRequestResolved
+from shvatka.core.notifications import request_interactors
 from shvatka.core.notifications.request_interactors import (
     CreateTeamJoinInviteInteractor,
     CreateTeamJoinRequestInteractor,
+    CreateTeamMergeRequestInteractor,
+    CreatePlayerMergeRequestInteractor,
     CancelRequestInteractor,
     DeclineRequestInteractor,
     AcceptRequestInteractor,
+    ListRequestsInteractor,
 )
 from shvatka.core.utils.datetime_utils import tz_utc
-from shvatka.core.utils.exceptions import RequestNotPending, RequestPermissionError
+from shvatka.core.utils.exceptions import (
+    NotAuthorizedForAdmin,
+    RequestNotPending,
+    RequestPermissionError,
+)
 
 
 def _player(id_: int, username: str = "p") -> dto.Player:
     return dto.Player(id=id_, can_be_author=False, is_dummy=False, username=username)
 
 
-def _team(captain: dto.Player | None = None) -> dto.Team:
+def _team(captain: dto.Player | None = None, id_: int = 1, name: str = "Gryffindor") -> dto.Team:
     return dto.Team(
-        id=1,
-        name="Gryffindor",
+        id=id_,
+        name=name,
         captain=captain,
         is_dummy=False,
         description=None,
@@ -35,15 +44,26 @@ def _team(captain: dto.Player | None = None) -> dto.Team:
 
 
 class FakeIdentity:
-    def __init__(self, player: dto.Player, team: dto.Team | None = None) -> None:
+    def __init__(
+        self, player: dto.Player, team: dto.Team | None = None, superuser: bool = False
+    ) -> None:
         self._player = player
         self._team = team
+        self._superuser = superuser
 
     async def get_required_player(self) -> dto.Player:
         return self._player
 
     async def get_team(self) -> dto.Team | None:
         return self._team
+
+    async def get_superuser(self) -> dto.Player:
+        if not self._superuser:
+            raise NotAuthorizedForAdmin(player=self._player)
+        return self._player
+
+    async def is_superuser(self) -> bool:
+        return self._superuser
 
 
 class FakeRequests:
@@ -87,6 +107,23 @@ class FakeRequests:
     async def add_bot_message(self, request_id: int, *, chat_id: int, message_id: int) -> None:
         pass
 
+    async def get_incoming(self, player_id: int, *, only_pending: bool = False):
+        return [
+            request
+            for request in self.rows.values()
+            if request.target_player_id == player_id and (not only_pending or request.is_pending)
+        ]
+
+    async def get_pending_for_teams(self, team_ids):
+        return []
+
+    async def get_pending_by_types(self, types):
+        return [
+            request
+            for request in self.rows.values()
+            if request.type in types and request.is_pending
+        ]
+
 
 class FakeNotifier:
     def __init__(self) -> None:
@@ -121,11 +158,20 @@ class FakeNotifications:
 
 
 class FakeTeamDao:
-    def __init__(self, team: dto.Team) -> None:
+    def __init__(self, team: dto.Team, *more: dto.Team) -> None:
+        self._teams = {t.id: t for t in (team, *more)}
         self._team = team
 
     async def get_by_id(self, team_id: int) -> dto.Team:
-        return self._team
+        return self._teams.get(team_id, self._team)
+
+
+class FakeSuperusers:
+    def __init__(self, player_ids: set[int]) -> None:
+        self._player_ids = player_ids
+
+    async def get_superuser_player_ids(self) -> set[int]:
+        return self._player_ids
 
 
 class FakePlayerDao:
@@ -306,6 +352,31 @@ async def test_decline_invite_wrong_actor_forbidden() -> None:
         await interactor(FakeIdentity(_player(7)), request_id=1)
 
 
+def _accept_interactor(
+    requests: FakeRequests,
+    *,
+    notifications: FakeNotifications | None = None,
+    team_dao=None,
+    player_dao=None,
+    bus: FakeBus | None = None,
+) -> AcceptRequestInteractor:
+    return AcceptRequestInteractor(
+        requests=requests,
+        notifications=notifications or FakeNotifications(),
+        team_joiner=SimpleNamespace(),
+        team_dao=team_dao or SimpleNamespace(),
+        team_player_dao=SimpleNamespace(),
+        player_dao=player_dao or SimpleNamespace(),
+        org_adder=SimpleNamespace(),
+        team_merger=SimpleNamespace(),
+        player_merger=SimpleNamespace(),
+        game_log=SimpleNamespace(),
+        team_notifier=SimpleNamespace(),
+        org_notifier=SimpleNamespace(),
+        bus=bus or FakeBus(),
+    )
+
+
 @pytest.mark.asyncio
 async def test_accept_rejects_non_pending() -> None:
     requests = FakeRequests()
@@ -317,18 +388,7 @@ async def test_accept_rejects_non_pending() -> None:
         target_player_id=2,
         created_at=datetime.now(tz=tz_utc),
     )
-    interactor = AcceptRequestInteractor(
-        requests=requests,
-        notifications=FakeNotifications(),
-        team_joiner=SimpleNamespace(),
-        team_dao=SimpleNamespace(),
-        team_player_dao=SimpleNamespace(),
-        player_dao=SimpleNamespace(),
-        org_adder=SimpleNamespace(),
-        team_notifier=SimpleNamespace(),
-        org_notifier=SimpleNamespace(),
-        bus=FakeBus(),
-    )
+    interactor = _accept_interactor(requests)
     with pytest.raises(RequestNotPending):
         await interactor(FakeIdentity(_player(2)), request_id=1)
 
@@ -345,17 +405,229 @@ async def test_accept_invite_wrong_actor_forbidden() -> None:
         team_id=1,
         created_at=datetime.now(tz=tz_utc),
     )
-    interactor = AcceptRequestInteractor(
-        requests=requests,
-        notifications=FakeNotifications(),
-        team_joiner=SimpleNamespace(),
-        team_dao=FakeTeamDao(_team()),
-        team_player_dao=SimpleNamespace(),
-        player_dao=FakePlayerDao({1: _player(1)}),
-        org_adder=SimpleNamespace(),
-        team_notifier=SimpleNamespace(),
-        org_notifier=SimpleNamespace(),
-        bus=FakeBus(),
+    interactor = _accept_interactor(
+        requests, team_dao=FakeTeamDao(_team()), player_dao=FakePlayerDao({1: _player(1)})
     )
     with pytest.raises(RequestPermissionError):
         await interactor(FakeIdentity(_player(7)), request_id=1)
+
+
+@pytest.mark.asyncio
+async def test_create_team_merge_request() -> None:
+    cap = _player(1, "cap")
+    primary = _team(cap, id_=1, name="Gryffindor")
+    secondary = _team(None, id_=2, name="Gryffindor (forum)")
+    requests = FakeRequests()
+    notifications = FakeNotifications()
+    notifier = FakeNotifier()
+    interactor = CreateTeamMergeRequestInteractor(
+        requests=requests,
+        notifications=notifications,
+        team_dao=FakeTeamDao(primary, secondary),
+        superusers=FakeSuperusers({10, 11}),
+        notifier=notifier,
+    )
+    request = await interactor(FakeIdentity(cap), primary_team_id=1, secondary_team_id=2)
+    assert request.type == RequestType.team_merge
+    assert request.team_id == 1
+    assert request.payload["secondary_team_id"] == 2
+    assert notifications.bulk[0]["recipient_ids"] == {10, 11}
+    assert notifications.bulk[0]["request_id"] == request.id
+    assert notifier.created == [request]
+    assert requests.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_create_team_merge_request_only_by_captain() -> None:
+    cap = _player(1, "cap")
+    stranger = _player(9, "stranger")
+    primary = _team(cap, id_=1)
+    interactor = CreateTeamMergeRequestInteractor(
+        requests=FakeRequests(),
+        notifications=FakeNotifications(),
+        team_dao=FakeTeamDao(primary),
+        superusers=FakeSuperusers(set()),
+        notifier=FakeNotifier(),
+    )
+    with pytest.raises(RequestPermissionError):
+        await interactor(FakeIdentity(stranger), primary_team_id=1, secondary_team_id=2)
+
+
+@pytest.mark.asyncio
+async def test_create_player_merge_request_for_self() -> None:
+    player = _player(3, "harry")
+    forum_copy = _player(8, "harry_forum")
+    requests = FakeRequests()
+    notifications = FakeNotifications()
+    interactor = CreatePlayerMergeRequestInteractor(
+        requests=requests,
+        notifications=notifications,
+        player_dao=FakePlayerDao({3: player, 8: forum_copy}),
+        superusers=FakeSuperusers({10}),
+        notifier=FakeNotifier(),
+    )
+    request = await interactor(FakeIdentity(player), secondary_player_id=8)
+    assert request.type == RequestType.player_merge
+    assert request.initiator_id == 3
+    assert request.target_player_id == 3
+    assert request.payload["secondary_player_id"] == 8
+    assert notifications.bulk[0]["recipient_ids"] == {10}
+
+
+@pytest.mark.asyncio
+async def test_create_player_merge_request_for_other_requires_admin() -> None:
+    actor = _player(3, "harry")
+    interactor = CreatePlayerMergeRequestInteractor(
+        requests=FakeRequests(),
+        notifications=FakeNotifications(),
+        player_dao=FakePlayerDao({4: _player(4), 8: _player(8)}),
+        superusers=FakeSuperusers(set()),
+        notifier=FakeNotifier(),
+    )
+    with pytest.raises(NotAuthorizedForAdmin):
+        await interactor(FakeIdentity(actor), secondary_player_id=8, primary_player_id=4)
+    request = await interactor(
+        FakeIdentity(actor, superuser=True), secondary_player_id=8, primary_player_id=4
+    )
+    assert request.target_player_id == 4
+    assert request.initiator_id == 3
+
+
+def _team_merge_request() -> ndto.ActionRequest:
+    return ndto.ActionRequest(
+        id=1,
+        type=RequestType.team_merge,
+        status=RequestStatus.pending,
+        initiator_id=1,
+        team_id=1,
+        created_at=datetime.now(tz=tz_utc),
+        payload={
+            "primary_team_id": 1,
+            "secondary_team_id": 2,
+            "captain_id": 1,
+            "captain_name": "cap",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_accept_team_merge_requires_superuser() -> None:
+    requests = FakeRequests()
+    requests.rows[1] = _team_merge_request()
+    interactor = _accept_interactor(requests)
+    with pytest.raises(NotAuthorizedForAdmin):
+        await interactor(FakeIdentity(_player(2)), request_id=1)
+    assert requests.rows[1].status == RequestStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_accept_team_merge_performs_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    cap = _player(1, "cap")
+    admin = _player(42, "admin")
+    primary = _team(cap, id_=1)
+    secondary = _team(None, id_=2, name="forum copy")
+    requests = FakeRequests()
+    requests.rows[1] = _team_merge_request()
+    merged = []
+
+    async def fake_merge_teams(manager, primary_, secondary_, game_log, dao):
+        merged.append((manager, primary_, secondary_))
+
+    monkeypatch.setattr(request_interactors, "merge_teams", fake_merge_teams)
+    notifications = FakeNotifications()
+    bus = FakeBus()
+    interactor = _accept_interactor(
+        requests,
+        notifications=notifications,
+        team_dao=FakeTeamDao(primary, secondary),
+        player_dao=FakePlayerDao({1: cap}),
+        bus=bus,
+    )
+    updated = await interactor(FakeIdentity(admin, superuser=True), request_id=1)
+    assert updated.status == RequestStatus.accepted
+    assert updated.responder_id == 42
+    assert merged == [(cap, primary, secondary)]
+    assert notifications.created[0]["recipient_id"] == 1
+    assert bus.events == [ActionRequestResolved(request_id=1)]
+
+
+@pytest.mark.asyncio
+async def test_accept_player_merge_performs_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    player = _player(3, "harry")
+    forum_copy = _player(8, "harry_forum")
+    admin = _player(42, "admin")
+    requests = FakeRequests()
+    requests.rows[1] = ndto.ActionRequest(
+        id=1,
+        type=RequestType.player_merge,
+        status=RequestStatus.pending,
+        initiator_id=3,
+        target_player_id=3,
+        created_at=datetime.now(tz=tz_utc),
+        payload={"primary_player_id": 3, "secondary_player_id": 8},
+    )
+    merged = []
+
+    async def fake_merge_players(primary, secondary, game_log, dao):
+        merged.append((primary, secondary))
+
+    monkeypatch.setattr(request_interactors, "merge_players", fake_merge_players)
+    bus = FakeBus()
+    interactor = _accept_interactor(
+        requests, player_dao=FakePlayerDao({3: player, 8: forum_copy}), bus=bus
+    )
+    updated = await interactor(FakeIdentity(admin, superuser=True), request_id=1)
+    assert updated.status == RequestStatus.accepted
+    assert merged == [(player, forum_copy)]
+    assert bus.events == [ActionRequestResolved(request_id=1)]
+
+
+@pytest.mark.asyncio
+async def test_decline_team_merge_requires_superuser() -> None:
+    requests = FakeRequests()
+    requests.rows[1] = _team_merge_request()
+    interactor = DeclineRequestInteractor(
+        requests=requests,
+        notifications=FakeNotifications(),
+        team_dao=SimpleNamespace(),
+        team_player_dao=SimpleNamespace(),
+        bus=FakeBus(),
+    )
+    with pytest.raises(NotAuthorizedForAdmin):
+        await interactor(FakeIdentity(_player(7)), request_id=1)
+    updated = await interactor(FakeIdentity(_player(42), superuser=True), request_id=1)
+    assert updated.status == RequestStatus.declined
+
+
+@pytest.mark.asyncio
+async def test_decline_player_merge_by_its_target() -> None:
+    requests = FakeRequests()
+    requests.rows[1] = ndto.ActionRequest(
+        id=1,
+        type=RequestType.player_merge,
+        status=RequestStatus.pending,
+        initiator_id=42,
+        target_player_id=3,
+        created_at=datetime.now(tz=tz_utc),
+        payload={"primary_player_id": 3, "secondary_player_id": 8},
+    )
+    interactor = DeclineRequestInteractor(
+        requests=requests,
+        notifications=FakeNotifications(),
+        team_dao=SimpleNamespace(),
+        team_player_dao=SimpleNamespace(),
+        bus=FakeBus(),
+    )
+    updated = await interactor(FakeIdentity(_player(3)), request_id=1)
+    assert updated.status == RequestStatus.declined
+
+
+@pytest.mark.asyncio
+async def test_incoming_includes_merges_for_superuser_only() -> None:
+    requests = FakeRequests()
+    requests.rows[1] = _team_merge_request()
+    interactor = ListRequestsInteractor(requests=requests)
+    plain = await interactor.incoming(FakeIdentity(_player(7)))
+    assert plain == []
+    admin = await interactor.incoming(FakeIdentity(_player(42), superuser=True))
+    assert [request.id for request in admin] == [1]

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -20,6 +20,7 @@ from shvatka.core.notifications.request_interactors import (
     AcceptRequestInteractor,
     ListRequestsInteractor,
 )
+from shvatka.core.players.dto import TimelineItem
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.exceptions import (
     NotAuthorizedForAdmin,
@@ -568,8 +569,8 @@ async def test_accept_player_merge_performs_merge(monkeypatch: pytest.MonkeyPatc
     )
     merged = []
 
-    async def fake_merge_players(primary, secondary, game_log, dao):
-        merged.append((primary, secondary))
+    async def fake_merge_players(primary, secondary, game_log, dao, timeline=None):
+        merged.append((primary, secondary, timeline))
 
     monkeypatch.setattr(request_interactors, "merge_players", fake_merge_players)
     bus = FakeBus()
@@ -578,8 +579,38 @@ async def test_accept_player_merge_performs_merge(monkeypatch: pytest.MonkeyPatc
     )
     updated = await interactor(FakeIdentity(admin, superuser=True), request_id=1)
     assert updated.status == RequestStatus.accepted
-    assert merged == [(player, forum_copy)]
+    assert merged == [(player, forum_copy, None)]
     assert bus.events == [ActionRequestResolved(request_id=1)]
+
+
+@pytest.mark.asyncio
+async def test_accept_player_merge_forwards_timeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    player = _player(3, "harry")
+    forum_copy = _player(8, "harry_forum")
+    admin = _player(42, "admin")
+    requests = FakeRequests()
+    requests.rows[1] = ndto.ActionRequest(
+        id=1,
+        type=RequestType.player_merge,
+        status=RequestStatus.pending,
+        initiator_id=3,
+        target_player_id=3,
+        created_at=datetime.now(tz=tz_utc),
+        payload={"primary_player_id": 3, "secondary_player_id": 8},
+    )
+    passed_timelines = []
+
+    async def fake_merge_players(primary, secondary, game_log, dao, timeline=None):
+        passed_timelines.append(timeline)
+
+    monkeypatch.setattr(request_interactors, "merge_players", fake_merge_players)
+    interactor = _accept_interactor(requests, player_dao=FakePlayerDao({3: player, 8: forum_copy}))
+    timeline = [TimelineItem(team_id=1, date_joined=datetime.now(tz=tz_utc))]
+    updated = await interactor(
+        FakeIdentity(admin, superuser=True), request_id=1, timeline=timeline
+    )
+    assert updated.status == RequestStatus.accepted
+    assert passed_timelines == [timeline]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Team/player merge proposals (`shvatka/tgbot/dialogs/merge`) now go through the notification/action-request subsystem instead of bare channel messages with ad-hoc callback buttons.

**New request types** `team_merge` and `player_merge` (no DB migration needed — request type is stored as text):

- **Creation (bot):** the merge dialogs and the `/merge_players` admin command call the new `CreateTeamMergeRequestInteractor` / `CreatePlayerMergeRequestInteractor`. They persist the request, write `team_merge_request` / `player_merge_request` notifications to every superuser (resolved from config tg-ids via the new `ConfigSuperusersResolver`), and post the proposal to the game-log channel with the generic accept/decline keyboard, recording the message via `add_bot_message`.
- **Web view:** `GET /requests?direction=incoming` now includes pending merge requests for superusers (`ListRequestsInteractor` + new quiet `IdentityProvider.is_superuser()`); no new endpoints needed.
- **Web resolve:** `POST /requests/{id}/accept` performs the actual merge (`merge_teams` / `merge_players`), which writes the same game-log entry as the bot flow, and emits `ActionRequestResolved` — deleting the channel message. Decline also cleans up and notifies the initiator. Both are superuser-only for merge types (the player whose account would be merged may decline a merge an admin filed for them).
- **Fixing the timeline from the web:** `POST /requests/{id}/accept` takes an optional body `{"timeline": [...]}` (same shape as `POST /admin/players/merge`). When a plain accept of a `player_merge` request fails with `MergeError` (422, incompatible team histories), the admin can build a corrected timeline in the UI (waiver points via `GET /admin/players/{id}/waiver-points`) and retry the accept — the timeline replaces both histories and is validated against both players' waiver points.
- **Bot resolve:** the channel button goes through the shared `AcceptRequestInteractor` / `DeclineRequestInteractor`, so clicking it resolves the stored request too. `TgBotIdentityProvider` gained `get_superuser`/`is_superuser` backed by `BotConfig.superusers`; non-admins get a polite callback answer.

## Notes

- `ActionResolvedInteractorImpl` moved from the bot-only `DpProvider` to the shared `ContextProvider`, so web-side resolution can delete bot messages in every deployment (this also fixes the previously missing `ActionResolvedInteractor` binding in the standalone API container).
- Legacy `TeamMergeCD`/`PlayerMergeCD` handlers are kept so confirm buttons on messages posted before this change still work; the now-unused legacy keyboard builders were removed.
- Duplicate proposals are idempotent: a pending merge request for the same team/player is returned as-is.

## Testing

- `ruff format --check`, `ruff check`, `mypy` — clean.
- `pytest tests/unit` — 169 passed; added unit coverage for create (captain-only / admin-on-behalf), accept (superuser-only, performs merge, forwards timeline, emits bus event), decline permissions, and superuser request listing.
- Integration suite left to CI (no Docker in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zXr2gbj8WdV1JTutyNh18