### PR TITLE
Count key and timer bonuses into game results

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,8 +265,10 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   rather than using `logger.exception(...)` or `exc_info=True`. Being explicit
   keeps the logged exception independent of the active `except` block and lets
   you choose the log level.
-- Some docstrings/comments are in Russian — that's expected; keep the existing
-  language of the file you're editing.
+- **Write comments and docstrings in English.** Some older ones are in Russian —
+  that's expected, and there's no need to translate them when you touch a file —
+  but anything you add should be English. User-facing strings (bot replies,
+  Excel report headers, etc.) stay Russian.
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -6,7 +6,14 @@ from uuid import UUID
 
 from adaptix import Retort
 
-from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole, Event
+from shvatka.core.games.dto import (
+    CurrentHintsAndKeys,
+    MyRole,
+    Event,
+    BonusSource,
+    GameStatWithBonuses,
+    BonusEvent as CoreBonusEvent,
+)
 from shvatka.core.models import dto, enums
 from shvatka.core.notifications.dto import (
     Notification as NotificationDto,
@@ -586,18 +593,48 @@ class LevelTime:
         )
 
 
+@dataclass(kw_only=True, frozen=True, slots=True)
+class BonusEvent:
+    """Бонус (minutes > 0) или штраф (minutes < 0), полученный командой."""
+
+    at: datetime
+    minutes: float
+    source: BonusSource
+    key: str | None
+    level_time_id: int | None
+    level_number: int | None
+    """Уровень, на котором получен. None — определить не удалось, учитывать только в итоге."""
+
+    @classmethod
+    def from_core(cls, core: CoreBonusEvent) -> "BonusEvent":
+        return cls(
+            at=core.at,
+            minutes=core.minutes,
+            source=core.source,
+            key=core.key,
+            level_time_id=core.level_time_id,
+            level_number=core.level_number,
+        )
+
+
 @dataclass
 class GameStat:
     level_times: dict[int, list[LevelTime]]
+    bonuses: dict[int, list[BonusEvent]]
+    """{team_id: [...]} — только команды, у которых бонусы есть."""
 
     @classmethod
-    def from_core(cls, core: dto.GameStatWithHints | None):
+    def from_core(cls, core: GameStatWithBonuses | None):
         if core is None:
             return None
         return cls(
             level_times={
                 team.id: [LevelTime.from_core(lt) for lt in lts]
                 for team, lts in core.level_times.items()
+            },
+            bonuses={
+                team_id: [BonusEvent.from_core(bonus) for bonus in bonuses]
+                for team_id, bonuses in core.bonuses.items()
             },
         )
 

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -595,21 +595,27 @@ class LevelTime:
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class BonusEvent:
-    """Бонус (minutes > 0) или штраф (minutes < 0), полученный командой."""
+    """An event that changed a team's time, with the whole effects that caused it.
+
+    The bonus itself is ``effects.bonus_minutes``: positive is a bonus, negative
+    a penalty. Only events that carry bonus minutes are returned.
+    """
 
     at: datetime
-    minutes: float
+    effects: Effects
     source: BonusSource
     key: str | None
     level_time_id: int | None
     level_number: int | None
-    """Уровень, на котором получен. None — определить не удалось, учитывать только в итоге."""
+    """Level it was earned on. None when unresolved — then count it in the total only."""
 
     @classmethod
-    def from_core(cls, core: CoreBonusEvent) -> "BonusEvent":
+    def from_core(
+        cls, core: CoreBonusEvent, level_numbers_by_name_id: Mapping[str, int]
+    ) -> "BonusEvent":
         return cls(
             at=core.at,
-            minutes=core.minutes,
+            effects=Effects.from_core(core.effects, level_numbers_by_name_id),
             source=core.source,
             key=core.key,
             level_time_id=core.level_time_id,
@@ -621,7 +627,7 @@ class BonusEvent:
 class GameStat:
     level_times: dict[int, list[LevelTime]]
     bonuses: dict[int, list[BonusEvent]]
-    """{team_id: [...]} — только команды, у которых бонусы есть."""
+    """{team_id: [...]} — only teams that actually have bonuses."""
 
     @classmethod
     def from_core(cls, core: GameStatWithBonuses | None):
@@ -633,7 +639,9 @@ class GameStat:
                 for team, lts in core.level_times.items()
             },
             bonuses={
-                team_id: [BonusEvent.from_core(bonus) for bonus in bonuses]
+                team_id: [
+                    BonusEvent.from_core(bonus, core.level_numbers_by_name_id) for bonus in bonuses
+                ]
                 for team_id, bonuses in core.bonuses.items()
             },
         )

--- a/shvatka/api/models/responses.py
+++ b/shvatka/api/models/responses.py
@@ -515,6 +515,13 @@ class KeyTime:
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class Effects:
+    """Effects addressing ``next_level`` by number, hiding the level's name_id.
+
+    For endpoints a playing team can read, where a name_id would leak part of
+    the scenario. Resolving it needs the game's levels — see
+    ``EffectsWithNameId`` for the places that don't have to hide anything.
+    """
+
     id: UUID
     hints_: Sequence[hints.AnyHint]
     bonus_minutes: float
@@ -536,6 +543,33 @@ class Effects:
                 if core.next_level is not None
                 else None
             ),
+        )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class EffectsWithNameId:
+    """Effects as stored, addressing ``next_level`` by the level's name_id.
+
+    For endpoints where name_ids are not secret anyway — game results, readable
+    only by orgs until the game is complete, and already carrying level name_ids
+    in ``LevelTime``. Needs no level mapping, so no extra query.
+    """
+
+    id: UUID
+    hints_: Sequence[hints.AnyHint]
+    bonus_minutes: float
+    level_up: bool
+    next_level: str | None
+    """name_id of the level the key routes to."""
+
+    @classmethod
+    def from_core(cls, core: action.Effects) -> "EffectsWithNameId":
+        return cls(
+            id=core.id,
+            hints_=core.hints_,
+            bonus_minutes=core.bonus_minutes,
+            level_up=core.level_up,
+            next_level=core.next_level,
         )
 
 
