### PR TITLE
Let admins change a player's username

### DIFF
--- a/shvatka/api/models/req.py
+++ b/shvatka/api/models/req.py
@@ -104,6 +104,11 @@ class AdminChangeEmail:
 
 
 @dataclass
+class AdminChangeUsername:
+    username: str
+
+
+@dataclass
 class AdminChangeTg:
     tg_id: int
     username: str | None = None

--- a/shvatka/api/routes/admin.py
+++ b/shvatka/api/routes/admin.py
@@ -23,6 +23,7 @@ from shvatka.core.players.admin_interactors import (
     AdminMergePlayersInteractor,
     AdminSearchPlayersInteractor,
     AdminSetPlayerEmailInteractor,
+    AdminSetPlayerUsernameInteractor,
 )
 from shvatka.core.services.one_time_link import GenerateOneTimeLoginLinkForPlayerInteractor
 from shvatka.core.services.scenario.files import get_file_metas
@@ -92,6 +93,23 @@ async def change_email(
     except exceptions.EmailAlreadyExist as e:
         raise HTTPException(status_code=409, detail="email already exists") from e
     return responses.EmailAccount(email=account.email, is_verified=account.is_verified)
+
+
+@inject
+async def change_username(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[AdminSetPlayerUsernameInteractor],
+    config: FromDishka[ApiConfig],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[req.AdminChangeUsername, Body()],
+) -> responses.PlayerWithIdentities:
+    try:
+        info = await interactor(identity=identity, player_id=id_, username=body.username)
+    except exceptions.PlayerInvalidUsername as e:
+        raise HTTPException(status_code=422, detail="invalid username") from e
+    except exceptions.PlayerUsernameOccupied as e:
+        raise HTTPException(status_code=409, detail="username already occupied") from e
+    return responses.PlayerWithIdentities.from_core(info.player, info.email, config.superusers)
 
 
 @inject
@@ -229,6 +247,7 @@ def setup() -> APIRouter:
     router.add_api_route("/players/{id}/one-time-link", create_one_time_link, methods=["POST"])
     router.add_api_route("/players/{id}/waiver-points", get_player_waiver_points, methods=["GET"])
     router.add_api_route("/players/{id}/email", change_email, methods=["PUT"])
+    router.add_api_route("/players/{id}/username", change_username, methods=["PUT"])
     router.add_api_route("/players/{id}/tg", change_tg, methods=["PUT"])
     router.add_api_route("/poll", get_poll, methods=["GET"])
     router.add_api_route(

--- a/shvatka/core/players/admin_interactors.py
+++ b/shvatka/core/players/admin_interactors.py
@@ -16,12 +16,13 @@ from shvatka.core.players.interfaces import (
     AdminPlayerReader,
     AdminEmailSetter,
     AdminTgChanger,
+    AdminUsernameSetter,
     AdminPlayerMerger,
     AdminPlayerWaiverPointsReader,
 )
-from shvatka.core.players.player import merge_players, get_waiver_points
+from shvatka.core.players.player import merge_players, get_waiver_points, set_player_username
 from shvatka.core.utils import exceptions
-from shvatka.core.utils.input_validation import validate_email
+from shvatka.core.utils.input_validation import validate_email, validate_new_username
 from shvatka.core.views.game import GameLogWriter
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,27 @@ class AdminSetPlayerEmailInteractor:
         )
         await self.dao.commit()
         return account
+
+
+@dataclass
+class AdminSetPlayerUsernameInteractor:
+    dao: AdminUsernameSetter
+
+    async def __call__(
+        self, identity: IdentityProvider, player_id: int, username: str
+    ) -> PlayerIdentitiesInfo:
+        admin = await identity.get_superuser()
+        logger.warning(
+            "admin %s changed username of player %s to %s", admin.id, player_id, username
+        )
+        player = await self.dao.get_by_id(player_id)
+        normalized = validate_new_username(username)
+        if normalized is None:
+            raise exceptions.PlayerInvalidUsername(text=f"invalid username {username}")
+        await set_player_username(player, normalized, self.dao)
+        updated = await self.dao.get_by_id(player.id)
+        email = await self.dao.get_email_by_player_id(updated.id)
+        return PlayerIdentitiesInfo(player=updated, email=email)
 
 
 @dataclass

--- a/shvatka/core/players/interfaces.py
+++ b/shvatka/core/players/interfaces.py
@@ -104,6 +104,12 @@ class AdminEmailSetter(PlayerByIdGetter, Committer, Protocol):
         raise NotImplementedError
 
 
+class AdminUsernameSetter(
+    PlayerUsernameChanger, PlayerByIdGetter, EmailByPlayerIdReader, Protocol
+):
+    """Set the username of an arbitrary player, plus reload them by id."""
+
+
 class AdminTgChanger(
     UserUpserter, PlayerByIdGetter, PlayerByUserIdGetter, EmailByPlayerIdReader, Protocol
 ):

--- a/shvatka/infrastructure/db/dao/complex/player.py
+++ b/shvatka/infrastructure/db/dao/complex/player.py
@@ -7,6 +7,7 @@ from shvatka.core.players.interfaces import (
     AdminPlayerReader,
     AdminEmailSetter,
     AdminTgChanger,
+    AdminUsernameSetter,
     AdminPlayerMerger,
     AdminPlayerWaiverPointsReader,
 )
@@ -131,6 +132,26 @@ class AdminEmailSetterImpl(AdminEmailSetter):
         self, player_id: int, email: str, is_verified: bool
     ) -> dto.EmailAccount:
         return await self.dao.email.set_player_email(player_id, email, is_verified)
