### PR TITLE
Generate player username from transliterated tg names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ shvatka-tgbot = "shvatka.tgbot.__main__:run"
 shvatka-api = "shvbatka.api.__main__:run"
 shvatka-file-id-updater = "shvatka.infrastructure.file_id_updater:run"
 shvatka-empty-file-repairer = "shvatka.infrastructure.empty_file_repairer:run"
+shvatka-player-username-updater = "shvatka.infrastructure.player_username_updater:run"
 shvatka-password = "shvatka.api.password_hash:generate"
 
 [build-system]

--- a/shvatka/core/utils/username.py
+++ b/shvatka/core/utils/username.py
@@ -1,0 +1,82 @@
+"""Generation of shvatka usernames from names of linked identities."""
+
+import re
+import unicodedata
+
+from shvatka.core.utils.input_validation import validate_new_username
+
+MAX_USERNAME_LENGTH = 50
+
+CYRILLIC_TO_LATIN = {
+    "а": "a",
+    "б": "b",
+    "в": "v",
+    "г": "g",
+    "ґ": "g",
+    "д": "d",
+    "е": "e",
+    "ё": "yo",
+    "є": "ye",
+    "ж": "zh",
+    "з": "z",
+    "и": "i",
+    "і": "i",
+    "ї": "yi",
+    "й": "y",
+    "к": "k",
+    "л": "l",
+    "м": "m",
+    "н": "n",
+    "о": "o",
+    "п": "p",
+    "р": "r",
+    "с": "s",
+    "т": "t",
+    "у": "u",
+    "ў": "u",
+    "ф": "f",
+    "х": "kh",
+    "ц": "ts",
+    "ч": "ch",
+    "ш": "sh",
+    "щ": "shch",
+    "ъ": "",
+    "ы": "y",
+    "ь": "",
+    "э": "e",
+    "ю": "yu",
+    "я": "ya",
+}
+
+NOT_LATIN_OR_DIGIT = re.compile(r"[^a-z0-9]+")
+
+
+def transliterate(text: str) -> str:
+    """Lowercase latin-only representation of text, suitable for a username part.
+
+    Cyrillic is transliterated char by char, diacritics of latin-based scripts are
+    dropped (é -> e), everything else (emoji, hieroglyphs, punctuation) becomes a
+    separator and is squashed into a single underscore.
+    """
+    normalized = unicodedata.normalize("NFC", text.lower())
+    latin = "".join(CYRILLIC_TO_LATIN.get(char, char) for char in normalized)
+    decomposed = unicodedata.normalize("NFKD", latin)
+    without_diacritics = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return NOT_LATIN_OR_DIGIT.sub("_", without_diacritics).strip("_")
+
+
+def username_from_names(first_name: str | None, last_name: str | None) -> str | None:
+    """Username built from a person's names, or None if nothing usable is left of them."""
+    parts = [
+        part for part in (transliterate(first_name or ""), transliterate(last_name or "")) if part
+    ]
+    if not parts:
+        return None
+    candidate = "_".join(parts)[:MAX_USERNAME_LENGTH].strip("_")
+    return validate_new_username(candidate) if candidate else None
+
+
+def numbered_username(username: str, number: int) -> str:
+    """Variant of username with a number appended, still short enough to be valid."""
+    suffix = f"_{number}"
+    return username[: MAX_USERNAME_LENGTH - len(suffix)].rstrip("_") + suffix

--- a/shvatka/infrastructure/crawler/game_scn/loader/load_scns.py
+++ b/shvatka/infrastructure/crawler/game_scn/loader/load_scns.py
@@ -42,17 +42,18 @@ async def main():
     )
     try:
         config = await dishka.get(TgBotConfig)
