### PR TITLE
Collect prometheus metrics of outgoing Bot API requests

### DIFF
--- a/shvatka/api/main_factory.py
+++ b/shvatka/api/main_factory.py
@@ -2,6 +2,7 @@ import logging
 
 from asgi_monitor.integrations.fastapi import setup_metrics, MetricsConfig
 from fastapi import FastAPI
+from prometheus_client import REGISTRY
 
 from shvatka.api.app import error_handler, middlewares, router
 from shvatka.api.app.config.models.main import ApiConfig
@@ -22,6 +23,9 @@ def create_app(config: ApiConfig) -> FastAPI:
             app_name=config.app.name,
             include_metrics_endpoint=True,
             include_trace_exemplar=True,
+            # the global registry, so that metrics collected outside of asgi
+            # (e.g. outgoing bot api requests) are exposed by /metrics too
+            registry=REGISTRY,
         ),
     )
 

--- a/shvatka/infrastructure/di/bot.py
+++ b/shvatka/infrastructure/di/bot.py
@@ -6,6 +6,7 @@ from aiogram.enums import ParseMode
 from dishka import Provider, Scope, provide
 
 from shvatka.tgbot.config.models.bot import BotConfig
+from shvatka.tgbot.utils.metrics import setup_metrics
 from shvatka.tgbot.views.bot_alert import BotAlert
 from shvatka.tgbot.views.jinja_filters import setup_jinja
 
@@ -24,6 +25,7 @@ class BotProvider(Provider):
             ),
         ) as bot:
             setup_jinja(bot)
+            setup_metrics(bot)
             yield bot
 
     @provide

--- a/shvatka/tgbot/utils/metrics.py
+++ b/shvatka/tgbot/utils/metrics.py
@@ -1,0 +1,70 @@
+import time
+
+from aiogram import Bot
+from aiogram.client.session.middlewares.base import (
+    BaseRequestMiddleware,
+    NextRequestMiddlewareType,
+)
+from aiogram.methods import Response, TelegramMethod
+from aiogram.methods.base import TelegramType
+from prometheus_client import REGISTRY, Counter, Gauge, Histogram
+
+PREFIX = "tgbot_api"
+SUCCESS_STATUS = "success"
+
+requests_total = Counter(
+    name=f"{PREFIX}_requests_total",
+    documentation="Total count of requests sent to Telegram Bot API by method",
+    labelnames=["method"],
+    registry=REGISTRY,
+)
+responses_total = Counter(
+    name=f"{PREFIX}_responses_total",
+    documentation=(
+        "Total count of Telegram Bot API responses by method and status "
+        "(success or the name of the raised error)"
+    ),
+    labelnames=["method", "status"],
+    registry=REGISTRY,
+)
+request_duration = Histogram(
+    name=f"{PREFIX}_request_duration_seconds",
+    documentation="Histogram of Telegram Bot API request duration by method, in seconds",
+    labelnames=["method"],
+    registry=REGISTRY,
+)
+requests_in_progress = Gauge(
+    name=f"{PREFIX}_requests_in_progress",
+    documentation="Gauge of Telegram Bot API requests by method currently in progress",
+    labelnames=["method"],
+    registry=REGISTRY,
+)
+
+
+class RequestMetricsMiddleware(BaseRequestMiddleware):
+    """Collects prometheus metrics of outgoing Telegram Bot API requests."""
+
+    async def __call__(
+        self,
+        make_request: NextRequestMiddlewareType[TelegramType],
+        bot: Bot,
+        method: TelegramMethod[TelegramType],
+    ) -> Response[TelegramType]:
+        method_name = type(method).__name__
+        status = SUCCESS_STATUS
+        requests_total.labels(method=method_name).inc()
+        requests_in_progress.labels(method=method_name).inc()
+        started_at = time.perf_counter()
+        try:
+            return await make_request(bot, method)
+        except Exception as e:
+            status = type(e).__name__
+            raise
+        finally:
+            request_duration.labels(method=method_name).observe(time.perf_counter() - started_at)
+            responses_total.labels(method=method_name, status=status).inc()
+            requests_in_progress.labels(method=method_name).dec()
+
+
+def setup_metrics(bot: Bot) -> None:
+    bot.session.middleware(RequestMetricsMiddleware())