@@ -602,7 +636,7 @@ class BonusEvent:
     """
 
     at: datetime
-    effects: Effects
+    effects: EffectsWithNameId
     source: BonusSource
     key: str | None
     level_time_id: int | None
@@ -610,12 +644,10 @@ class BonusEvent:
     """Level it was earned on. None when unresolved — then count it in the total only."""
 
     @classmethod
-    def from_core(
-        cls, core: CoreBonusEvent, level_numbers_by_name_id: Mapping[str, int]
-    ) -> "BonusEvent":
+    def from_core(cls, core: CoreBonusEvent) -> "BonusEvent":
         return cls(
             at=core.at,
-            effects=Effects.from_core(core.effects, level_numbers_by_name_id),
+            effects=EffectsWithNameId.from_core(core.effects),
             source=core.source,
             key=core.key,
             level_time_id=core.level_time_id,
@@ -639,9 +671,7 @@ class GameStat:
                 for team, lts in core.level_times.items()
             },
             bonuses={
-                team_id: [
-                    BonusEvent.from_core(bonus, core.level_numbers_by_name_id) for bonus in bonuses
-                ]
+                team_id: [BonusEvent.from_core(bonus) for bonus in bonuses]
                 for team_id, bonuses in core.bonuses.items()
             },
         )

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from shvatka.core.games.dto import CurrentHintsOnly, Event
+from shvatka.core.games.dto import BonusEvent, CurrentHintsOnly, Event
 from shvatka.core.interfaces.dal.complex import GameScenarioEditor, TypedKeyGetter, GameStatDao
 from shvatka.core.interfaces.dal.file_info import FileInfoGetter
 from shvatka.core.interfaces.dal.game import GameAuthorTransferer, GameByIdGetter
@@ -34,7 +34,13 @@ class AdminGameScenarioEditor(GameScenarioEditor, GameAuthorTransferer, Protocol
         raise NotImplementedError
 
 
-class GameStatReader(GameStatDao, GameByIdGetter, PlayerByUserGetter, Protocol):
+class GameBonusesGetter(Protocol):
+    async def get_game_bonuses_by_teams(self, game: dto.Game) -> dict[int, list[BonusEvent]]:
+        """Бонусы и штрафы всех команд за игру, сгруппированные по id команды."""
+        raise NotImplementedError
+
+
+class GameStatReader(GameStatDao, GameBonusesGetter, GameByIdGetter, PlayerByUserGetter, Protocol):
     pass
 
 

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -36,7 +36,7 @@ class AdminGameScenarioEditor(GameScenarioEditor, GameAuthorTransferer, Protocol
 
 class GameBonusesGetter(Protocol):
     async def get_game_bonuses_by_teams(self, game: dto.Game) -> dict[int, list[BonusEvent]]:
-        """Бонусы и штрафы всех команд за игру, сгруппированные по id команды."""
+        """All teams' bonuses and penalties for the game, grouped by team id."""
         raise NotImplementedError
 
 

--- a/shvatka/core/games/dto.py
+++ b/shvatka/core/games/dto.py
@@ -18,7 +18,7 @@ class Event:
 
 
 class BonusSource(enum.StrEnum):
-    """Что именно принесло команде бонус (или штраф)."""
+    """What brought the team a bonus (or a penalty)."""
 
     key = enum.auto()
     timer = enum.auto()
@@ -27,14 +27,17 @@ class BonusSource(enum.StrEnum):
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class BonusEvent:
-    """Одно событие, изменившее время команды: бонус (>0) или штраф (<0).
+    """An event that changed a team's time: bonus (>0 minutes) or penalty (<0).
 
-    ``level_time_id`` в БД nullable, поэтому уровень может остаться нерешённым —
-    тогда ``level_number`` равен None и бонус учитывается только в итоге.
+    Carries the whole ``effects`` rather than just its bonus minutes, so new
+    kinds of effect become visible to clients without an API change.
+
+    ``level_time_id`` is nullable in the DB, so the level may stay unresolved —
+    then ``level_number`` is None and the bonus only counts towards the total.
     """
 
     at: datetime
-    minutes: float
+    effects: action.Effects
     source: BonusSource
     key: action.SHKey | None
     level_time_id: int | None
@@ -43,7 +46,7 @@ class BonusEvent:
     def with_level_number(self, level_number: int | None) -> "BonusEvent":
         return BonusEvent(
             at=self.at,
-            minutes=self.minutes,
+            effects=self.effects,
             source=self.source,
             key=self.key,
             level_time_id=self.level_time_id,
@@ -51,22 +54,28 @@ class BonusEvent:
         )
 
     @property
+    def minutes(self) -> float:
+        return self.effects.bonus_minutes
+
+    @property
     def td(self) -> timedelta:
-        """Сколько времени бонус снимает с результата (штраф — отрицательный)."""
+        """How much time the bonus takes off the result (a penalty is negative)."""
         return timedelta(minutes=self.minutes)
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class GameStatWithBonuses:
-    """Статистика игры вместе с бонусами и штрафами команд.
+    """Game stat together with the teams' bonuses and penalties.
 
-    Скорректированные времена здесь не считаются: отдаём исходные времена и
-    сами бонусы, чтобы клиент мог переключать режимы отображения без запросов.
+    Adjusted times are not computed here: we hand out the raw times and the
+    bonuses themselves, so a client can switch display modes without requests.
     """
 
     level_times: dict[dto.Team, list[dto.LevelTimeOnGame]]
     bonuses: dict[int, list[BonusEvent]]
-    """{team_id: [...]} — только команды, у которых бонусы есть."""
+    """{team_id: [...]} — only teams that actually have bonuses."""
+    level_numbers_by_name_id: dict[str, int]
+    """Mapping of level name_id to its number_in_game, used to resolve effects' next_level."""
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)

--- a/shvatka/core/games/dto.py
+++ b/shvatka/core/games/dto.py
@@ -74,8 +74,6 @@ class GameStatWithBonuses:
     level_times: dict[dto.Team, list[dto.LevelTimeOnGame]]
     bonuses: dict[int, list[BonusEvent]]
     """{team_id: [...]} — only teams that actually have bonuses."""
-    level_numbers_by_name_id: dict[str, int]
-    """Mapping of level name_id to its number_in_game, used to resolve effects' next_level."""
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)

--- a/shvatka/core/games/dto.py
+++ b/shvatka/core/games/dto.py
@@ -1,5 +1,6 @@
+import enum
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from shvatka.core.models import dto, enums
@@ -14,6 +15,58 @@ class Event:
     effects: action.Effects
     key: action.SHKey | None = None
     is_timer: bool
+
+
+class BonusSource(enum.StrEnum):
+    """Что именно принесло команде бонус (или штраф)."""
+
+    key = enum.auto()
+    timer = enum.auto()
+    unknown = enum.auto()
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class BonusEvent:
+    """Одно событие, изменившее время команды: бонус (>0) или штраф (<0).
+
+    ``level_time_id`` в БД nullable, поэтому уровень может остаться нерешённым —
+    тогда ``level_number`` равен None и бонус учитывается только в итоге.
+    """
+
+    at: datetime
+    minutes: float
+    source: BonusSource
+    key: action.SHKey | None
+    level_time_id: int | None
+    level_number: int | None = None
+
+    def with_level_number(self, level_number: int | None) -> "BonusEvent":
+        return BonusEvent(
+            at=self.at,
+            minutes=self.minutes,
+            source=self.source,
+            key=self.key,
+            level_time_id=self.level_time_id,
+            level_number=level_number,
+        )
+
+    @property
+    def td(self) -> timedelta:
+        """Сколько времени бонус снимает с результата (штраф — отрицательный)."""
+        return timedelta(minutes=self.minutes)
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class GameStatWithBonuses:
+    """Статистика игры вместе с бонусами и штрафами команд.
+
+    Скорректированные времена здесь не считаются: отдаём исходные времена и
+    сами бонусы, чтобы клиент мог переключать режимы отображения без запросов.
+    """
+
+    level_times: dict[dto.Team, list[dto.LevelTimeOnGame]]
+    bonuses: dict[int, list[BonusEvent]]
+    """{team_id: [...]} — только команды, у которых бонусы есть."""
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -69,12 +69,16 @@ class GameStatReaderInteractor:
         game = await self.dao.get_by_id(game_id)
         stat = await get_game_stat_with_hints(game, player, self.dao)
         bonuses = await self.dao.get_game_bonuses_by_teams(game)