+
+    async def commit(self) -> None:
+        return await self.dao.commit()
+
+
+@dataclass
+class AdminUsernameSetterImpl(AdminUsernameSetter):
+    dao: "HolderDao"
+
+    async def get_by_id(self, id_: int) -> dto.Player:
+        return await self.dao.player.get_by_id(id_)
+
+    async def is_username_occupied(self, username: str) -> bool:
+        return await self.dao.player.is_username_occupied(username)
+
+    async def set_username(self, player: dto.Player, username: str) -> None:
+        return await self.dao.player.set_username(player, username)
+
+    async def get_email_by_player_id(self, player_id: int) -> dto.EmailAccount | None:
+        return await self.dao.email.get_by_player_id(player_id)
 
     async def commit(self) -> None:
         return await self.dao.commit()

--- a/shvatka/infrastructure/db/dao/rdb/user.py
+++ b/shvatka/infrastructure/db/dao/rdb/user.py
@@ -65,7 +65,10 @@ class UserDao(BaseDAO[User]):
             .on_conflict_do_update(
                 index_elements=(User.tg_id,), set_=kwargs, where=User.tg_id == user.tg_id
             )
-            .returning(User)
+            .returning(User),
+            # the session never expires on commit, so a user already loaded into it
+            # would keep its old names here and in every relationship pointing at it
+            execution_options={"populate_existing": True},
         )
         return saved_user.scalar_one().to_dto()
 

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -70,6 +70,7 @@ from shvatka.core.players.interactors import (
 from shvatka.core.players.admin_interactors import (
     AdminSetPlayerEmailInteractor,
     AdminChangePlayerTgInteractor,
+    AdminSetPlayerUsernameInteractor,
     AdminMergePlayersInteractor,
     AdminSearchPlayersInteractor,
     AdminGetPlayerInteractor,
@@ -79,6 +80,7 @@ from shvatka.core.players.interfaces import (
     AdminPlayerReader,
     AdminEmailSetter,
     AdminTgChanger,
+    AdminUsernameSetter,
     AdminPlayerMerger,
     AdminPlayerWaiverPointsReader,
 )
@@ -156,6 +158,7 @@ from shvatka.infrastructure.db.dao.complex2.waiver import (
 from shvatka.infrastructure.db.dao.complex.player import (
     AdminEmailSetterImpl,
     AdminTgChangerImpl,
+    AdminUsernameSetterImpl,
     AdminPlayerMergerImpl,
     AdminPlayerReaderImpl,
     AdminPlayerWaiverPointsReaderImpl,
@@ -459,6 +462,10 @@ class AdminProvider(Provider):
         return AdminTgChangerImpl(dao)
 
     @provide
+    def admin_username_setter(self, dao: HolderDao) -> AdminUsernameSetter:
+        return AdminUsernameSetterImpl(dao)
+
+    @provide
     def admin_player_reader(self, dao: HolderDao) -> AdminPlayerReader:
         return AdminPlayerReaderImpl(dao)
 
@@ -477,6 +484,7 @@ class AdminProvider(Provider):
     # Interactors
     admin_set_email = provide(AdminSetPlayerEmailInteractor)
     admin_change_tg = provide(AdminChangePlayerTgInteractor)
+    admin_set_username = provide(AdminSetPlayerUsernameInteractor)
     admin_get_player = provide(AdminGetPlayerInteractor)
     admin_poll_reader = provide(AdminPollReaderInteractor)
     admin_remove_poll_vote = provide(AdminRemovePollVoteInteractor)

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -230,6 +230,95 @@ async def test_change_tg_conflict(
 
 
 @pytest.mark.asyncio
+async def test_change_username(
+    client: AsyncClient,
+    admin_token: Token,
+    hermione: dto.Player,
+    check_dao: HolderDao,
+):
+    resp = await client.put(
+        f"/admin/players/{hermione.id}/username",
+        json={"username": "granger"},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success
+    assert resp.json()["username"] == "granger"
+    reloaded = await check_dao.player.get_by_id(hermione.id)
+    assert reloaded.username == "granger"
+
+
+@pytest.mark.asyncio
+async def test_change_username_invalid(
+    client: AsyncClient,
+    admin_token: Token,
+    hermione: dto.Player,
+    check_dao: HolderDao,
+):
+    before = (await check_dao.player.get_by_id(hermione.id)).username
+    resp = await client.put(
+        f"/admin/players/{hermione.id}/username",
+        json={"username": "не латиница"},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422
+    assert (await check_dao.player.get_by_id(hermione.id)).username == before
+
+
+@pytest.mark.asyncio
+async def test_change_username_occupied(
+    client: AsyncClient,
+    admin_token: Token,
+    harry: dto.Player,
+    hermione: dto.Player,
+    check_dao: HolderDao,
+):
+    harry_username = (await check_dao.player.get_by_id(harry.id)).username
+    assert harry_username is not None
+    resp = await client.put(
+        f"/admin/players/{hermione.id}/username",
+        json={"username": harry_username},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_change_own_username_to_the_same_one(
+    client: AsyncClient,
+    admin_token: Token,
+    hermione: dto.Player,
+    check_dao: HolderDao,
+):
+    """Keeping a player's current username must not trip the occupied check."""
+    current = (await check_dao.player.get_by_id(hermione.id)).username
+    assert current is not None
+    resp = await client.put(
+        f"/admin/players/{hermione.id}/username",
+        json={"username": current},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success
+    assert resp.json()["username"] == current
+
+
+@pytest.mark.asyncio
+async def test_change_username_forbidden_for_non_superuser(
+    client: AsyncClient, hermione_token: Token, hermione: dto.Player
+):
+    resp = await client.put(
+        f"/admin/players/{hermione.id}/username",
+        json={"username": "granger"},
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_poll_empty(client: AsyncClient, admin_token: Token):
     resp = await client.get(
         "/admin/poll",

--- a/tests/integration/test_save_user.py
+++ b/tests/integration/test_save_user.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import pytest
 
+from shvatka.infrastructure.db import models
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.services.identity import save_user
 from shvatka.tgbot.utils.data import SHMiddlewareData
@@ -35,3 +36,27 @@ async def test_upsert_user(dao: HolderDao):
     assert_user(expected, actual)
     assert old.db_id == actual.db_id
     assert await dao.user.count() == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_user_refreshes_already_loaded_user(dao: HolderDao):
+    """An upsert must win over the copy of the user the session already holds.
+
+    The session does not expire on commit, so a stale user would otherwise be
+    handed out both by the upsert itself and by every relationship loading it.
+    """
+    old = await dao.user.upsert_user(create_dto_harry())
+    await dao.commit()
+    # keep the mapped instance alive, so it can't leave the identity map
+    loaded = await dao.session.get(models.User, old.db_id)
+    assert loaded is not None
+
+    renamed = create_dto_harry()
+    renamed.first_name = "Гарри"
+    renamed.last_name = "Поттер"
+    actual = await dao.user.upsert_user(renamed)
+    await dao.commit()
+
+    assert_user(renamed, actual)
+    assert loaded.first_name == "Гарри"
+    assert loaded.last_name == "Поттер"


### PR DESCRIPTION
The admin panel could already change a player's email and relink their telegram account. This adds the third identity field: the username itself.

## Changes

- `AdminSetPlayerUsernameInteractor` (`core/players/admin_interactors.py`) — authorises through `identity.get_superuser()`, logs the acting admin, validates the new username with `validate_new_username` (same rules as the self-service change) and delegates to the existing `set_player_username`, which rejects an occupied one.
- `AdminUsernameSetter` protocol + `AdminUsernameSetterImpl` adapter, wired into `AdminProvider`.
- `PUT /admin/players/{id}/username` returning the refreshed `PlayerWithIdentities`, so the UI can re-render the whole card. Invalid username → 422, occupied → 409 — matching the mapping the email-register route already uses.

Renaming a player to their own current username is a no-op success (`is_same_username` short-circuits the occupied check), which keeps the UI's "save" button harmless when nothing was edited.

## Second commit: a stale user in the session

The first push turned `tests/integration/test_player_username.py::test_renew_id_usernames` red, and it was not the new endpoint's doing — the test asserts that a player carrying an `id{id}` username gets renamed from their telegram names, and it got no rename at all.

Root cause: `UserDao.upsert_user` runs `INSERT … ON CONFLICT DO UPDATE … RETURNING User`, and sessions are created with `expire_on_commit=False`. When the user being upserted is already in the session's identity map, the ORM hands back that mapped instance without applying the returned row, so the upsert's own return value — and every relationship pointing at that user — keeps the pre-upsert names. `renew_id_usernames` then reads `player.user.first_name` as `None`, finds no name to build a username from, and renames nobody.

The test only ever passed because the mapped instance is weakly referenced: when it happened to be garbage-collected before the next read, the relationship reloaded from the database and saw the new names. That is why master is green and why this branch failed twice — the latent bug predates it.

Fix: pass `populate_existing=True` on that execute, so the returned row wins over what the session already holds. `tests/integration/test_save_user.py::test_upsert_user_refreshes_already_loaded_user` pins the mapped instance in the session and asserts both the returned dto and the mapped user carry the new names, so it fails deterministically without the fix rather than depending on the garbage collector.

## Tests

Integration tests in `tests/integration/api_full/test_admin.py`: successful rename, invalid username, occupied username, renaming to the current username, and the non-superuser 403. Plus the upsert regression test above.

Verified locally against a real Postgres: `ruff format --check`, `ruff check`, `mypy` clean, and the full suite green (498 passed).