--- a/tests/unit/test_bot_api_metrics.py
+++ b/tests/unit/test_bot_api_metrics.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram.exceptions import TelegramBadRequest
+from aiogram.methods import GetMe, SendMessage
+from prometheus_client import REGISTRY
+
+from shvatka.tgbot.utils.metrics import RequestMetricsMiddleware
+
+
+def get_value(name: str, labels: dict[str, str]) -> float:
+    return REGISTRY.get_sample_value(name, labels) or 0.0
+
+
+@pytest.mark.asyncio
+async def test_success_request_counted():
+    method = GetMe()
+    labels = {"method": "GetMe"}
+    requests_before = get_value("tgbot_api_requests_total", labels)
+    responses_before = get_value("tgbot_api_responses_total", {**labels, "status": "success"})
+    duration_before = get_value("tgbot_api_request_duration_seconds_count", labels)
+
+    async def make_request(bot, method_):
+        return "result"
+
+    result = await RequestMetricsMiddleware()(make_request, AsyncMock(), method)
+
+    assert result == "result"
+    assert get_value("tgbot_api_requests_total", labels) == requests_before + 1
+    assert (
+        get_value("tgbot_api_responses_total", {**labels, "status": "success"})
+        == responses_before + 1
+    )
+    assert get_value("tgbot_api_request_duration_seconds_count", labels) == duration_before + 1
+    assert get_value("tgbot_api_requests_in_progress", labels) == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_request_counted():
+    method = SendMessage(chat_id=1, text="hello")
+    labels = {"method": "SendMessage"}
+    requests_before = get_value("tgbot_api_requests_total", labels)
+    errors_before = get_value(
+        "tgbot_api_responses_total", {**labels, "status": "TelegramBadRequest"}
+    )
+
+    async def make_request(bot, method_):
+        raise TelegramBadRequest(method=method_, message="chat not found")
+
+    with pytest.raises(TelegramBadRequest):
+        await RequestMetricsMiddleware()(make_request, AsyncMock(), method)
+
+    assert get_value("tgbot_api_requests_total", labels) == requests_before + 1
+    assert (
+        get_value("tgbot_api_responses_total", {**labels, "status": "TelegramBadRequest"})
+        == errors_before + 1
+    )
+    assert get_value("tgbot_api_requests_in_progress", labels) == 0


### PR DESCRIPTION
Closes #97.

## What

Outgoing requests to the Telegram Bot API were not instrumented at all — there was no way to see the bot's request rate, its error rate, or which API methods it spends its time on. This adds an aiogram **session** middleware (`RequestMetricsMiddleware`, `shvatka/tgbot/utils/metrics.py`) that wraps every request the bot makes, plus the plumbing to actually expose those metrics.

## Metrics

All labelled by `method` (the aiogram method class name: `SendMessage`, `GetUpdates`, `EditMessageText`, …):

| metric | type | labels | purpose |
| --- | --- | --- | --- |
| `tgbot_api_requests_total` | Counter | `method` | rps — `rate(tgbot_api_requests_total[1m])` |
| `tgbot_api_responses_total` | Counter | `method`, `status` | errors — `status` is `success` or the raised error class (`TelegramBadRequest`, `TelegramRetryAfter`, `TelegramNetworkError`, …) |
| `tgbot_api_request_duration_seconds` | Histogram | `method` | latency per method |
| `tgbot_api_requests_in_progress` | Gauge | `method` | in-flight requests |

The middleware never swallows anything — the original exception is re-raised after the metrics are written in `finally`.

## Wiring

- Registered on the bot session in `BotProvider.get_bot` (`shvatka/infrastructure/di/bot.py`), next to `setup_jinja`, so every entrypoint that builds a `Bot` through DI gets it.
- `create_app` passed no `registry` to asgi-monitor's `MetricsConfig`, and its default is a **private** `CollectorRegistry`. That meant `/metrics` exposed only asgi-monitor's own ASGI metrics — anything in the global prometheus registry (these new metrics, and the pre-existing `privacy_got` counter) was invisible. It now passes the global `REGISTRY`, so both sets are served by the same endpoint (default process/GC collectors come along too).

Note that exposition still comes from the FastAPI `/metrics` route, i.e. the production `python -m shvatka` entrypoint where bot and API share a process. The polling-only `shvatka-tgbot` entrypoint has no HTTP server, so it collects but does not serve them; adding an exporter there can be a follow-up if that mode ever needs scraping.

## Tests

`tests/unit/test_bot_api_metrics.py` drives the middleware with a fake `make_request` and asserts, on deltas of the registry samples, that a successful call increments requests/responses(`success`)/duration-count and leaves the in-progress gauge at zero, and that a failing call re-raises and is counted under `status="TelegramBadRequest"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015hmFHnashks4g2Mr7ggCUJ)_