-        dao = await dishka.get(HolderDao)
-        file_gateway = await dishka.get(FileGateway)
-        bot_player = await dao.player.upsert_author_dummy()
-        await dao.commit()
-        await load_scns(
-            bot_player=bot_player,
-            dao=dao,
-            file_gateway=file_gateway,
-            retort=await dishka.get(Retort),
-            path=config.file_storage_config.path.parent / "scn",
-        )
+        async with dishka() as request_dishka:
+            dao = await request_dishka.get(HolderDao)
+            file_gateway = await request_dishka.get(FileGateway)
+            bot_player = await dao.player.upsert_author_dummy()
+            await dao.commit()
+            await load_scns(
+                bot_player=bot_player,
+                dao=dao,
+                file_gateway=file_gateway,
+                retort=await dishka.get(Retort),
+                path=config.file_storage_config.path.parent / "scn",
+            )
     finally:
         await dishka.close()
 

--- a/shvatka/infrastructure/crawler/teams/loader.py
+++ b/shvatka/infrastructure/crawler/teams/loader.py
@@ -31,10 +31,11 @@ async def main(with_team_players: bool):
     )
     try:
         config = await dishka.get(TgBotConfig)
-        dao = await dishka.get(HolderDao)
         dcf = await dishka.get(Factory)
-        path = config.file_storage_config.path.parent / "teams.json"
-        await load_teams(path, with_team_players, dao, dcf)
+        async with dishka() as request_dishka:
+            dao = await request_dishka.get(HolderDao)
+            path = config.file_storage_config.path.parent / "teams.json"
+            await load_teams(path, with_team_players, dao, dcf)
     finally:
         await dishka.close()
 

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import joinedload, selectinload, contains_eager
 
 from shvatka.core.models import dto, enums
 from shvatka.core.utils import exceptions
+from shvatka.core.utils.username import numbered_username, username_from_names
 from shvatka.infrastructure.db import models
 from .base import BaseDAO, ILIKE_ESCAPE, ilike_pattern
 
@@ -385,16 +386,76 @@ class PlayerDao(BaseDAO[models.Player]):
     async def get_free_and_associated_username(self, player: models.Player) -> str:
         if player.username is not None:
             return player.username
+        associated = await self.find_associated_username(player)
+        if associated is not None:
+            return associated
+        return await self._free_id_username(player)
+
+    async def find_associated_username(self, player: models.Player) -> str | None:
+        """Free username based on names of identities linked to the player.
+
+        Telegram username is the best one, then a forum name, then the telegram
+        first and last name transliterated to latin. Returns None if the player has
+        no name to build a username from (or all of them are occupied).
+        """
         state = inspect(player)
-        if "user" not in state.unloaded and player.user and player.user.username:
+        user_loaded = "user" not in state.unloaded and player.user is not None
+        if user_loaded and player.user.username:
             if not await self.is_username_occupied(player.user.username):
                 return player.user.username
         if "forum_user" not in state.unloaded and player.forum_user and player.forum_user.name:
             if not await self.is_username_occupied(player.forum_user.name):
                 return player.forum_user.name
+        if user_loaded:
+            from_names = username_from_names(player.user.first_name, player.user.last_name)
+            if from_names is not None:
+                return await self._free_variant(from_names)
+        return None
+
+    async def _free_variant(self, username: str) -> str | None:
+        """The username itself, or a numbered variant of it, if it's occupied."""
+        if not await self.is_username_occupied(username):
+            return username
+        for i in range(1, 100):
+            numbered = numbered_username(username, i)
+            if not await self.is_username_occupied(numbered):
+                return numbered
+        return None
+
+    async def _free_id_username(self, player: models.Player) -> str:
         if not await self.is_username_occupied(f"id{player.id}"):
             return f"id{player.id}"
         for i in range(1000):
             if not await self.is_username_occupied(f"id{player.id}_{i}"):
                 return f"id{player.id}_{i}"
         return uuid.uuid4().hex
