### PR TITLE
feat(api): promote players via action requests

### DIFF
--- a/docs/notifications-feature-plan.md
+++ b/docs/notifications-feature-plan.md
@@ -196,6 +196,8 @@ it's testable without the web layer.
   invites a player.
 - `POST /requests/team-join` `{team_id}` — player asks to join.
 - `POST /requests/org-invite` `{game_id, player_id}` — invite an org.
+- `POST /requests/promotion-invite` `{player_id}` — an author invites a player
+  to be promoted to author ("аппрув"); the target accepts to get the rights.
 - `POST /requests/{id}/accept`
 - `POST /requests/{id}/decline`
 - `POST /requests/{id}/cancel` — initiator withdraws.

--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -196,3 +196,8 @@ class TeamJoinRequest:
 class OrgInvite:
     game_id: int
     player_id: int
+
+
+@dataclass
+class PromotionInvite:
+    player_id: int

--- a/shvatka/api/routes/requests.py
+++ b/shvatka/api/routes/requests.py
@@ -9,6 +9,7 @@ from shvatka.core.notifications.request_interactors import (
     CreateTeamJoinInviteInteractor,
     CreateTeamJoinRequestInteractor,
     CreateOrgInviteInteractor,
+    CreatePromotionInviteInteractor,
     AcceptRequestInteractor,
     DeclineRequestInteractor,
     CancelRequestInteractor,
@@ -49,6 +50,16 @@ async def create_org_invite(
     body: Annotated[req.OrgInvite, Body()],
 ) -> responses.ActionRequest:
     request = await interactor(identity=identity, game_id=body.game_id, player_id=body.player_id)
+    return responses.ActionRequest.from_core(request)
+
+
+@inject
+async def create_promotion_invite(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[CreatePromotionInviteInteractor],
+    body: Annotated[req.PromotionInvite, Body()],
+) -> responses.ActionRequest:
+    request = await interactor(identity=identity, player_id=body.player_id)
     return responses.ActionRequest.from_core(request)
 
 
@@ -105,6 +116,7 @@ def setup() -> APIRouter:
     router.add_api_route("/team-join-invite", create_team_join_invite, methods=["POST"])
     router.add_api_route("/team-join", create_team_join_request, methods=["POST"])
     router.add_api_route("/org-invite", create_org_invite, methods=["POST"])
+    router.add_api_route("/promotion-invite", create_promotion_invite, methods=["POST"])
     router.add_api_route("/{id}/accept", accept_request, methods=["POST"])
     router.add_api_route("/{id}/decline", decline_request, methods=["POST"])
     router.add_api_route("/{id}/cancel", cancel_request, methods=["POST"])

--- a/shvatka/core/models/enums/notification.py
+++ b/shvatka/core/models/enums/notification.py
@@ -15,6 +15,7 @@ class NotificationType(enum.Enum):
     org_invite = enum.auto()
     team_merge_request = enum.auto()
     player_merge_request = enum.auto()
+    promotion_invite = enum.auto()
     request_accepted = enum.auto()
     request_declined = enum.auto()
 

--- a/shvatka/core/models/enums/request.py
+++ b/shvatka/core/models/enums/request.py
@@ -14,6 +14,8 @@ class RequestType(enum.Enum):
     """A captain asks admins to merge their team with its forum copy."""
     player_merge = enum.auto()
     """A player asks admins to merge their achievements with a forum copy."""
+    promotion = enum.auto()
+    """An author invites a player to be promoted to author (get "аппрув")."""
 
 
 class RequestStatus(enum.Enum):

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -237,9 +237,7 @@ class CreatePromotionInviteInteractor:
     player_dao: PlayerByIdGetter
     notifier: RequestNotifier
 
-    async def __call__(
-        self, identity: IdentityProvider, player_id: int
-    ) -> ndto.ActionRequest:
+    async def __call__(self, identity: IdentityProvider, player_id: int) -> ndto.ActionRequest:
         author = await identity.get_required_player()
         check_allow_be_author(author)
         target = await self.player_dao.get_by_id(player_id)

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -23,6 +23,7 @@ from shvatka.core.interfaces.dal.complex import TeamMerger
 from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
+    PlayerPromoter,
     TeamJoiner,
     TeamPlayerGetter,
     TeamPlayersGetter,
@@ -42,13 +43,20 @@ from shvatka.core.notifications.adapters import (
 )
 from shvatka.core.players.dto import TimelineItem
 from shvatka.core.players.interfaces import PlayerMerger
-from shvatka.core.players.player import check_can_add_players, join_team, merge_players
+from shvatka.core.players.player import (
+    check_allow_be_author,
+    check_can_add_players,
+    join_team,
+    merge_players,
+    promote,
+)
 from shvatka.core.services.game import get_game
 from shvatka.core.services.organizers import check_allow_manage_orgs, get_orgs
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.core.utils.exceptions import (
     PlayerRestoredInTeam,
+    PromoteError,
     RequestNotPending,
     RequestPermissionError,
 )
@@ -217,6 +225,57 @@ class CreateOrgInviteInteractor:
 
 
 @dataclass
+class CreatePromotionInviteInteractor:
+    """An author invites a player to be promoted to author (get "аппрув").
+
+    The target accepts the request to actually receive author rights, mirroring
+    the inline-invite / confirm flow the bot exposes.
+    """
+
+    requests: RequestStorage
+    notifications: NotificationWriter
+    player_dao: PlayerByIdGetter
+    notifier: RequestNotifier
+
+    async def __call__(
+        self, identity: IdentityProvider, player_id: int
+    ) -> ndto.ActionRequest:
+        author = await identity.get_required_player()
+        check_allow_be_author(author)
+        target = await self.player_dao.get_by_id(player_id)
+        if target.can_be_author:
+            raise PromoteError(text="user already have author rights", player=author)
+        existing = await self.requests.get_pending(
+            type_=RequestType.promotion, target_player_id=target.id
+        )
+        if existing is not None:
+            return existing
+        payload = {
+            "inviter_id": author.id,
+            "inviter_name": author.name_mention,
+            "player_id": target.id,
+            "player_name": target.name_mention,
+        }
+        request = await self.requests.create(
+            type_=RequestType.promotion,
+            initiator_id=author.id,
+            target_player_id=target.id,
+            payload=payload,
+        )
+        await self.notifications.create(
+            recipient_id=target.id,
+            type_=NotificationType.promotion_invite,
+            severity=NotificationSeverity.normal,
+            actor_id=author.id,
+            payload=payload,
+            request_id=request.id,
+        )
+        await self.notifier.notify_created(request)
+        await self.requests.commit()
+        return request
+
+
+@dataclass
 class CreateTeamMergeRequestInteractor:
     """A captain asks the admins to merge their team with its forum copy."""
 
@@ -336,6 +395,7 @@ class AcceptRequestInteractor:
     org_adder: OrgAdder
     team_merger: TeamMerger
     player_merger: PlayerMerger
+    player_promoter: PlayerPromoter
     game_log: GameLogWriter
     team_notifier: TeamNotifier
     org_notifier: OrgNotifier
@@ -369,6 +429,8 @@ class AcceptRequestInteractor:
                 return await self._accept_team_merge(identity, request)
             case RequestType.player_merge:
                 return await self._accept_player_merge(identity, request, timeline)
+            case RequestType.promotion:
+                return await self._accept_promotion(actor, request)
         raise RequestNotPending(player=actor)  # pragma: no cover - exhaustive match
 
     async def _accept_team_join_invite(
@@ -415,6 +477,19 @@ class AcceptRequestInteractor:
         org = await self.org_adder.add_new_org(game, actor)
         await self.requests.commit()
         await self.org_notifier.notify(NewOrg(orgs_list=notify_orgs, game=game, org=org))
+        await self._submit_resolved(updated)
+        return updated
+
+    async def _accept_promotion(
+        self, actor: dto.Player, request: ndto.ActionRequest
+    ) -> ndto.ActionRequest:
+        if request.target_player_id != actor.id:
+            raise RequestPermissionError(player=actor)
+        inviter = await self.player_dao.get_by_id(request.initiator_id)
+        updated = await self._resolve(request, RequestStatus.accepted, actor)
+        await self._notify_initiator(request, NotificationType.request_accepted, actor)
+        # promote commits, taking the resolution and notification along
+        await promote(inviter, actor, self.player_promoter)
         await self._submit_resolved(updated)
         return updated
 

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -44,6 +44,7 @@ from shvatka.core.notifications.request_interactors import (
     CreateTeamJoinInviteInteractor,
     CreateTeamJoinRequestInteractor,
     CreateOrgInviteInteractor,
+    CreatePromotionInviteInteractor,
     CreateTeamMergeRequestInteractor,
     CreatePlayerMergeRequestInteractor,
     AcceptRequestInteractor,
@@ -566,6 +567,21 @@ class RequestProvider(Provider):
         )
 
     @provide
+    def create_promotion_invite(
+        self,
+        dao: HolderDao,
+        requests: RequestStorage,
+        notifications: NotificationWriter,
+        notifier: RequestNotifier,
+    ) -> CreatePromotionInviteInteractor:
+        return CreatePromotionInviteInteractor(
+            requests=requests,
+            notifications=notifications,
+            player_dao=dao.player,
+            notifier=notifier,
+        )
+
+    @provide
     def create_team_merge_request(
         self,
         dao: HolderDao,
@@ -620,6 +636,7 @@ class RequestProvider(Provider):
             org_adder=dao.org_adder,
             team_merger=dao.team_merger,
             player_merger=dao.player_merger,
+            player_promoter=dao.player_promoter,
             game_log=game_log,
             team_notifier=team_notifier,
             org_notifier=org_notifier,

--- a/shvatka/tgbot/views/action_request.py
+++ b/shvatka/tgbot/views/action_request.py
@@ -84,6 +84,11 @@ class BotRequestNotifier(RequestNotifier):
                 author_name = payload.get("author_name", "Автор")
                 game_name = payload.get("game_name", "")
                 return f"{author_name} приглашает вас стать организатором игры {game_name}."
+            case RequestType.promotion:
+                return (
+                    f"{payload.get('inviter_name', 'Игрок')} предлагает наделить вас "
+                    f"полномочиями автора (аппрувом) — для написания игр и создания команд."
+                )
             case RequestType.team_merge:
                 return (
                     f"Капитан {hd.quote(payload.get('captain_name', ''))} "

--- a/tests/integration/api_full/test_notifications.py
+++ b/tests/integration/api_full/test_notifications.py
@@ -155,6 +155,81 @@ async def test_team_join_invite_and_accept(
 
 
 @pytest.mark.asyncio
+async def test_promotion_invite_and_accept(
+    client: AsyncClient,
+    harry: dto.Player,
+    hermione: dto.Player,
+    harry_token: Token,
+    hermione_token: Token,
+    check_dao: HolderDao,
+    bot_session: BaseSession,
+):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
+    ]
+    assert (await check_dao.player.get_by_id(hermione.id)).can_be_author is False
+
+    invite = await client.post(
+        "/requests/promotion-invite",
+        cookies=auth_cookies(harry_token),
+        json={"player_id": hermione.id},
+        follow_redirects=True,
+    )
+    assert invite.is_success
+    invite.read()
+    request_id = invite.json()["id"]
+    assert invite.json()["type"] == "promotion"
+    assert invite.json()["status"] == "pending"
+
+    # hermione sees the invite as incoming
+    incoming = await client.get(
+        "/requests",
+        params={"direction": "incoming", "pending": True},
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    incoming.read()
+    assert request_id in [r["id"] for r in incoming.json()["items"]]
+
+    # hermione accepts -> gets author rights
+    accept = await client.post(
+        f"/requests/{request_id}/accept",
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert accept.is_success
+    accept.read()
+    assert accept.json()["status"] == "accepted"
+
+    assert (await check_dao.player.get_by_id(hermione.id)).can_be_author is True
+
+
+@pytest.mark.asyncio
+async def test_promotion_invite_forbidden_for_non_author(
+    client: AsyncClient,
+    hermione: dto.Player,
+    harry: dto.Player,
+    hermione_token: Token,
+    bot_session: BaseSession,
+):
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        Message(message_id=1, chat=create_tg_chat(), date=datetime.now(tz=tz_utc)),
+    ]
+    # hermione is not an author, so she cannot promote anyone
+    resp = await client.post(
+        "/requests/promotion-invite",
+        cookies=auth_cookies(hermione_token),
+        json={"player_id": harry.id},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422
+    resp.read()
+    assert resp.json()["type"] == "CantBeAuthor"
+
+
+@pytest.mark.asyncio
 async def test_team_join_invite_accept_forbidden_for_stranger(
     client: AsyncClient,
     harry: dto.Player,

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -13,6 +13,7 @@ from shvatka.core.notifications import request_interactors
 from shvatka.core.notifications.request_interactors import (
     CreateTeamJoinInviteInteractor,
     CreateTeamJoinRequestInteractor,
+    CreatePromotionInviteInteractor,
     CreateTeamMergeRequestInteractor,
     CreatePlayerMergeRequestInteractor,
     CancelRequestInteractor,
@@ -23,7 +24,9 @@ from shvatka.core.notifications.request_interactors import (
 from shvatka.core.players.dto import TimelineItem
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.exceptions import (
+    CantBeAuthor,
     NotAuthorizedForAdmin,
+    PromoteError,
     RequestNotPending,
     RequestPermissionError,
 )
@@ -181,6 +184,18 @@ class FakePlayerDao:
 
     async def get_by_id(self, player_id: int) -> dto.Player:
         return self._players[player_id]
+
+
+class FakePromoter:
+    def __init__(self) -> None:
+        self.promoted: list[tuple[int, int]] = []
+        self.commits = 0
+
+    async def promote(self, actor: dto.Player, target: dto.Player) -> None:
+        self.promoted.append((actor.id, target.id))
+
+    async def commit(self) -> None:
+        self.commits += 1
 
 
 class FakeTeamPlayersDao:
@@ -359,6 +374,7 @@ def _accept_interactor(
     notifications: FakeNotifications | None = None,
     team_dao=None,
     player_dao=None,
+    player_promoter=None,
     bus: FakeBus | None = None,
 ) -> AcceptRequestInteractor:
     return AcceptRequestInteractor(
@@ -371,6 +387,7 @@ def _accept_interactor(
         org_adder=SimpleNamespace(),
         team_merger=SimpleNamespace(),
         player_merger=SimpleNamespace(),
+        player_promoter=player_promoter or SimpleNamespace(),
         game_log=SimpleNamespace(),
         team_notifier=SimpleNamespace(),
         org_notifier=SimpleNamespace(),
@@ -408,6 +425,139 @@ async def test_accept_invite_wrong_actor_forbidden() -> None:
     )
     interactor = _accept_interactor(
         requests, team_dao=FakeTeamDao(_team()), player_dao=FakePlayerDao({1: _player(1)})
+    )
+    with pytest.raises(RequestPermissionError):
+        await interactor(FakeIdentity(_player(7)), request_id=1)
+
+
+def _author(id_: int, username: str = "author") -> dto.Player:
+    return dto.Player(id=id_, can_be_author=True, is_dummy=False, username=username)
+
+
+@pytest.mark.asyncio
+async def test_create_promotion_invite() -> None:
+    author = _author(1, "author")
+    target = _player(2, "target")
+    requests = FakeRequests()
+    notifications = FakeNotifications()
+    notifier = FakeNotifier()
+    interactor = CreatePromotionInviteInteractor(
+        requests=requests,
+        notifications=notifications,
+        player_dao=FakePlayerDao({2: target}),
+        notifier=notifier,
+    )
+    request = await interactor(FakeIdentity(author), player_id=2)
+    assert request.type == RequestType.promotion
+    assert request.initiator_id == 1
+    assert request.target_player_id == 2
+    assert requests.commits == 1
+    assert notifications.created[0]["recipient_id"] == 2
+    assert notifications.created[0]["request_id"] == request.id
+    assert notifier.created == [request]
+
+
+@pytest.mark.asyncio
+async def test_create_promotion_invite_requires_author() -> None:
+    not_author = _player(1, "plain")
+    interactor = CreatePromotionInviteInteractor(
+        requests=FakeRequests(),
+        notifications=FakeNotifications(),
+        player_dao=FakePlayerDao({2: _player(2)}),
+        notifier=FakeNotifier(),
+    )
+    with pytest.raises(CantBeAuthor):
+        await interactor(FakeIdentity(not_author), player_id=2)
+
+
+@pytest.mark.asyncio
+async def test_create_promotion_invite_rejects_existing_author() -> None:
+    author = _author(1, "author")
+    interactor = CreatePromotionInviteInteractor(
+        requests=FakeRequests(),
+        notifications=FakeNotifications(),
+        player_dao=FakePlayerDao({2: _author(2, "already")}),
+        notifier=FakeNotifier(),
+    )
+    with pytest.raises(PromoteError):
+        await interactor(FakeIdentity(author), player_id=2)
+
+
+@pytest.mark.asyncio
+async def test_create_promotion_invite_is_idempotent() -> None:
+    author = _author(1, "author")
+    requests = FakeRequests()
+    existing = ndto.ActionRequest(
+        id=77,
+        type=RequestType.promotion,
+        status=RequestStatus.pending,
+        initiator_id=1,
+        target_player_id=2,
+        created_at=datetime.now(tz=tz_utc),
+    )
+    requests.pending = existing
+    notifications = FakeNotifications()
+    interactor = CreatePromotionInviteInteractor(
+        requests=requests,
+        notifications=notifications,
+        player_dao=FakePlayerDao({2: _player(2)}),
+        notifier=FakeNotifier(),
+    )
+    request = await interactor(FakeIdentity(author), player_id=2)
+    assert request.id == 77
+    assert notifications.created == []
+    assert requests.commits == 0
+
+
+@pytest.mark.asyncio
+async def test_accept_promotion_promotes_target() -> None:
+    author = _author(1, "author")
+    target = _player(2, "target")
+    requests = FakeRequests()
+    requests.rows[1] = ndto.ActionRequest(
+        id=1,
+        type=RequestType.promotion,
+        status=RequestStatus.pending,
+        initiator_id=1,
+        target_player_id=2,
+        created_at=datetime.now(tz=tz_utc),
+        payload={"inviter_id": 1, "player_id": 2},
+    )
+    notifications = FakeNotifications()
+    promoter = FakePromoter()
+    bus = FakeBus()
+    interactor = _accept_interactor(
+        requests,
+        notifications=notifications,
+        player_dao=FakePlayerDao({1: author, 2: target}),
+        player_promoter=promoter,
+        bus=bus,
+    )
+    updated = await interactor(FakeIdentity(target), request_id=1)
+    assert updated.status == RequestStatus.accepted
+    assert updated.responder_id == 2
+    assert promoter.promoted == [(1, 2)]
+    assert promoter.commits == 1
+    assert notifications.created[0]["recipient_id"] == 1
+    assert bus.events == [ActionRequestResolved(request_id=1)]
+
+
+@pytest.mark.asyncio
+async def test_accept_promotion_wrong_actor_forbidden() -> None:
+    requests = FakeRequests()
+    requests.rows[1] = ndto.ActionRequest(
+        id=1,
+        type=RequestType.promotion,
+        status=RequestStatus.pending,
+        initiator_id=1,
+        target_player_id=2,
+        created_at=datetime.now(tz=tz_utc),
+        payload={"inviter_id": 1, "player_id": 2},
+    )
+    interactor = _accept_interactor(
+        requests,
+        player_dao=FakePlayerDao({1: _author(1), 2: _player(2)}),
+        player_promoter=FakePromoter(),
     )
     with pytest.raises(RequestPermissionError):
         await interactor(FakeIdentity(_player(7)), request_id=1)


### PR DESCRIPTION
## Summary

Adds a way to promote a player to author ("аппрув" — the right to write games and create teams) **through the API**, using the existing action-requests infrastructure.

Until now, promotion was only reachable via the Telegram inline-invite / confirm flow (`send_promotion_invite` → `agree_promotion`). This wires the same domain operation (`promote()`) into the request lifecycle so it works from the web/API too.

### Flow
1. An author `POST`s `/requests/promotion-invite {player_id}` — creates a pending `promotion` request targeting that player and notifies them.
2. The target `POST`s `/requests/{id}/accept` — runs the existing `promote()` domain service, granting author rights. Resolution + notification + promotion commit together.
3. The target can `decline`; the initiator can `cancel` — no new handling needed, the generic paths already cover a target-scoped request.

## Changes
- **Enums**: `RequestType.promotion`, `NotificationType.promotion_invite` (both stored by name, no migration).
- **Interactor**: `CreatePromotionInviteInteractor` — author-only (`check_allow_be_author`), rejects a target who already has author rights (`PromoteError`), idempotent on an existing pending request. `AcceptRequestInteractor` gains a `promotion` case (`_accept_promotion`) and a `player_promoter` dependency.
- **API**: `req.PromotionInvite`, route `POST /requests/promotion-invite`.
- **Bot**: rendering for the new request type in `BotRequestNotifier`.
- **DI**: provide the new interactor and the `player_promoter` for accept.
- **Docs**: endpoint listed in the notifications feature plan.

## Testing
- Unit tests (`tests/unit/services/request_interactors_test.py`): create (happy path, non-author forbidden, already-author rejected, idempotent) and accept (promotes target, wrong-actor forbidden). All unit tests pass (`175 passed`).
- API integration tests (`tests/integration/api_full/test_notifications.py`): full invite→accept promotion flow and the non-author 422 case. Written to match the existing suite; they require Docker/testcontainers, which is unavailable in the CI sandbox used here.
- `ruff` and `mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01691Gmgy6SCTckeuRpjWags)_