+        full_game = await self.dao.add_levels(game)
         return GameStatWithBonuses(
             level_times=stat.level_times,
             bonuses={
                 team.id: resolve_bonus_levels(lts, bonuses[team.id])
                 for team, lts in stat.level_times.items()
                 if bonuses.get(team.id)
+            },
+            level_numbers_by_name_id={
+                level.name_id: level.number_in_game for level in full_game.levels
             },
         )
 

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -3,9 +3,9 @@ import typing
 from dataclasses import dataclass
 from datetime import datetime
 
-from shvatka.core.games.dto import CurrentHintsAndKeys, MyRole
+from shvatka.core.games.dto import CurrentHintsAndKeys, GameStatWithBonuses, MyRole
 from shvatka.core.games.game_play import schedule_first_hint
-from shvatka.core.games.results import build_results_table
+from shvatka.core.games.results import build_results_table, resolve_bonus_levels
 from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.interfaces.printer import TablePrinter
 from shvatka.core.games.adapters import (
@@ -64,10 +64,19 @@ class GameStatReaderInteractor:
     def __init__(self, dao: GameStatReader):
         self.dao = dao
 
-    async def __call__(self, game_id: int, identity: IdentityProvider) -> dto.GameStatWithHints:
+    async def __call__(self, game_id: int, identity: IdentityProvider) -> GameStatWithBonuses:
         player = await identity.get_required_player()
         game = await self.dao.get_by_id(game_id)
-        return await get_game_stat_with_hints(game, player, self.dao)
+        stat = await get_game_stat_with_hints(game, player, self.dao)
+        bonuses = await self.dao.get_game_bonuses_by_teams(game)
+        return GameStatWithBonuses(
+            level_times=stat.level_times,
+            bonuses={
+                team.id: resolve_bonus_levels(lts, bonuses[team.id])
+                for team, lts in stat.level_times.items()
+                if bonuses.get(team.id)
+            },
+        )
 
 
 class GameResultsFileInteractor:
@@ -78,7 +87,8 @@ class GameResultsFileInteractor:
     async def __call__(self, game_id: int, identity: IdentityProvider) -> typing.BinaryIO:
         game = await self.dao.get_full(game_id)
         game_stat = await get_game_stat(game, identity, self.dao)
-        return self.printer.print_table(build_results_table(game, game_stat))
+        bonuses = await self.dao.get_game_bonuses_by_teams(game)
+        return self.printer.print_table(build_results_table(game, game_stat, bonuses))
 
 
 class GameFileReaderInteractor:

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -69,16 +69,12 @@ class GameStatReaderInteractor:
         game = await self.dao.get_by_id(game_id)
         stat = await get_game_stat_with_hints(game, player, self.dao)
         bonuses = await self.dao.get_game_bonuses_by_teams(game)
-        full_game = await self.dao.add_levels(game)
         return GameStatWithBonuses(
             level_times=stat.level_times,
             bonuses={
                 team.id: resolve_bonus_levels(lts, bonuses[team.id])
                 for team, lts in stat.level_times.items()
                 if bonuses.get(team.id)
-            },
-            level_numbers_by_name_id={
-                level.name_id: level.number_in_game for level in full_game.levels
             },
         )
 

--- a/shvatka/core/games/results.py
+++ b/shvatka/core/games/results.py
@@ -37,17 +37,17 @@ class TeamLevels(typing.NamedTuple):
     levels_times: dict[int, list[LevelTime]]
     levels_timedelta: dict[int, list[LevelTimedelta]]
     bonuses: dict[int | None, list[BonusEvent]]
-    """Бонусы и штрафы, разложенные по номеру уровня. Ключ None — уровень не определён."""
+    """Bonuses and penalties routed by level number. The None key means level unknown."""
 
     def get_level_bonus(self, level_number: int) -> timedelta:
-        """Суммарный бонус (штраф — отрицательный) за один уровень."""
+        """Total bonus for a single level (a penalty is negative)."""
         return sum(
             (be.td for be in self.bonuses.get(level_number, [])),
             start=timedelta(seconds=0),
         )
 
     def get_total_bonus(self) -> timedelta:
-        """Суммарный бонус за всю игру, включая события без определённого уровня."""
+        """Total bonus for the whole game, including events with no resolved level."""
         return sum(
             (be.td for bes in self.bonuses.values() for be in bes),
             start=timedelta(seconds=0),
@@ -142,10 +142,10 @@ def _add_bonuses_part(
     results: Results,
     start_row: int,
 ) -> None:
-    """Блок с бонусами и штрафами в минутах: команда × уровень плюс итог.
+    """Block of bonuses and penalties in minutes: team x level plus a total.
 
-    Сами скорректированные времена не считаем — в файле даём исходные данные,
-    чтобы их можно было посчитать в самом Excel.
+    Adjusted times are not computed — the file carries the raw numbers so they
+    can be worked out in Excel itself.
     """
     if not any(team_levels.bonuses for team_levels in results.data):
         return
@@ -196,12 +196,12 @@ def resolve_bonus_levels(
     level_times: typing.Sequence[dto.LevelTime],
     bonuses: typing.Iterable[BonusEvent],
 ) -> list[BonusEvent]:
-    """Проставить каждому бонусу номер уровня, на котором он получен.
+    """Set on each bonus the number of the level it was earned on.
 
-    Уровень берётся из ``level_time_id`` события. Если его нет (колонка nullable),
-    уровень определяется по времени события: тот, на котором команда была в момент
-    ``at``. Что определить не удалось — остаётся с ``level_number=None`` и
-    учитывается только в итоге.
+    The level comes from the event's ``level_time_id``. When that is missing (the
+    column is nullable), the level is resolved by the event's time: the one the
+    team was on at ``at``. What cannot be resolved keeps ``level_number=None``
+    and only counts towards the total.
     """
     levels_by_time_id = {lt.id: lt.level_number for lt in level_times}
     result = []
@@ -219,7 +219,7 @@ def route_bonuses(
     level_times: typing.Sequence[dto.LevelTime],
     bonuses: typing.Iterable[BonusEvent],
 ) -> dict[int | None, list[BonusEvent]]:
-    """Разложить бонусы команды по номерам уровней. Ключ None — уровень не определён."""
+    """Route a team's bonuses by level number. The None key means level unknown."""
     routed: dict[int | None, list[BonusEvent]] = {}
     for bonus in resolve_bonus_levels(level_times, bonuses):
         routed.setdefault(bonus.level_number, []).append(bonus)
@@ -229,7 +229,7 @@ def route_bonuses(
 def _resolve_level_by_time(
     level_times: typing.Sequence[dto.LevelTime], at: datetime
 ) -> int | None:
-    """Найти уровень, на котором команда была в момент ``at``."""
+    """Find the level the team was on at ``at``."""
     ordered = sorted(level_times, key=lambda lt: lt.start_at)
     result = None
     for lt in ordered:

--- a/shvatka/core/games/results.py
+++ b/shvatka/core/games/results.py
@@ -2,6 +2,7 @@ import typing
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+from shvatka.core.games.dto import BonusEvent
 from shvatka.core.models import dto
 from shvatka.core.utils.datetime_utils import trim_tz
 from shvatka.core.utils.exceptions import GameNotFinished
@@ -15,6 +16,8 @@ from shvatka.core.interfaces.printer import (
 
 FIRST_TEAM_NAME = CellAddress(row=3, column=1)
 GAME_NAME = CellAddress(row=1, column=1)
+BONUSES_TITLE = "Бонусы, мин"
+TOTAL_TITLE = "Итого"
 
 
 class LevelTime(typing.NamedTuple):
@@ -33,6 +36,22 @@ class TeamLevels(typing.NamedTuple):
     team: dto.Team
     levels_times: dict[int, list[LevelTime]]
     levels_timedelta: dict[int, list[LevelTimedelta]]
+    bonuses: dict[int | None, list[BonusEvent]]
+    """Бонусы и штрафы, разложенные по номеру уровня. Ключ None — уровень не определён."""
+
+    def get_level_bonus(self, level_number: int) -> timedelta:
+        """Суммарный бонус (штраф — отрицательный) за один уровень."""
+        return sum(
+            (be.td for be in self.bonuses.get(level_number, [])),
+            start=timedelta(seconds=0),
+        )
+
+    def get_total_bonus(self) -> timedelta:
+        """Суммарный бонус за всю игру, включая события без определённого уровня."""
+        return sum(
+            (be.td for bes in self.bonuses.values() for be in bes),
+            start=timedelta(seconds=0),
+        )
 
     def get_level_time(self, level_number: int) -> LevelTime | None:
         min_time = datetime.max
@@ -58,10 +77,14 @@ class Results:
     game_stat: dto.GameStat
 
 
-def build_results_table(game: dto.FullGame, game_stat: dto.GameStat) -> Table:
+def build_results_table(
+    game: dto.FullGame,
+    game_stat: dto.GameStat,
+    bonuses: dict[int, list[BonusEvent]] | None = None,
+) -> Table:
     if not (game.is_complete() or game.is_finished()):
         raise GameNotFinished
-    return results_to_table_routed(game, to_results(game_stat))
+    return results_to_table_routed(game, to_results(game_stat, bonuses))
 
 
 def results_to_table_routed(game: dto.FullGame, results: Results) -> Table:  # noqa: C901
@@ -109,11 +132,51 @@ def results_to_table_routed(game: dto.FullGame, results: Results) -> Table:  # n
             table[FIRST_TEAM_NAME.shift(rows=i * 2 + third_part_start, columns=j)] = Cell(
                 value=lt.level_number + 1
             )
+    _add_bonuses_part(table, game, results, start_row=i * 2 + third_part_start + 3)
     return Table(fields=table)
 
 
-def to_results(game_stat: dto.GameStat) -> Results:
+def _add_bonuses_part(
+    table: dict[CellAddress, Cell],
+    game: dto.FullGame,
+    results: Results,
+    start_row: int,
+) -> None:
+    """Блок с бонусами и штрафами в минутах: команда × уровень плюс итог.
+
+    Сами скорректированные времена не считаем — в файле даём исходные данные,
+    чтобы их можно было посчитать в самом Excel.
+    """
+    if not any(team_levels.bonuses for team_levels in results.data):
+        return
+    total_column = len(game.levels) + 1
+    table[FIRST_TEAM_NAME.shift(rows=start_row - 1, columns=0)] = Cell(value=BONUSES_TITLE)
+    for level in game.levels:
+        table[FIRST_TEAM_NAME.shift(rows=start_row - 1, columns=level.number_in_game + 1)] = Cell(
+            value=level.number_in_game + 1
+        )
+    table[FIRST_TEAM_NAME.shift(rows=start_row - 1, columns=total_column)] = Cell(
+        value=TOTAL_TITLE
+    )
+    for i, team_levels in enumerate(results.data, start_row):
+        table[FIRST_TEAM_NAME.shift(rows=i, columns=0)] = Cell(value=team_levels.team.name)
+        for level_number, bonus_events in team_levels.bonuses.items():
+            if level_number is None:
+                continue
+            table[FIRST_TEAM_NAME.shift(rows=i, columns=level_number + 1)] = Cell(
+                value=sum(be.minutes for be in bonus_events)
+            )
+        table[FIRST_TEAM_NAME.shift(rows=i, columns=total_column)] = Cell(
+            value=team_levels.get_total_bonus().total_seconds() / 60
+        )
+
+
+def to_results(
+    game_stat: dto.GameStat,
+    bonuses: dict[int, list[BonusEvent]] | None = None,
+) -> Results:
     result = []
+    bonuses = bonuses or {}
     for team, lts in game_stat.level_times.items():
         levels_times = [LevelTime(lt.level_number, trim_tz(lt.start_at)) for lt in lts]
         routed_lt: dict[int, list[LevelTime]] = {}
@@ -123,5 +186,54 @@ def to_results(game_stat: dto.GameStat) -> Results:
         for previous, current in zip(levels_times[:-1], levels_times[1:]):  # type: LevelTime, LevelTime
             td = current.time - previous.time
             routed_ltd.setdefault(previous.level, []).append(LevelTimedelta(previous.level, td))
-        result.append(TeamLevels(team, routed_lt, routed_ltd))
+        result.append(
+            TeamLevels(team, routed_lt, routed_ltd, route_bonuses(lts, bonuses.get(team.id, [])))
+        )
     return Results(data=result, game_stat=game_stat)
+
+
+def resolve_bonus_levels(
+    level_times: typing.Sequence[dto.LevelTime],
+    bonuses: typing.Iterable[BonusEvent],
+) -> list[BonusEvent]:
+    """Проставить каждому бонусу номер уровня, на котором он получен.
+
+    Уровень берётся из ``level_time_id`` события. Если его нет (колонка nullable),
+    уровень определяется по времени события: тот, на котором команда была в момент
+    ``at``. Что определить не удалось — остаётся с ``level_number=None`` и
+    учитывается только в итоге.
+    """
+    levels_by_time_id = {lt.id: lt.level_number for lt in level_times}
+    result = []
+    for bonus in bonuses:
+        level_number = (
+            levels_by_time_id.get(bonus.level_time_id) if bonus.level_time_id is not None else None
+        )
+        if level_number is None:
+            level_number = _resolve_level_by_time(level_times, bonus.at)
+        result.append(bonus.with_level_number(level_number))
+    return result
+
+
+def route_bonuses(
+    level_times: typing.Sequence[dto.LevelTime],
+    bonuses: typing.Iterable[BonusEvent],
+) -> dict[int | None, list[BonusEvent]]:
+    """Разложить бонусы команды по номерам уровней. Ключ None — уровень не определён."""
+    routed: dict[int | None, list[BonusEvent]] = {}
+    for bonus in resolve_bonus_levels(level_times, bonuses):
+        routed.setdefault(bonus.level_number, []).append(bonus)
+    return routed
+
+
+def _resolve_level_by_time(
+    level_times: typing.Sequence[dto.LevelTime], at: datetime
+) -> int | None:
+    """Найти уровень, на котором команда была в момент ``at``."""
+    ordered = sorted(level_times, key=lambda lt: lt.start_at)
+    result = None
+    for lt in ordered:
+        if lt.start_at > at:
+            break
+        result = lt.level_number
+    return result

--- a/shvatka/core/interfaces/printer.py
+++ b/shvatka/core/interfaces/printer.py
@@ -20,7 +20,7 @@ class CellAddress:
 
 @dataclass(kw_only=True)
 class Cell:
-    value: str | datetime | int | time
+    value: str | datetime | int | float | time
     format: str | None = None
 
 

--- a/shvatka/infrastructure/db/dao/complex/level_times.py
+++ b/shvatka/infrastructure/db/dao/complex/level_times.py
@@ -2,6 +2,7 @@ import typing
 from dataclasses import dataclass
 
 from shvatka.core.games.adapters import GameStatReader
+from shvatka.core.games.dto import BonusEvent
 from shvatka.core.interfaces.dal.complex import GameStatDao
 from shvatka.core.models import dto
 
@@ -74,6 +75,9 @@ class GameStatReaderImpl(GameStatReader):
         self, game: dto.FullGame
     ) -> dict[dto.Team, list[dto.LevelTimeOnGame]]:
         return await self.dao.level_time.get_game_level_times_with_hints(game)
+
+    async def get_game_bonuses_by_teams(self, game: dto.Game) -> dict[int, list[BonusEvent]]:
+        return await self.dao.events.get_game_bonuses_by_teams(game)
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return await self.dao.game.get_by_id(id_, author)

--- a/shvatka/infrastructure/db/dao/rdb/events.py
+++ b/shvatka/infrastructure/db/dao/rdb/events.py
@@ -5,7 +5,7 @@ from sqlalchemy import select, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from shvatka.core.games.dto import Event
+from shvatka.core.games.dto import BonusEvent, BonusSource, Event
 from shvatka.core.models import dto
 from shvatka.core.models.dto import action
 from shvatka.core.utils.datetime_utils import tz_utc
@@ -64,6 +64,41 @@ class GameEventDao(BaseDAO[models.GameEvent]):
             .order_by(models.GameEvent.at.desc())
         )
         return [self.map_to_event(event) for event in result.all()]
+
+    async def get_game_bonuses_by_teams(self, game: dto.Game) -> dict[int, list[BonusEvent]]:
+        """Бонусы и штрафы всех команд за игру, сгруппированные по id команды."""
+        result: ScalarResult[models.GameEvent] = await self.session.scalars(
+            select(models.GameEvent)
+            .options(
+                joinedload(models.GameEvent.key),
+                joinedload(models.GameEvent.timer),
+            )
+            .where(models.GameEvent.game_id == game.id)
+            .order_by(models.GameEvent.at)
+        )
+        bonuses: dict[int, list[BonusEvent]] = {}
+        for event in result.all():
+            if not event.effects.bonus_minutes:
+                continue
+            bonuses.setdefault(event.team_id, []).append(self.map_to_bonus(event))
+        return bonuses
+
+    def map_to_bonus(self, event: models.GameEvent) -> BonusEvent:
+        return BonusEvent(
+            at=event.at,
+            minutes=event.effects.bonus_minutes,
+            source=self._resolve_source(event),
+            key=event.key.key_text if event.key else None,
+            level_time_id=event.level_time_id,
+        )
+
+    @staticmethod
+    def _resolve_source(event: models.GameEvent) -> BonusSource:
+        if event.key is not None:
+            return BonusSource.key
+        if event.timer is not None:
+            return BonusSource.timer
+        return BonusSource.unknown
 
     def map_to_event(self, event: models.GameEvent) -> Event:
         return Event(

--- a/shvatka/infrastructure/db/dao/rdb/events.py
+++ b/shvatka/infrastructure/db/dao/rdb/events.py
@@ -66,7 +66,7 @@ class GameEventDao(BaseDAO[models.GameEvent]):
         return [self.map_to_event(event) for event in result.all()]
 
     async def get_game_bonuses_by_teams(self, game: dto.Game) -> dict[int, list[BonusEvent]]:
-        """Бонусы и штрафы всех команд за игру, сгруппированные по id команды."""
+        """All teams' bonuses and penalties for the game, grouped by team id."""
         result: ScalarResult[models.GameEvent] = await self.session.scalars(
             select(models.GameEvent)
             .options(
@@ -86,7 +86,7 @@ class GameEventDao(BaseDAO[models.GameEvent]):
     def map_to_bonus(self, event: models.GameEvent) -> BonusEvent:
         return BonusEvent(
             at=event.at,
-            minutes=event.effects.bonus_minutes,
+            effects=event.effects,
             source=self._resolve_source(event),
             key=event.key.key_text if event.key else None,
             level_time_id=event.level_time_id,

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from adaptix import Retort
@@ -10,7 +11,7 @@ from httpx import AsyncClient
 from shvatka.api.models import responses
 from shvatka.common.factory import REQUIRED_GAME_RECIPES
 from shvatka.core.models import dto
-from shvatka.core.models.dto import scn
+from shvatka.core.models.dto import action, scn
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.org_permission import OrgPermission
 from shvatka.core.services.game import create_game
@@ -324,3 +325,82 @@ async def test_post_bonus_hint_key(
     assert resp_json["game_finished"] is False
     assert resp_json["is_duplicate"] is False
     assert resp_json["wrong"] is False
+
+
+@pytest.mark.asyncio
+async def test_game_stat_bonuses(
+    finished_game: dto.FullGame,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+):
+    """Бонусы и штрафы отдаются вместе со статистикой, с номером уровня."""
+    token = auth.create_user_token(harry)
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    level_times = [
+        lt
+        for lt in await dao.level_time.get_game_level_times(finished_game)
+        if lt.team.id == gryffindor.id
+    ]
+    first_level = next(lt for lt in level_times if lt.level_number == 0)
+    second_level = next(lt for lt in level_times if lt.level_number == 1)
+    await dao.events.save_event(
+        team=gryffindor,
+        game=finished_game,
+        level_time=first_level,
+        effects=action.Effects(id=uuid4(), bonus_minutes=5.0),
+        at=first_level.start_at + timedelta(seconds=1),
+    )
+    await dao.events.save_event(
+        team=gryffindor,
+        game=finished_game,
+        level_time=second_level,
+        effects=action.Effects(id=uuid4(), bonus_minutes=-3.0),
+        at=second_level.start_at + timedelta(seconds=1),
+    )
+    # событие без бонуса в выдачу попадать не должно
+    await dao.events.save_event(
+        team=gryffindor,
+        game=finished_game,
+        level_time=second_level,
+        effects=action.Effects(id=uuid4(), level_up=True),
+        at=second_level.start_at + timedelta(seconds=2),
+    )
+    await dao.commit()
+
+    resp = await client.get(
+        f"/games/{finished_game.id}/stat",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+    assert resp.status_code == 200, resp.text
+    bonuses = resp.json()["bonuses"]
+    assert list(bonuses) == [str(gryffindor.id)]
+    team_bonuses = bonuses[str(gryffindor.id)]
+    assert [(b["minutes"], b["level_number"]) for b in team_bonuses] == [(5.0, 0), (-3.0, 1)]
+    assert {b["source"] for b in team_bonuses} == {"unknown"}
+    assert team_bonuses[0]["level_time_id"] == first_level.id
+    assert team_bonuses[1]["level_time_id"] == second_level.id
+
+
+@pytest.mark.asyncio
+async def test_game_stat_without_bonuses(
+    finished_game: dto.FullGame,
+    dao: HolderDao,
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+):
+    token = auth.create_user_token(harry)
+    await dao.game.set_completed(finished_game)
+    await dao.game.set_number(finished_game, 1)
+    await dao.commit()
+    resp = await client.get(
+        f"/games/{finished_game.id}/stat",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["bonuses"] == {}
+    assert resp.json()["level_times"]

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -362,7 +362,12 @@ async def test_game_stat_bonuses(
         team=gryffindor,
         game=finished_game,
         level_time=second_level,
-        effects=action.Effects(id=uuid4(), bonus_minutes=-3.0),
+        effects=action.Effects(
+            id=uuid4(),
+            bonus_minutes=-3.0,
+            level_up=True,
+            next_level=finished_game.levels[2].name_id,
+        ),
         at=second_level.start_at + timedelta(seconds=1),
     )
     # an event with no bonus must not show up in the response
@@ -395,6 +400,9 @@ async def test_game_stat_bonuses(
         {"type": "text", "text": "bonus hint", "link_preview": None}
     ]
     assert team_bonuses[0]["effects"]["level_up"] is False
+    # next_level stays a name_id here: results already expose level name_ids,
+    # so there is nothing to hide and no level mapping to load
+    assert team_bonuses[1]["effects"]["next_level"] == finished_game.levels[2].name_id
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -11,7 +11,7 @@ from httpx import AsyncClient
 from shvatka.api.models import responses
 from shvatka.common.factory import REQUIRED_GAME_RECIPES
 from shvatka.core.models import dto
-from shvatka.core.models.dto import action, scn
+from shvatka.core.models.dto import action, hints, scn
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.org_permission import OrgPermission
 from shvatka.core.services.game import create_game
@@ -336,7 +336,7 @@ async def test_game_stat_bonuses(
     auth: AuthProperties,
     harry: dto.Player,
 ):
-    """Бонусы и штрафы отдаются вместе со статистикой, с номером уровня."""
+    """Bonuses and penalties come with the stat, carrying their level number."""
     token = auth.create_user_token(harry)
     await dao.game.set_completed(finished_game)
     await dao.game.set_number(finished_game, 1)
@@ -351,7 +351,11 @@ async def test_game_stat_bonuses(
         team=gryffindor,
         game=finished_game,
         level_time=first_level,
-        effects=action.Effects(id=uuid4(), bonus_minutes=5.0),
+        effects=action.Effects(
+            id=uuid4(),
+            bonus_minutes=5.0,
+            hints_=[hints.TextHint(text="bonus hint")],
+        ),
         at=first_level.start_at + timedelta(seconds=1),
     )
     await dao.events.save_event(
@@ -361,7 +365,7 @@ async def test_game_stat_bonuses(
         effects=action.Effects(id=uuid4(), bonus_minutes=-3.0),
         at=second_level.start_at + timedelta(seconds=1),
     )
-    # событие без бонуса в выдачу попадать не должно
+    # an event with no bonus must not show up in the response
     await dao.events.save_event(
         team=gryffindor,
         game=finished_game,
@@ -379,10 +383,18 @@ async def test_game_stat_bonuses(
     bonuses = resp.json()["bonuses"]
     assert list(bonuses) == [str(gryffindor.id)]
     team_bonuses = bonuses[str(gryffindor.id)]
-    assert [(b["minutes"], b["level_number"]) for b in team_bonuses] == [(5.0, 0), (-3.0, 1)]
+    assert [(b["effects"]["bonus_minutes"], b["level_number"]) for b in team_bonuses] == [
+        (5.0, 0),
+        (-3.0, 1),
+    ]
     assert {b["source"] for b in team_bonuses} == {"unknown"}
     assert team_bonuses[0]["level_time_id"] == first_level.id
     assert team_bonuses[1]["level_time_id"] == second_level.id
+    # the whole effects come through, not just the minutes
+    assert team_bonuses[0]["effects"]["hints_"] == [
+        {"type": "text", "text": "bonus hint", "link_preview": None}
+    ]
+    assert team_bonuses[0]["effects"]["level_up"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -366,7 +366,7 @@ async def test_game_stat_bonuses(
             id=uuid4(),
             bonus_minutes=-3.0,
             level_up=True,
-            next_level=finished_game.levels[2].name_id,
+            next_level=finished_game.levels[0].name_id,
         ),
         at=second_level.start_at + timedelta(seconds=1),
     )
@@ -402,7 +402,7 @@ async def test_game_stat_bonuses(
     assert team_bonuses[0]["effects"]["level_up"] is False
     # next_level stays a name_id here: results already expose level name_ids,
     # so there is nothing to hide and no level mapping to load
-    assert team_bonuses[1]["effects"]["next_level"] == finished_game.levels[2].name_id
+    assert team_bonuses[1]["effects"]["next_level"] == finished_game.levels[0].name_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/bonuses_test.py
+++ b/tests/unit/domain/bonuses_test.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from shvatka.core.games.dto import BonusEvent, BonusSource
+from shvatka.core.games.results import (
+    TeamLevels,
+    resolve_bonus_levels,
+    route_bonuses,
+    to_results,
+)
+from shvatka.core.models import dto
+from shvatka.core.utils.datetime_utils import tz_utc
+
+BASE_TIME = datetime(2026, 7, 26, 20, 0, tzinfo=tz_utc)
+
+
+@pytest.fixture
+def team() -> dto.Team:
+    return dto.Team(id=1, name="Gryffindor", captain=None, is_dummy=False, description=None)
+
+
+@pytest.fixture
+def level_times(team: dto.Team) -> list[dto.LevelTime]:
+    """Уровень 0 занял 20 минут, уровень 1 — 10 минут, дальше финиш."""
+    return [
+        _level_time(id_=10, team=team, level_number=0, offset=0),
+        _level_time(id_=11, team=team, level_number=1, offset=20),
+        _level_time(id_=12, team=team, level_number=2, offset=30),
+    ]
+
+
+def _level_time(id_: int, team: dto.Team, level_number: int, offset: int) -> dto.LevelTime:
+    # расчёт бонусов игру не читает, поэтому здесь она не нужна
+    return dto.LevelTime(
+        id=id_,
+        game=None,
+        team=team,
+        level_number=level_number,
+        start_at=BASE_TIME + timedelta(minutes=offset),
+    )
+
+
+def _bonus(
+    minutes: float,
+    level_time_id: int | None = 10,
+    offset: int = 5,
+    source: BonusSource = BonusSource.key,
+    key: str | None = "SHБОНУС",
+) -> BonusEvent:
+    return BonusEvent(
+        at=BASE_TIME + timedelta(minutes=offset),
+        minutes=minutes,
+        source=source,
+        key=key,
+        level_time_id=level_time_id,
+    )
+
+
+def test_bonus_resolved_to_level_of_its_level_time(level_times: list[dto.LevelTime]):
+    resolved = resolve_bonus_levels(level_times, [_bonus(5.0, level_time_id=11)])
+    assert [b.level_number for b in resolved] == [1]
+
+
+def test_bonus_without_level_time_resolved_by_time(level_times: list[dto.LevelTime]):
+    """level_time_id в БД nullable — тогда уровень ищется по времени события."""
+    resolved = resolve_bonus_levels(
+        level_times,
+        [
+            _bonus(5.0, level_time_id=None, offset=5),
+            _bonus(5.0, level_time_id=None, offset=25),
+            _bonus(5.0, level_time_id=None, offset=35),
+        ],
+    )
+    assert [b.level_number for b in resolved] == [0, 1, 2]
+
+
+def test_bonus_of_unknown_level_time_falls_back_to_time(level_times: list[dto.LevelTime]):
+    """Ссылка на чужой level_time не должна терять бонус — уровень ищем по времени."""
+    resolved = resolve_bonus_levels(level_times, [_bonus(5.0, level_time_id=999, offset=25)])
+    assert [b.level_number for b in resolved] == [1]
+
+
+def test_bonus_before_game_start_stays_without_level(level_times: list[dto.LevelTime]):
+    resolved = resolve_bonus_levels(level_times, [_bonus(5.0, level_time_id=None, offset=-10)])
+    assert [b.level_number for b in resolved] == [None]
+
+
+def test_route_bonuses_groups_by_level(level_times: list[dto.LevelTime]):
+    routed = route_bonuses(
+        level_times,
+        [
+            _bonus(5.0, level_time_id=10),
+            _bonus(-3.0, level_time_id=10),
+            _bonus(2.0, level_time_id=11),
+            _bonus(1.0, level_time_id=None, offset=-10),
+        ],
+    )
+    assert sorted(routed, key=lambda k: (k is None, k)) == [0, 1, None]
+    assert [b.minutes for b in routed[0]] == [5.0, -3.0]
+    assert [b.minutes for b in routed[1]] == [2.0]
+    assert [b.minutes for b in routed[None]] == [1.0]
+
+
+def test_source_and_key_survive_routing(level_times: list[dto.LevelTime]):
+    routed = route_bonuses(
+        level_times,
+        [
+            _bonus(5.0, source=BonusSource.timer, key=None),
+            _bonus(-3.0, source=BonusSource.key, key="SHШТРАФ"),
+        ],
+    )
+    assert [(b.source, b.key) for b in routed[0]] == [
+        (BonusSource.timer, None),
+        (BonusSource.key, "SHШТРАФ"),
+    ]
+
+
+class TestTeamLevelsBonuses:
+    def test_no_bonuses_at_all(self, team: dto.Team, level_times: list[dto.LevelTime]):
+        team_levels = self._to_team_levels(team, level_times, None)
+        assert team_levels.bonuses == {}
+        assert team_levels.get_total_bonus() == timedelta()
+        assert team_levels.get_level_bonus(0) == timedelta()
+
+    def test_bonus_and_penalty_on_same_level_are_summed(
+        self, team: dto.Team, level_times: list[dto.LevelTime]
+    ):
+        team_levels = self._to_team_levels(
+            team, level_times, [_bonus(5.0, level_time_id=10), _bonus(-3.0, level_time_id=10)]
+        )
+        assert team_levels.get_level_bonus(0) == timedelta(minutes=2)
+
+    def test_penalty_is_negative(self, team: dto.Team, level_times: list[dto.LevelTime]):
+        team_levels = self._to_team_levels(team, level_times, [_bonus(-3.0, level_time_id=10)])
+        assert team_levels.get_level_bonus(0) == timedelta(minutes=-3)
+
+    def test_total_includes_bonuses_without_level(
+        self, team: dto.Team, level_times: list[dto.LevelTime]
+    ):
+        """Бонус, чей уровень не определён, всё равно попадает в итог."""
+        team_levels = self._to_team_levels(
+            team,
+            level_times,
+            [_bonus(5.0, level_time_id=10), _bonus(7.0, level_time_id=None, offset=-10)],
+        )
+        assert team_levels.get_level_bonus(0) == timedelta(minutes=5)
+        assert team_levels.get_total_bonus() == timedelta(minutes=12)
+
+    def test_bonus_bigger_than_level_duration_goes_negative(
+        self, team: dto.Team, level_times: list[dto.LevelTime]
+    ):
+        """Уровень 1 длился 10 минут, бонус 15 — не обрезаем, показываем минус."""
+        team_levels = self._to_team_levels(team, level_times, [_bonus(15.0, level_time_id=11)])
+        raw = team_levels.get_level_timedelta(1)
+        assert raw is not None
+        assert raw.td - team_levels.get_level_bonus(1) == timedelta(minutes=-5)
+
+    def test_sum_of_level_bonuses_equals_total(
+        self, team: dto.Team, level_times: list[dto.LevelTime]
+    ):
+        """Аддитивность: сумма по уровням должна совпадать с итогом."""
+        team_levels = self._to_team_levels(
+            team,
+            level_times,
+            [
+                _bonus(5.0, level_time_id=10),
+                _bonus(-3.0, level_time_id=11),
+                _bonus(2.0, level_time_id=12),
+            ],
+        )
+        by_levels = sum(
+            (team_levels.get_level_bonus(level) for level in (0, 1, 2)),
+            start=timedelta(),
+        )
+        assert by_levels == team_levels.get_total_bonus() == timedelta(minutes=4)
+
+    @staticmethod
+    def _to_team_levels(
+        team: dto.Team,
+        level_times: list[dto.LevelTime],
+        bonuses: list[BonusEvent] | None,
+    ) -> TeamLevels:
+        results = to_results(
+            dto.GameStat(level_times={team: level_times}),
+            {team.id: bonuses} if bonuses else None,
+        )
+        return results.data[0]

--- a/tests/unit/domain/bonuses_test.py
+++ b/tests/unit/domain/bonuses_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 import pytest
 
@@ -10,6 +11,7 @@ from shvatka.core.games.results import (
     to_results,
 )
 from shvatka.core.models import dto
+from shvatka.core.models.dto import action
 from shvatka.core.utils.datetime_utils import tz_utc
 
 BASE_TIME = datetime(2026, 7, 26, 20, 0, tzinfo=tz_utc)
@@ -22,7 +24,7 @@ def team() -> dto.Team:
 
 @pytest.fixture
 def level_times(team: dto.Team) -> list[dto.LevelTime]:
-    """Уровень 0 занял 20 минут, уровень 1 — 10 минут, дальше финиш."""
+    """Level 0 took 20 minutes, level 1 took 10, then the finish."""
     return [
         _level_time(id_=10, team=team, level_number=0, offset=0),
         _level_time(id_=11, team=team, level_number=1, offset=20),
@@ -31,7 +33,7 @@ def level_times(team: dto.Team) -> list[dto.LevelTime]:
 
 
 def _level_time(id_: int, team: dto.Team, level_number: int, offset: int) -> dto.LevelTime:
-    # расчёт бонусов игру не читает, поэтому здесь она не нужна
+    # computing bonuses never reads the game, so it is not needed here
     return dto.LevelTime(
         id=id_,
         game=None,
@@ -50,7 +52,7 @@ def _bonus(
 ) -> BonusEvent:
     return BonusEvent(
         at=BASE_TIME + timedelta(minutes=offset),
-        minutes=minutes,
+        effects=action.Effects(id=uuid4(), bonus_minutes=minutes),
         source=source,
         key=key,
         level_time_id=level_time_id,
@@ -63,7 +65,7 @@ def test_bonus_resolved_to_level_of_its_level_time(level_times: list[dto.LevelTi
 
 
 def test_bonus_without_level_time_resolved_by_time(level_times: list[dto.LevelTime]):
-    """level_time_id в БД nullable — тогда уровень ищется по времени события."""
+    """level_time_id is nullable in the DB — then the level comes from the event time."""
     resolved = resolve_bonus_levels(
         level_times,
         [
@@ -76,7 +78,7 @@ def test_bonus_without_level_time_resolved_by_time(level_times: list[dto.LevelTi
 
 
 def test_bonus_of_unknown_level_time_falls_back_to_time(level_times: list[dto.LevelTime]):
-    """Ссылка на чужой level_time не должна терять бонус — уровень ищем по времени."""
+    """A reference to someone else's level_time must not lose the bonus."""
     resolved = resolve_bonus_levels(level_times, [_bonus(5.0, level_time_id=999, offset=25)])
     assert [b.level_number for b in resolved] == [1]
 
@@ -138,7 +140,7 @@ class TestTeamLevelsBonuses:
     def test_total_includes_bonuses_without_level(
         self, team: dto.Team, level_times: list[dto.LevelTime]
     ):
-        """Бонус, чей уровень не определён, всё равно попадает в итог."""
+        """A bonus whose level is unresolved still lands in the total."""
         team_levels = self._to_team_levels(
             team,
             level_times,
@@ -150,7 +152,7 @@ class TestTeamLevelsBonuses:
     def test_bonus_bigger_than_level_duration_goes_negative(
         self, team: dto.Team, level_times: list[dto.LevelTime]
     ):
-        """Уровень 1 длился 10 минут, бонус 15 — не обрезаем, показываем минус."""
+        """Level 1 lasted 10 minutes, the bonus is 15 — not clamped, shown negative."""
         team_levels = self._to_team_levels(team, level_times, [_bonus(15.0, level_time_id=11)])
         raw = team_levels.get_level_timedelta(1)
         assert raw is not None
@@ -159,7 +161,7 @@ class TestTeamLevelsBonuses:
     def test_sum_of_level_bonuses_equals_total(
         self, team: dto.Team, level_times: list[dto.LevelTime]
     ):
-        """Аддитивность: сумма по уровням должна совпадать с итогом."""
+        """Additivity: the per-level sum must match the total."""
         team_levels = self._to_team_levels(
             team,
             level_times,


### PR DESCRIPTION
Backend part of #258. UI part: bomzheg/shvatka-ui#155.

`bonus_minutes` was already stored in `event_log` for every key and timer effect, but nothing ever counted it — it was only rendered in bot views. This exposes it so results can show times adjusted by bonuses and penalties.

**No migration needed** — all the data is already there, and permissions are inherited unchanged (`get_game_stat_with_hints` already gates non-complete games to spy-capable orgs).

## Semantics

`bonus_minutes > 0` is a bonus, `< 0` a penalty, so one formula covers both:

```
adjusted = raw - timedelta(minutes=bonus_minutes)
```

Bonuses are attributed to a level via `event_log.level_time_id`. That column is nullable, so there are two fallbacks: resolve the level from the event's timestamp, and failing that keep the event in a `None` bucket that counts only towards the total. A bonus larger than the level's duration is *not* clamped to zero — clamping would break `Σ per-level == total` and would hide a scenario mistake from the organizer.

## Changes

- `GameEventDao.get_game_bonuses_by_teams` — one game-wide query joined to `log_keys` / `timers_log` so the bonus source (key vs. timer) is known. Events with no bonus minutes are filtered out.
- `GameBonusesGetter` protocol composed into `GameStatReader`, so the interactor still takes a single DAO.
- `core/games/results.py` — `resolve_bonus_levels` / `route_bonuses` do the attribution as pure functions; `TeamLevels` gains `bonuses` plus `get_level_bonus` / `get_total_bonus`. The `level_time_id`→level mapping comes from the level times already loaded, so attribution costs no extra query.
- `GET /games/{id}/stat` gains a `bonuses` field, additively — existing clients keep working. Each entry carries the **whole effects** (per review feedback) rather than just the extracted minutes, so new kinds of effect reach clients without an API change:

```json
{
  "level_times": { "42": ["..."] },
  "bonuses": {
    "42": [
      {
        "at": "2026-07-26T21:05:00Z",
        "effects": {
          "id": "...", "bonus_minutes": 5.0, "level_up": false,
          "next_level": null, "hints_": []
        },
        "source": "key",
        "key": "SHКЛЮЧ",
        "level_time_id": 123,
        "level_number": 2
      }
    ]
  }
}
```

(keys of both maps are team ids). Raw times plus a flat list of bonuses, so the client can switch display modes without another request.

- `GameStatWithBonuses` also carries `level_numbers_by_name_id`, the way `CurrentHintsAndKeys` already does, because `Effects.from_core` resolves `next_level` from name_id to `number_in_game`. That costs one extra `add_levels` call in the interactor — deliberate, see the [review thread](https://github.com/bomzheg/Shvatka/pull/308#discussion_r3652410295): deriving the mapping from the level times already loaded would leave `next_level` unresolved when it points at a level no team reached.
- xlsx export gains a bonus block (minutes per team × level, plus a total). Per the issue discussion it carries the raw numbers rather than adjusted times, so they can be computed in Excel; the three existing blocks are untouched, and the block is skipped entirely when a game had no bonuses.
- `Cell.value` accepts `float` (bonus minutes are fractional).
- `AGENTS.md`: new comments and docstrings go in English. The old rule said to follow each file's existing language, which is why this branch first landed Russian ones — see the [review thread](https://github.com/bomzheg/Shvatka/pull/308#discussion_r3652410596).

## Tests

- `tests/unit/domain/bonuses_test.py` — 12 tests: bonus, penalty, both on one level, bonus exceeding the duration, `NULL` / unknown `level_time_id`, event before game start, grouping, source/key survival, and `Σ per-level == total`.
- `tests/integration/api_full/test_game.py` — the `bonuses` payload and its level numbers, that a bonus effect carrying a hint round-trips with the hint intact, that a no-bonus event is excluded, and that a game with no bonuses returns `{}`.

`ruff format --check`, `ruff check` and `mypy` are clean; `pytest tests/unit` passes (213). Integration tests need Docker, which isn't available in this environment — CI covers those, and is green.

## Open question

The review asked whether the UI should filter, which may have meant returning *all* events rather than only those with bonus minutes. I kept the server-side filter to avoid putting every level-up key event into a payload that gets polled during play — happy to drop it, it's a small change. See the thread linked above.

## Not in this PR

The chart (`game_chart.part`, `infrastructure/picture`), bonuses in live standings of an unfinished game, `effects` on `GET /games/{id}/keys`, and bot-side rendering.