+
+    async def renew_id_usernames(self) -> list[tuple[str, str]]:
+        """Replace `id{id}` usernames with ones based on names of linked identities.
+
+        Players saved before username generation from names was introduced (or before
+        they got any identity linked) still carry the id-based placeholder. Returns
+        pairs of old and new username of every renamed player.
+        """
+        renamed = []
+        for player in await self._get_with_id_username():
+            new_username = await self.find_associated_username(player)
+            if new_username is None or new_username == player.username:
+                continue
+            renamed.append((typing.cast(str, player.username), new_username))
+            player.username = new_username
+            # autoflush is off, but the next occupation check must see this username
+            await self._flush(player)
+        return renamed
+
+    async def _get_with_id_username(self) -> Sequence[models.Player]:
+        result: ScalarResult[models.Player] = await self.session.scalars(
+            select(models.Player)
+            .options(
+                selectinload(models.Player.user),
+                selectinload(models.Player.forum_user),
+            )
+            .where(models.Player.username == func.concat("id", models.Player.id))
+            .order_by(models.Player.id)
+        )
+        return result.all()

--- a/shvatka/infrastructure/empty_file_repairer.py
+++ b/shvatka/infrastructure/empty_file_repairer.py
@@ -32,10 +32,13 @@ async def main():
         *get_infra_only_providers(),
     )
     try:
-        dao = await dishka.get(HolderDao)
-        storage = await dishka.get(FileStorage)
-        file_gateway = await dishka.get(FileGateway)
-        await repair_empty_files(dao.file_info, storage, typing.cast(BotFileGateway, file_gateway))
+        async with dishka() as request_dishka:
+            dao = await request_dishka.get(HolderDao)
+            storage = await request_dishka.get(FileStorage)
+            file_gateway = await request_dishka.get(FileGateway)
+            await repair_empty_files(
+                dao.file_info, storage, typing.cast(BotFileGateway, file_gateway)
+            )
     finally:
         await dishka.close()
 

--- a/shvatka/infrastructure/file_id_updater.py
+++ b/shvatka/infrastructure/file_id_updater.py
@@ -22,9 +22,10 @@ async def main():
         *get_infra_only_providers(),
     )
     try:
-        dao = await dishka.get(HolderDao)
-        file_gateway = await dishka.get(FileGateway)
-        await fill_all_file_id(dao.file_info, typing.cast(BotFileGateway, file_gateway))
+        async with dishka() as request_dishka:
+            dao = await request_dishka.get(HolderDao)
+            file_gateway = await request_dishka.get(FileGateway)
+            await fill_all_file_id(dao.file_info, typing.cast(BotFileGateway, file_gateway))
     finally:
         await dishka.close()
 

--- a/shvatka/infrastructure/player_username_updater.py
+++ b/shvatka/infrastructure/player_username_updater.py
@@ -1,0 +1,49 @@
+import asyncio
+import logging
+
+from dishka import make_async_container
+
+from shvatka.common import setup_logging
+from shvatka.common.config.parser.paths import common_get_paths
+from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.di import get_providers
+from shvatka.infrastructure.di.infra import get_infra_only_providers
+
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    paths = common_get_paths("INFRA_PATH")
+
+    setup_logging(paths)
+    dishka = make_async_container(
+        *get_providers("INFRA_PATH"),
+        *get_infra_only_providers(),
+    )
+    try:
+        dao = await dishka.get(HolderDao)
+        await renew_id_usernames(dao)
+    finally:
+        await dishka.close()
+
+
+async def renew_id_usernames(dao: HolderDao) -> list[tuple[str, str]]:
+    """Give players with an `id{id}` username a name-based one instead.
+
+    Players are renamed only if their telegram or forum identity provides a free
+    username, so those without any name keep the id-based one.
+    """
+    renamed = await dao.player.renew_id_usernames()
+    for old, new in renamed:
+        logger.info("username %s renewed to %s", old, new)
+    await dao.commit()
+    logger.info("renewed %s usernames", len(renamed))
+    return renamed
+
+
+def run():
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run()

