### PR TITLE
Ignore "message is not modified" errors globally

### DIFF
--- a/shvatka/tgbot/handlers/errors.py
+++ b/shvatka/tgbot/handlers/errors.py
@@ -4,7 +4,7 @@ import typing
 from functools import partial
 
 from aiogram import Dispatcher, Bot
-from aiogram.exceptions import AiogramError
+from aiogram.exceptions import AiogramError, TelegramBadRequest
 from aiogram.filters import ExceptionTypeFilter
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.types.error_event import ErrorEvent
@@ -14,6 +14,21 @@ from aiogram_dialog.api.exceptions import UnknownIntent
 from shvatka.core.utils.exceptions import SHError
 
 logger = logging.getLogger(__name__)
+
+MESSAGE_IS_NOT_MODIFIED = "message is not modified"
+
+
+def is_message_not_modified(error: ErrorEvent) -> bool:
+    exception = error.exception
+    return (
+        isinstance(exception, TelegramBadRequest) and MESSAGE_IS_NOT_MODIFIED in exception.message
+    )
+
+
+async def ignore_message_not_modified(error: ErrorEvent) -> None:
+    logger.debug("Ignoring %s", error.exception)
+    if c := error.update.callback_query:
+        await c.answer()
 
 
 async def handle_sh_error(error: ErrorEvent, log_chat_id: int, bot: Bot):
@@ -72,4 +87,5 @@ def setup(dp: Dispatcher, log_chat_id: int):
         partial(handle_sh_error, log_chat_id=log_chat_id), ExceptionTypeFilter(SHError)
     )
     dp.errors.register(clear_unknown_intent, ExceptionTypeFilter(UnknownIntent))
+    dp.errors.register(ignore_message_not_modified, is_message_not_modified)
     dp.errors.register(partial(handle, log_chat_id=log_chat_id))


### PR DESCRIPTION
## Summary

- Fixes #149: pressing a waiver poll vote button when the vote wouldn't change the poll message text/markup (e.g. re-clicking the same vote) made `CallbackQuery.message.edit_text` raise `TelegramBadRequest: message is not modified`.
- This exception was previously falling through to the generic error handler in `shvatka/tgbot/handlers/errors.py`, which logs it as an unexpected exception and forwards it to the admin log chat — noisy and not actionable.
- Added a dedicated error handler (`is_message_not_modified` filter + `ignore_message_not_modified` handler) registered on the dispatcher that answers the callback query and swallows this specific error at debug level, without logging it as an exception or notifying admins.

This is a global fix in the error-handling pipeline, so it also covers other places in the bot that call `edit_text`/`edit_message_text` and could hit the same race, not just the waiver poll.

## Test plan

- [x] `ruff format --check` / `ruff check` pass on the changed file
- [x] `mypy` passes on the changed file
- [x] `pytest tests/unit` passes (201 passed)
- [ ] Manual check: rapidly press the same waiver vote button twice in a Telegram chat and confirm no error is logged/sent to the admin log chat


---
_Generated by [Claude Code](https://claude.ai/code/session_01CiUkYie5436XUAUsUJkkhS)_