--- a/shvatka/infrastructure/player_username_updater.py
+++ b/shvatka/infrastructure/player_username_updater.py
@@ -21,8 +21,9 @@ async def main():
         *get_infra_only_providers(),
     )
     try:
-        dao = await dishka.get(HolderDao)
-        await renew_id_usernames(dao)
+        async with dishka() as request_dishka:
+            dao = await request_dishka.get(HolderDao)
+            await renew_id_usernames(dao)
     finally:
         await dishka.close()
 

--- a/tests/integration/test_player_username.py
+++ b/tests/integration/test_player_username.py
@@ -1,0 +1,64 @@
+import pytest
+
+from shvatka.core.models import dto
+from shvatka.core.services.user import upsert_user
+from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.player_username_updater import renew_id_usernames
+from tests.fixtures.player import create_player
+
+
+@pytest.mark.asyncio
+async def test_username_by_tg_username(dao: HolderDao):
+    player = await create_player(
+        dto.User(tg_id=101, username="the_chosen_one", first_name="Гарри", last_name="Поттер"),
+        dao,
+    )
+    assert player.username == "the_chosen_one"
+
+
+@pytest.mark.asyncio
+async def test_username_by_transliterated_names(dao: HolderDao):
+    player = await create_player(dto.User(tg_id=102, first_name="Гарри", last_name="Поттер"), dao)
+    assert player.username == "garri_potter"
+
+
+@pytest.mark.asyncio
+async def test_username_by_first_name_only(dao: HolderDao):
+    player = await create_player(dto.User(tg_id=103, first_name="Гарри"), dao)
+    assert player.username == "garri"
+
+
+@pytest.mark.asyncio
+async def test_username_by_names_occupied(dao: HolderDao):
+    first = await create_player(dto.User(tg_id=104, first_name="Гарри", last_name="Поттер"), dao)
+    second = await create_player(dto.User(tg_id=105, first_name="Гарри", last_name="Поттер"), dao)
+    assert first.username == "garri_potter"
+    assert second.username == "garri_potter_1"
+
+
+@pytest.mark.asyncio
+async def test_username_by_id_without_names(dao: HolderDao):
+    player = await create_player(dto.User(tg_id=106), dao)
+    assert player.username == f"id{player.id}"
+
+
+@pytest.mark.asyncio
+async def test_renew_id_usernames(dao: HolderDao, check_dao: HolderDao):
+    nameless = await create_player(dto.User(tg_id=107), dao)
+    with_username = await create_player(dto.User(tg_id=108, username="voldemort_fan"), dao)
+    assert nameless.username == f"id{nameless.id}"
+
+    await upsert_user(dto.User(tg_id=107, first_name="Джоан", last_name="Роулинг"), dao.user)
+    renamed = await renew_id_usernames(dao)
+
+    assert renamed == [(f"id{nameless.id}", "dzhoan_rouling")]
+    assert (await check_dao.player.get_by_id(nameless.id)).username == "dzhoan_rouling"
+    assert (await check_dao.player.get_by_id(with_username.id)).username == "voldemort_fan"
+
+
+@pytest.mark.asyncio
+async def test_renew_id_usernames_keeps_nameless_player(dao: HolderDao, check_dao: HolderDao):
+    nameless = await create_player(dto.User(tg_id=109), dao)
+
+    assert await renew_id_usernames(dao) == []
+    assert (await check_dao.player.get_by_id(nameless.id)).username == f"id{nameless.id}"

--- a/tests/unit/domain/username_generation_test.py
+++ b/tests/unit/domain/username_generation_test.py
@@ -1,0 +1,55 @@
+import pytest
+
+from shvatka.core.utils.username import (
+    numbered_username,
+    transliterate,
+    username_from_names,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Harry", "harry"),
+        ("Юрий", "yuriy"),
+        ("Щёкин", "shchyokin"),
+        ("Объезд", "obezd"),
+        ("Гарри Поттер", "garri_potter"),
+        ("Жанна д'Арк", "zhanna_d_ark"),
+        ("Renée", "renee"),
+        ("  Ян  ", "yan"),
+        ("Ігор", "igor"),
+        ("😀", ""),
+        ("", ""),
+    ],
+)
+def test_transliterate(text: str, expected: str):
+    assert transliterate(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("first_name", "last_name", "expected"),
+    [
+        ("Harry", "Potter", "harry_potter"),
+        ("Гарри", "Поттер", "garri_potter"),
+        ("Гарри", None, "garri"),
+        (None, "Поттер", "potter"),
+        ("Ян", "Ли", "yan_li"),
+        ("Ли", None, None),  # too short for a username
+        ("😀", None, None),
+        (None, None, None),
+        ("", "", None),
+        (
+            "Ааааааааааааааааааааааааааааааа",
+            "Бббббббббббббббббббббббббббббббб",
+            "a" * 31 + "_" + "b" * 18,
+        ),
+    ],
+)
+def test_username_from_names(first_name: str | None, last_name: str | None, expected: str | None):
+    assert username_from_names(first_name, last_name) == expected
+
+
+def test_numbered_username():
+    assert numbered_username("harry_potter", 1) == "harry_potter_1"
+    assert numbered_username("a" * 50, 12) == "a" * 47 + "_12"


### PR DESCRIPTION
## What

A new telegram player got `id{id}` as a shvatka username whenever telegram gave
no username. Now the username is built from the transliterated telegram first
and last name, and the id-based one is kept only for players who have no name at
all.

Username sources for a new player, in order:

1. telegram username (as before);
2. forum name (as before);
3. transliterated telegram first + last name — **new**, e.g. `Гарри Поттер` →
   `garri_potter`, `Гарри` → `garri`;
4. `id{id}` / `id{id}_{n}` (as before).

## How

- `shvatka/core/utils/username.py` — new pure-domain module:
  - `transliterate()` maps cyrillic (ru/ua/by letters) char by char, drops
    diacritics of latin-based scripts (`Renée` → `renee`) and squashes
    everything else (punctuation, emoji, hieroglyphs) into a single underscore;
  - `username_from_names()` joins the two names and validates the result with
    the existing `validate_new_username`, so anything too short or with no
    latin-able characters left yields `None` and the id fallback applies;
  - `numbered_username()` builds the `_1`, `_2`… variants without exceeding the
    50-char limit.
- `PlayerDao.get_free_and_associated_username` is split into
  `find_associated_username` (name-based, may return `None`) and
  `_free_id_username` (the old id fallback), so both player creation and the
  updater script share one generation rule.
- Occupied name-based candidates get a numeric suffix (`garri_potter_1`).

## Updating already saved players

New entry point `shvatka-player-username-updater`
(`shvatka/infrastructure/player_username_updater.py`) selects players whose
username is exactly `id{id}`, regenerates it from their linked telegram/forum
identity and commits, logging every rename. Players with no usable name keep
their id-based username, so the script is safe to re-run.

## Tests

- `tests/unit/domain/username_generation_test.py` — transliteration, name
  joining, length limits, unusable names.
- `tests/integration/test_player_username.py` — username by tg username, by
  transliterated names, by first name only, collision suffix, id fallback, and
  the updater renaming (and not renaming) saved players.

`ruff format`, `ruff check`, `mypy` and `pytest tests/unit` pass locally;
integration tests need Docker, so they run in CI.

## Note

`is_username_occupied` matches with `ILIKE` without escaping, so `_` in a
candidate acts as a wildcard and a name-based username can be reported occupied
by a similar-looking one (`garri_potter` vs `garrixpotter`). That only ever adds
a numeric suffix, never breaks uniqueness, so this PR leaves the pre-existing
behaviour (shared with login lookup) untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_013TTaDFTX1tNf6f5PCXFbrg)_