### PR TITLE
Render every dialog window in the preview

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,10 +149,12 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies
         run: uv sync --group test
-      - name: Render Aiogram-dialogs transitions
+      - name: Render Aiogram-dialogs transitions and preview
         run: source .venv/bin/activate && python -m shvatka.tgbot.dialogs.__init__
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: transitions
-          path: out/shvatka-dialogs.png
+          path: |
+            out/shvatka-dialogs.png
+            out/shvatka-dialogs-preview.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,6 +322,13 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   that's expected, and there's no need to translate them when you touch a file —
   but anything you add should be English. User-facing strings (bot replies,
   Excel report headers, etc.) stay Russian.
+- **Every aiogram_dialog `Window` with a getter needs `preview_data`.** Getters
+  are not called in preview mode, so a window without it renders against an
+  empty dict. Reuse the fixtures in `shvatka/tgbot/dialogs/preview_data.py` and
+  add new ones there. `tests/unit/test_dialogs_preview.py` renders every window
+  and fails when one is missing; `python -m shvatka.tgbot.dialogs.__init__`
+  writes the page to `out/shvatka-dialogs-preview.html`. Each state of a
+  `StatesGroup` must have a window too — the same test asserts it.
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes

--- a/shvatka/tgbot/dialogs/__init__.py
+++ b/shvatka/tgbot/dialogs/__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from aiogram import Router, F
 from aiogram.enums import ChatType
 from aiogram_dialog import setup_dialogs
@@ -24,6 +26,7 @@ from shvatka.tgbot.dialogs import (
     effects,
     profile,
 )
+from shvatka.tgbot.dialogs.preview import render_dialogs_preview
 from shvatka.tgbot.filters import GameStatusFilter
 
 
@@ -73,6 +76,8 @@ def setup_active_game_dialogs() -> Router:
 def render_all():
     router = Router(name="main")
     setup(router, MessageManager())
+    # preview first: it needs no graphviz, so it is produced even without `dot`
+    asyncio.run(render_dialogs_preview(router))
     render_transitions(router, title="Shvatka", filename="out/shvatka-dialogs")
 
 

--- a/shvatka/tgbot/dialogs/__init__.py
+++ b/shvatka/tgbot/dialogs/__init__.py
@@ -2,7 +2,7 @@ import asyncio
 
 from aiogram import Router, F
 from aiogram.enums import ChatType
-from aiogram_dialog import setup_dialogs
+from aiogram_dialog import Dialog, setup_dialogs
 from aiogram_dialog.api.protocols import MessageManagerProtocol, BgManagerFactory
 from aiogram_dialog.manager.message_manager import MessageManager
 from aiogram_dialog.tools import render_transitions
@@ -28,6 +28,41 @@ from shvatka.tgbot.dialogs import (
 )
 from shvatka.tgbot.dialogs.preview import render_dialogs_preview
 from shvatka.tgbot.filters import GameStatusFilter
+
+DIALOG_PACKAGES = (
+    starters,
+    main_menu,
+    profile,
+    game_manage,
+    game_scn,
+    level_scn,
+    time_hint,
+    level_manage,
+    game_orgs,
+    game_publish,
+    team_manage,
+    merge,
+    team_view,
+    player_view,
+    timers,
+    effects,
+    game_spy,
+)
+
+
+def collect_all_dialogs() -> list[Dialog]:
+    """Every dialog of the bot, without attaching it to a router.
+
+    Dialogs are module-level singletons, so `setup` can run only once per
+    process - which the bot itself does. Tools that only need to read the
+    dialogs (the preview) go through here instead.
+    """
+    found: dict[int, Dialog] = {}
+    for package in DIALOG_PACKAGES:
+        for obj in vars(package).values():
+            if isinstance(obj, Dialog):
+                found.setdefault(id(obj), obj)
+    return list(found.values())
 
 
 def setup(router: Router, message_manager: MessageManagerProtocol) -> BgManagerFactory:
@@ -74,10 +109,10 @@ def setup_active_game_dialogs() -> Router:
 
 
 def render_all():
+    # preview first: it needs no graphviz, so it is produced even without `dot`
+    asyncio.run(render_dialogs_preview(collect_all_dialogs()))
     router = Router(name="main")
     setup(router, MessageManager())
-    # preview first: it needs no graphviz, so it is produced even without `dot`
-    asyncio.run(render_dialogs_preview(router))
     render_transitions(router, title="Shvatka", filename="out/shvatka-dialogs")
 
 

--- a/shvatka/tgbot/dialogs/effects/dialogs.py
+++ b/shvatka/tgbot/dialogs/effects/dialogs.py
@@ -25,6 +25,7 @@ from .handlers import (
     not_correct_id,
     process_routed_level_id,
 )
+from shvatka.tgbot.dialogs.preview_data import PREVIEW_EFFECTS_DATA, PREVIEW_HINTS_DATA
 
 
 effects = Dialog(
@@ -75,6 +76,7 @@ effects = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.EffectsSG.menu,
         getter=get_effects,
+        preview_data=PREVIEW_EFFECTS_DATA,
     ),
     Window(
         Jinja(
@@ -96,6 +98,7 @@ effects = Dialog(
         ),
         state=states.EffectsSG.bonus,
         getter=get_effects,
+        preview_data=PREVIEW_EFFECTS_DATA,
     ),
     Window(
         Jinja("🔀Переход на уровень:\n{{next_level}}"),
@@ -112,6 +115,7 @@ effects = Dialog(
         ),
         state=states.EffectsSG.routed_level_up,
         getter=get_effects,
+        preview_data=PREVIEW_EFFECTS_DATA,
     ),
     Window(
         Jinja("💡Подсказки\n\n{{hints | hints}}"),
@@ -143,6 +147,7 @@ effects = Dialog(
         ),
         getter=get_hints,
         state=states.EffectsSG.hints,
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     Window(
         Jinja("Подсказка выходящая в {{time}} мин."),
@@ -161,6 +166,7 @@ effects = Dialog(
         ),
         getter=get_hints,
         state=states.EffectsSG.add_hints,
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     on_start=effects_on_start,
 )

--- a/shvatka/tgbot/dialogs/game_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_manage/dialogs.py
@@ -49,7 +49,14 @@ from .handlers import (
     show_all_keys,
     show_transitions,
 )
-from shvatka.tgbot.dialogs.preview_data import PREVIEW_GAME, PreviewSwitchTo, PreviewStart
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_GAME,
+    PREVIEW_NOW,
+    PREVIEW_RESULTS_MEDIA,
+    PREVIEW_WAIVERS,
+    PreviewStart,
+    PreviewSwitchTo,
+)
 
 games = Dialog(
     Window(
@@ -125,7 +132,7 @@ games = Dialog(
         ),
         state=states.CompletedGamesPanelSG.game,
         getter=get_completed_game,
-        preview_data={"game": PREVIEW_GAME},
+        preview_data={"game": PREVIEW_GAME, "webapp_url": "https://shvatka.ru/games/1"},
         preview_add_transitions=[
             PreviewStart(states.GameOrgsSG.orgs_list),
         ],
@@ -161,6 +168,7 @@ games = Dialog(
         ),
         getter=get_game_waivers,
         state=states.CompletedGamesPanelSG.waivers,
+        preview_data={"game": PREVIEW_GAME, "waivers": PREVIEW_WAIVERS},
     ),
     Window(
         DynamicMedia(selector="results.png"),
@@ -185,6 +193,7 @@ games = Dialog(
         ),
         getter=get_game_results,
         state=states.CompletedGamesPanelSG.results,
+        preview_data={"game": PREVIEW_GAME, "results.png": PREVIEW_RESULTS_MEDIA},
     ),
     Window(
         Jinja("Сценарий игры тут: {{invite}}\n"),
@@ -200,6 +209,7 @@ games = Dialog(
         ),
         getter=get_game_with_channel,
         state=states.CompletedGamesPanelSG.scenario_channel,
+        preview_data={"game": PREVIEW_GAME, "invite": "https://t.me/+preview"},
     ),
     Window(
         Jinja(
@@ -224,6 +234,7 @@ games = Dialog(
         ),
         getter=get_game_keys,
         state=states.CompletedGamesPanelSG.keys,
+        preview_data={"game": PREVIEW_GAME, "key_link": "https://telegra.ph/keys"},
     ),
 )
 
@@ -358,6 +369,7 @@ my_games = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.MyGamesPanelSG.game_menu),
         state=states.MyGamesPanelSG.rename,
         getter=get_game,
+        preview_data={"game": PREVIEW_GAME},
     ),
 )
 
@@ -393,7 +405,7 @@ schedule_game_dialog = Dialog(
         ),
         Cancel(Const("🔙Назад")),
         getter=get_game_time,
-        preview_data={"game": PREVIEW_GAME, "has_time": True},
+        preview_data={"game": PREVIEW_GAME, "has_time": True, "scheduled_time": "21:00"},
         state=states.GameScheduleSG.time,
     ),
     Window(
@@ -411,7 +423,7 @@ schedule_game_dialog = Dialog(
         ),
         Cancel(Const("❌Отменить")),
         getter=get_game_datetime,
-        preview_data={"game": PREVIEW_GAME},
+        preview_data={"game": PREVIEW_GAME, "scheduled_datetime": PREVIEW_NOW},
         state=states.GameScheduleSG.confirm,
     ),
 )

--- a/shvatka/tgbot/dialogs/game_orgs/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_orgs/dialogs.py
@@ -13,6 +13,12 @@ from aiogram_dialog.widgets.text import Format, Const, Multi, Jinja
 from shvatka.tgbot import states
 from .getters import get_orgs, get_org
 from .handlers import select_org, change_permission_handler, change_deleted_handler
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_ORG,
+    PREVIEW_ORG_PERMISSIONS,
+    PREVIEW_ORGS,
+    PREVIEW_SIMPLE_GAME,
+)
 
 game_orgs = Dialog(
     Window(
@@ -41,6 +47,11 @@ game_orgs = Dialog(
         Cancel(Const("🔙Назад")),
         getter=get_orgs,
         state=states.GameOrgsSG.orgs_list,
+        preview_data={
+            "game": PREVIEW_SIMPLE_GAME,
+            "orgs": PREVIEW_ORGS,
+            "inline_query": "add-game-org-token",
+        },
     ),
     Window(
         Multi(
@@ -84,5 +95,6 @@ game_orgs = Dialog(
         Back(text=Const("К списку организаторов")),
         getter=get_org,
         state=states.GameOrgsSG.org_menu,
+        preview_data={"org": PREVIEW_ORG, **PREVIEW_ORG_PERMISSIONS},
     ),
 )

--- a/shvatka/tgbot/dialogs/game_publish/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_publish/dialogs.py
@@ -10,6 +10,7 @@ from shvatka.tgbot import states
 from .getters import get_org
 from .handlers import process_publish_message
 from shvatka.tgbot.dialogs.game_manage.handlers import publish_game_forum
+from shvatka.tgbot.dialogs.preview_data import PREVIEW_AUTHOR, PREVIEW_SIMPLE_GAME
 
 game_publish = Dialog(
     Window(
@@ -38,6 +39,13 @@ game_publish = Dialog(
         MessageInput(func=process_publish_message, filter=Command("publish")),
         state=states.GamePublishSG.prepare,
         getter=get_org,
+        preview_data={
+            "game": PREVIEW_SIMPLE_GAME,
+            "player": PREVIEW_AUTHOR,
+            "started": False,
+            "started_at": None,
+            "text_invite": None,
+        },
     ),
     Window(
         Jinja(

--- a/shvatka/tgbot/dialogs/game_scn/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_scn/dialogs.py
@@ -15,7 +15,12 @@ from aiogram_dialog.widgets.text import Const, Format, Jinja
 from shvatka.tgbot import states
 from .getters import get_game_name, select_my_levels, select_full_game
 from .handlers import process_name, save_game, edit_level, add_level_handler, process_zip_scn
-from shvatka.tgbot.dialogs.preview_data import PreviewStart
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_FULL_GAME,
+    PREVIEW_GAME,
+    PREVIEW_LEVELS,
+    PreviewStart,
+)
 
 game_writer = Dialog(
     Window(
@@ -60,6 +65,7 @@ game_writer = Dialog(
         Cancel(Const("🔙Не создавать игру")),
         state=states.GameWriteSG.levels,
         getter=[get_game_name, select_my_levels],
+        preview_data={"game_name": PREVIEW_GAME.name, "levels": PREVIEW_LEVELS},
     ),
     Window(
         Const("Жду zip-файл с готовой игрой"),
@@ -94,6 +100,7 @@ game_editor = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.GameEditSG.current_levels,
         getter=select_full_game,
+        preview_data={"game": PREVIEW_FULL_GAME, "levels": PREVIEW_LEVELS},
         preview_add_transitions=[
             PreviewStart(states.LevelTestSG.wait_key),
         ],
@@ -116,5 +123,6 @@ game_editor = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.GameEditSG.current_levels),
         state=states.GameEditSG.add_level,
         getter=(select_full_game, select_my_levels),
+        preview_data={"game": PREVIEW_FULL_GAME, "levels": PREVIEW_LEVELS},
     ),
 )

--- a/shvatka/tgbot/dialogs/game_spy/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_spy/dialogs.py
@@ -6,6 +6,12 @@ from aiogram_dialog.widgets.text import Const, Jinja, Multi
 from shvatka.tgbot import states
 from .getters import get_org, get_spy, get_keys
 from .handlers import keys_handler
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_FINISHED_LEVEL_TIME,
+    PREVIEW_NOW,
+    PREVIEW_SPY_ORG,
+    PREVIEW_SPY_STAT,
+)
 
 game_spy = Dialog(
     Window(
@@ -34,6 +40,7 @@ game_spy = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.OrgSpySG.main,
         getter=get_org,
+        preview_data=PREVIEW_SPY_ORG,
     ),
     Window(
         Const("Актуальные сведения с полей схватки:"),
@@ -56,6 +63,12 @@ game_spy = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.OrgSpySG.main),
         state=states.OrgSpySG.spy,
         getter=(get_spy, get_org),
+        preview_data={
+            **PREVIEW_SPY_ORG,
+            "stat": PREVIEW_SPY_STAT,
+            "finished": [PREVIEW_FINISHED_LEVEL_TIME],
+            "now": PREVIEW_NOW,
+        },
     ),
     Window(
         Jinja(
@@ -73,6 +86,11 @@ game_spy = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.OrgSpySG.main),
         state=states.OrgSpySG.keys,
         getter=(get_org, get_keys),
+        preview_data={
+            **PREVIEW_SPY_ORG,
+            "key_link": "https://telegra.ph/keys",
+            "updated": PREVIEW_NOW,
+        },
         disable_web_page_preview=True,
     ),
 )

--- a/shvatka/tgbot/dialogs/level_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/level_manage/dialogs.py
@@ -19,7 +19,14 @@ from .handlers import (
     unlink_level_handler,
     delete_level_handler,
 )
-from shvatka.tgbot.dialogs.preview_data import PreviewStart
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_FULL_GAME,
+    PREVIEW_LEVEL,
+    PREVIEW_LEVELS,
+    PREVIEW_MANAGED_LEVEL,
+    PREVIEW_ORGS,
+    PreviewStart,
+)
 
 levels_list = Dialog(
     Window(
@@ -39,6 +46,7 @@ levels_list = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.LevelListSG.levels,
         getter=get_levels,
+        preview_data={"levels": PREVIEW_LEVELS},
         preview_add_transitions=[PreviewStart(states.LevelManageSG.menu)],
     ),
 )
@@ -91,6 +99,7 @@ level_manage = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.LevelManageSG.menu,
         getter=get_level_id,
+        preview_data=PREVIEW_MANAGED_LEVEL,
         preview_add_transitions=[
             PreviewStart(states.LevelEditSg.menu),
             PreviewStart(states.LevelTestSG.wait_key),
@@ -117,6 +126,11 @@ level_manage = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.LevelManageSG.menu),
         state=states.LevelManageSG.send_to_test,
         getter=get_orgs,
+        preview_data={
+            "game": PREVIEW_FULL_GAME,
+            "orgs": PREVIEW_ORGS,
+            "level": PREVIEW_LEVEL,
+        },
     ),
 )
 
@@ -132,6 +146,7 @@ level_test_dialog = Dialog(
         ),
         getter=get_level_id,
         state=states.LevelTestSG.wait_key,
+        preview_data=PREVIEW_MANAGED_LEVEL,
         preview_add_transitions=[Cancel()],
     ),
 )

--- a/shvatka/tgbot/dialogs/level_scn/dialogs.py
+++ b/shvatka/tgbot/dialogs/level_scn/dialogs.py
@@ -53,7 +53,16 @@ from .handlers import (
     save_effects_condition,
     delete_effects_condition,
 )
-from shvatka.tgbot.dialogs.preview_data import PreviewStart
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_EFFECTS,
+    PREVIEW_EFFECTS_CONDITIONS,
+    PREVIEW_GAME,
+    PREVIEW_KEYS,
+    PREVIEW_LEVEL,
+    PREVIEW_LEVEL_SCN,
+    PREVIEW_TIME_HINTS,
+    PreviewStart,
+)
 
 level = Dialog(
     Window(
@@ -128,9 +137,7 @@ level = Dialog(
         ),
         state=states.LevelSG.menu,
         getter=get_level_data,
-        preview_data={
-            "level_id": "Pinky Pie",
-        },
+        preview_data=PREVIEW_LEVEL_SCN,
         preview_add_transitions=[
             PreviewStart(state=states.LevelKeysSG.keys),
             PreviewStart(state=states.LevelEffectsKeysSG.menu),
@@ -180,9 +187,7 @@ level_edit_dialog = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.LevelEditSg.menu,
         getter=get_level_data,
-        preview_data={
-            "level_id": "Pinky Pie",
-        },
+        preview_data=PREVIEW_LEVEL_SCN,
         preview_add_transitions=[
             PreviewStart(state=states.LevelKeysSG.keys),
             PreviewStart(state=states.LevelEffectsKeysSG.menu),
@@ -226,6 +231,7 @@ keys_dialog = Dialog(
         ),
         state=states.LevelKeysSG.keys,
         getter=(get_level_id, get_keys),
+        preview_data={"level_id": PREVIEW_LEVEL.name_id, "keys": PREVIEW_KEYS},
     ),
 )
 
@@ -268,8 +274,9 @@ hints_dialog = Dialog(
         state=states.LevelHintsSG.time_hints,
         getter=get_time_hints,
         preview_data={
-            "time_hints": [],
-            "level_id": "Pinky Pie",
+            "time_hints": PREVIEW_TIME_HINTS,
+            "level_id": PREVIEW_LEVEL.name_id,
+            "dialog_data": {"time_hints": PREVIEW_TIME_HINTS},
         },
         preview_add_transitions=[
             PreviewStart(state=states.TimeHintSG.time),
@@ -323,6 +330,11 @@ effects_key_dialog = Dialog(
         preview_add_transitions=[
             PreviewStart(state=states.KeyEffectsSG.menu),
         ],
+        preview_data={
+            "level_id": PREVIEW_LEVEL.name_id,
+            "effects_conditions": PREVIEW_EFFECTS_CONDITIONS,
+            "game_id": PREVIEW_GAME.id,
+        },
         getter=(get_level_id, get_effects_conditions),
         state=states.LevelEffectsKeysSG.menu,
     ),
@@ -350,6 +362,7 @@ key_effects_condition_dialog = Dialog(
             PreviewStart(state=states.LevelKeysSG.keys),
             PreviewStart(state=states.EffectsSG.menu),
         ],
+        preview_data={"keys": PREVIEW_KEYS, "effects": PREVIEW_EFFECTS},
         getter=get_effects_condition,
         state=states.KeyEffectsSG.menu,
     ),

--- a/shvatka/tgbot/dialogs/main_menu/dialogs.py
+++ b/shvatka/tgbot/dialogs/main_menu/dialogs.py
@@ -6,6 +6,14 @@ from aiogram_dialog.widgets.text import Const, Format, Jinja
 from shvatka.core.models import enums
 from shvatka.tgbot import states
 from .getters import get_promotion_token, get_main
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_AUTHOR,
+    PREVIEW_ORG,
+    PREVIEW_SIMPLE_GAME,
+    PREVIEW_TEAM,
+    PREVIEW_TEAM_PLAYER,
+    PREVIEW_VOTE,
+)
 
 main_menu = Dialog(
     Window(
@@ -109,6 +117,14 @@ main_menu = Dialog(
         # ачивки
         state=states.MainMenuSG.main,
         getter=get_main,
+        preview_data={
+            "player": PREVIEW_AUTHOR,
+            "game": PREVIEW_SIMPLE_GAME,
+            "org": PREVIEW_ORG,
+            "team": PREVIEW_TEAM,
+            "team_player": PREVIEW_TEAM_PLAYER,
+            "waiver": PREVIEW_VOTE,
+        },
     ),
 )
 
@@ -134,5 +150,6 @@ promote_dialog = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.PromotionSG.disclaimer,
         getter=get_promotion_token,
+        preview_data={"player": PREVIEW_AUTHOR, "inline_query": "promote-player-token"},
     )
 )

--- a/shvatka/tgbot/dialogs/merge/dialogs.py
+++ b/shvatka/tgbot/dialogs/merge/dialogs.py
@@ -7,6 +7,12 @@ from aiogram_dialog.widgets.text import Jinja, Const
 from shvatka.tgbot import states
 from .getters import get_team, get_forum_team, get_forum_teams, get_forum_user
 from .handlers import select_forum_team, confirm_merge, player_link_handler, confirm_merge_player
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_FORUM_TEAM,
+    PREVIEW_FORUM_TEAMS,
+    PREVIEW_FORUM_USER,
+    PREVIEW_TEAM,
+)
 
 merge_teams_dialog = Dialog(
     Window(
@@ -24,6 +30,7 @@ merge_teams_dialog = Dialog(
         Cancel(Const("🔙Ой нет, это я случайно")),
         getter=get_team,
         state=states.MergeTeamsSG.main,
+        preview_data={"team": PREVIEW_TEAM},
     ),
     Window(
         Jinja("Итак мы ищем форумную версию для команды {{team.name}}"),
@@ -42,6 +49,7 @@ merge_teams_dialog = Dialog(
         Cancel(Const("🔙Не надо ничего объединять")),
         getter=(get_team, get_forum_teams),
         state=states.MergeTeamsSG.list_forum,
+        preview_data={"team": PREVIEW_TEAM, "forum_teams": PREVIEW_FORUM_TEAMS},
     ),
     Window(
         Jinja(
@@ -57,6 +65,7 @@ merge_teams_dialog = Dialog(
         Cancel(Const("🔙Нет!!")),
         getter=(get_team, get_forum_team),
         state=states.MergeTeamsSG.confirm,
+        preview_data={"team": PREVIEW_TEAM, "forum_team": PREVIEW_FORUM_TEAM},
     ),
 )
 
@@ -103,5 +112,6 @@ merge_player_dialog = Dialog(
         Cancel(Const("🔙Я передумал, не надо")),
         getter=get_forum_user,
         state=states.MergePlayersSG.confirm,
+        preview_data={"forum_user": PREVIEW_FORUM_USER},
     ),
 )

--- a/shvatka/tgbot/dialogs/player_view/dialogs.py
+++ b/shvatka/tgbot/dialogs/player_view/dialogs.py
@@ -4,6 +4,7 @@ from aiogram_dialog.widgets.text import Jinja, Const
 
 from shvatka.tgbot import states
 from .getters import player_getter
+from shvatka.tgbot.dialogs.preview_data import PREVIEW_PLAYER_STAT
 
 player_dialog = Dialog(
     Window(
@@ -23,5 +24,6 @@ player_dialog = Dialog(
         Cancel(Const("🔙Выход")),
         getter=player_getter,
         state=states.PlayerSg.main,
+        preview_data=PREVIEW_PLAYER_STAT,
     ),
 )

--- a/shvatka/tgbot/dialogs/preview.py
+++ b/shvatka/tgbot/dialogs/preview.py
@@ -4,21 +4,45 @@ The preview never touches a bot, a database or the DI container: windows are
 rendered from their ``preview_data`` (see :mod:`shvatka.tgbot.dialogs.preview_data`).
 """
 
+from collections.abc import Iterable
 from pathlib import Path
 
-from aiogram import Router
-from aiogram_dialog.tools.preview import render_preview
+from aiogram_dialog import Dialog
+from aiogram_dialog.tools.preview import FakeManager, render_dialog
 from aiogram_dialog.widgets.text.jinja import default_env
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 from shvatka.tgbot.views.jinja_filters import get_filters
 
 DEFAULT_PREVIEW_FILE = "out/shvatka-dialogs-preview.html"
 
 
-async def render_dialogs_preview(router: Router, filename: str = DEFAULT_PREVIEW_FILE) -> None:
+async def render_dialogs_preview(
+    dialogs: Iterable[Dialog], filename: str = DEFAULT_PREVIEW_FILE
+) -> None:
+    """Render the given dialogs into an html page.
+
+    Takes dialogs rather than a router: they are module-level singletons and can
+    be attached to a router only once per process, which the bot itself does.
+    """
     # There is neither Bot nor Dispatcher while rendering a preview, so the Jinja
     # widget falls back to the library-wide default environment. Teach that one
     # our filters, otherwise every window using them fails to render.
     default_env.filters.update(get_filters())
-    Path(filename).parent.mkdir(parents=True, exist_ok=True)
-    await render_preview(router, filename)
+    manager = FakeManager()
+    rendered = [
+        await render_dialog(
+            manager=manager,
+            group=dialog.states_group(),
+            dialog=dialog,
+            simulate_events=False,
+        )
+        for dialog in dialogs
+    ]
+    env = Environment(
+        loader=PackageLoader("aiogram_dialog.tools"),
+        autoescape=select_autoescape(),
+    )
+    path = Path(filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(env.get_template("message.html").render(dialogs=rendered), encoding="utf-8")

--- a/shvatka/tgbot/dialogs/preview.py
+++ b/shvatka/tgbot/dialogs/preview.py
@@ -1,0 +1,24 @@
+"""Rendering every dialog window into one static html page.
+
+The preview never touches a bot, a database or the DI container: windows are
+rendered from their ``preview_data`` (see :mod:`shvatka.tgbot.dialogs.preview_data`).
+"""
+
+from pathlib import Path
+
+from aiogram import Router
+from aiogram_dialog.tools.preview import render_preview
+from aiogram_dialog.widgets.text.jinja import default_env
+
+from shvatka.tgbot.views.jinja_filters import get_filters
+
+DEFAULT_PREVIEW_FILE = "out/shvatka-dialogs-preview.html"
+
+
+async def render_dialogs_preview(router: Router, filename: str = DEFAULT_PREVIEW_FILE) -> None:
+    # There is neither Bot nor Dispatcher while rendering a preview, so the Jinja
+    # widget falls back to the library-wide default environment. Teach that one
+    # our filters, otherwise every window using them fails to render.
+    default_env.filters.update(get_filters())
+    Path(filename).parent.mkdir(parents=True, exist_ok=True)
+    await render_preview(router, filename)

--- a/shvatka/tgbot/dialogs/preview_data.py
+++ b/shvatka/tgbot/dialogs/preview_data.py
@@ -1,12 +1,28 @@
-from datetime import datetime
+"""Static data for rendering dialogs without a database.
 
+Every window with a getter needs a matching ``preview_data``: in preview mode
+the real getter is never called, so a window without it renders against an
+empty dict and usually just blows up on the first missing key.
+"""
+
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from aiogram.enums import ContentType
 from aiogram.fsm.state import State
+from aiogram_dialog.api.entities import MediaAttachment, MediaId
 from aiogram_dialog.widgets.kbd import Start, SwitchTo
 from aiogram_dialog.widgets.text import Const
 
-from shvatka.core.models import dto
+from shvatka.core.models import dto, enums
+from shvatka.core.models.dto import action, hints
+from shvatka.core.models.dto.scn.level import Conditions, HintsList, LevelScenario
 from shvatka.core.models.enums import GameStatus
+from shvatka.core.models.enums.played import Played
 from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.core.views.texts import PERMISSION_EMOJI
+
+PREVIEW_NOW = datetime(2024, 5, 18, 18, 0, tzinfo=tz_utc)
 
 PREVIEW_USER = dto.User(
     db_id=5,
@@ -18,15 +34,142 @@ PREVIEW_USER = dto.User(
 PREVIEW_AUTHOR = dto.Player(
     id=1,
     user=PREVIEW_USER,
+    username="bomzheg",
     can_be_author=True,
     is_dummy=False,
 )
+
+PREVIEW_PLAYER = dto.Player(
+    id=2,
+    user=dto.User(
+        db_id=6,
+        tg_id=901,
+        username="rainbow_dash",
+        first_name="Rainbow",
+        last_name="Dash",
+    ),
+    username="rainbow_dash",
+    can_be_author=False,
+    is_dummy=False,
+)
+
+PREVIEW_PLAYER_WITH_STAT = PREVIEW_AUTHOR.with_stat(
+    typed_keys_count=350,
+    typed_correct_keys_count=280,
+)
+
+PREVIEW_FORUM_USER = dto.ForumUser(
+    db_id=7,
+    forum_id=6767,
+    name="bomzheg",
+    registered=PREVIEW_NOW.date(),
+    player_id=PREVIEW_AUTHOR.id,
+)
+
+PREVIEW_FORUM_TEAM = dto.ForumTeam(
+    id=3,
+    forum_id=42,
+    name="Пони",
+    url="http://www.shvatka.ru/index.php?showtopic=42",
+)
+PREVIEW_FORUM_TEAMS = [PREVIEW_FORUM_TEAM]
+
+PREVIEW_TEAM = dto.Team(
+    id=1,
+    name="Пони",
+    captain=PREVIEW_AUTHOR,
+    is_dummy=False,
+    description="Дружба - это чудо",
+    chat=dto.Chat(
+        db_id=11,
+        tg_id=-100123456,
+        type=enums.ChatType.supergroup,
+        title="Пони",
+    ),
+)
+
+PREVIEW_ANOTHER_TEAM = dto.Team(
+    id=2,
+    name="Дискорд",
+    captain=PREVIEW_PLAYER,
+    is_dummy=False,
+    description=None,
+)
+
+PREVIEW_TEAMS = [PREVIEW_TEAM, PREVIEW_ANOTHER_TEAM]
+
+
+def _preview_team_player(
+    id_: int,
+    player: dto.Player,
+    role: str,
+    emoji: str,
+    team: dto.Team = PREVIEW_TEAM,
+    joined_days_ago: int = 365,
+    left_days_ago: int | None = None,
+) -> dto.FullTeamPlayer:
+    return dto.FullTeamPlayer(
+        id=id_,
+        player_id=player.id,
+        team_id=team.id,
+        date_joined=PREVIEW_NOW - timedelta(days=joined_days_ago),
+        date_left=None if left_days_ago is None else PREVIEW_NOW - timedelta(days=left_days_ago),
+        role=role,
+        emoji=emoji,
+        _can_manage_waivers=True,
+        _can_manage_players=True,
+        _can_change_team_name=True,
+        _can_add_players=True,
+        _can_remove_players=True,
+        player=player,
+        team=team,
+    )
+
+
+PREVIEW_TEAM_PLAYER = _preview_team_player(1, PREVIEW_AUTHOR, "Капитан", "👑")
+PREVIEW_SELECTED_TEAM_PLAYER = _preview_team_player(2, PREVIEW_PLAYER, "Пилот", "✈️")
+PREVIEW_TEAM_PLAYERS = [PREVIEW_TEAM_PLAYER, PREVIEW_SELECTED_TEAM_PLAYER]
+PREVIEW_LEFT_TEAM_PLAYER = _preview_team_player(
+    3,
+    PREVIEW_AUTHOR,
+    "Пилот",
+    "✈️",
+    team=PREVIEW_ANOTHER_TEAM,
+    joined_days_ago=730,
+    left_days_ago=365,
+)
+PREVIEW_TEAMS_HISTORY = [PREVIEW_LEFT_TEAM_PLAYER, PREVIEW_TEAM_PLAYER]
+PREVIEW_PERMISSIONS = {
+    permission.name: PERMISSION_EMOJI[value]
+    for permission, value in PREVIEW_SELECTED_TEAM_PLAYER.permissions.items()
+}
+
+PREVIEW_PLAYER_STAT = {
+    "player": PREVIEW_PLAYER_WITH_STAT,
+    "correct_keys": (
+        PREVIEW_PLAYER_WITH_STAT.typed_correct_keys_count
+        / PREVIEW_PLAYER_WITH_STAT.typed_keys_count
+    ),
+    "history": PREVIEW_TEAMS_HISTORY,
+}
+
+PREVIEW_MY_TEAM = {"team": PREVIEW_TEAM, "team_player": PREVIEW_TEAM_PLAYER}
+PREVIEW_TEAM_WITH_PLAYERS = {
+    **PREVIEW_MY_TEAM,
+    "players": [PREVIEW_SELECTED_TEAM_PLAYER],
+}
+PREVIEW_SELECTED_TEAM_PLAYER_DATA = {
+    **PREVIEW_MY_TEAM,
+    "selected_player": PREVIEW_PLAYER,
+    "selected_team_player": PREVIEW_SELECTED_TEAM_PLAYER,
+    **PREVIEW_PERMISSIONS,
+}
 
 PREVIEW_GAME = dto.PreviewGame(
     id=1,
     author=PREVIEW_AUTHOR,
     name="Схватка это чудо",
-    start_at=datetime.now(tz=tz_utc),
+    start_at=PREVIEW_NOW,
     status=GameStatus.getting_waivers,
     manage_token="1",
     results=dto.GameResults(
@@ -37,6 +180,169 @@ PREVIEW_GAME = dto.PreviewGame(
     number=1,
     levels_count=13,
 )
+PREVIEW_GAMES = [PREVIEW_GAME]
+
+PREVIEW_TEAM_CARD = {
+    "team": PREVIEW_TEAM,
+    "players": PREVIEW_TEAM_PLAYERS,
+    "games": PREVIEW_GAMES,
+    "game_numbers": [str(PREVIEW_GAME.number)],
+}
+
+PREVIEW_SIMPLE_GAME = dto.Game(
+    id=PREVIEW_GAME.id,
+    author=PREVIEW_GAME.author,
+    name=PREVIEW_GAME.name,
+    start_at=PREVIEW_GAME.start_at,
+    status=PREVIEW_GAME.status,
+    manage_token=PREVIEW_GAME.manage_token,
+    results=PREVIEW_GAME.results,
+    number=PREVIEW_GAME.number,
+)
+
+PREVIEW_ORG = dto.SecondaryOrganizer(
+    id=1,
+    player=PREVIEW_PLAYER,
+    game=PREVIEW_SIMPLE_GAME,
+    can_spy=True,
+    can_see_log_keys=True,
+    can_validate_waivers=False,
+    view_scenario=True,
+    deleted=False,
+)
+PREVIEW_ORGS = [PREVIEW_ORG]
+PREVIEW_ORG_PERMISSIONS = {
+    "can_spy": PERMISSION_EMOJI[PREVIEW_ORG.can_spy],
+    "can_see_log_keys": PERMISSION_EMOJI[PREVIEW_ORG.can_see_log_keys],
+    "can_validate_waivers": PERMISSION_EMOJI[PREVIEW_ORG.can_validate_waivers],
+    "view_scenario": PERMISSION_EMOJI[PREVIEW_ORG.view_scenario],
+}
+
+PREVIEW_SPY_ORG = {
+    "game": PREVIEW_SIMPLE_GAME,
+    "player": PREVIEW_AUTHOR,
+    "org": PREVIEW_ORG,
+}
+
+PREVIEW_KEYS = {"СХПОНИ", "СХДРУЖБА"}
+PREVIEW_HINTS: list[hints.AnyHint] = [
+    hints.TextHint(text="Загадка уровня: где живёт Пинки Пай?"),
+    hints.GPSHint(latitude=55.75, longitude=37.61),
+]
+PREVIEW_NUMERATED_HINTS = list(enumerate(PREVIEW_HINTS))
+PREVIEW_TIME_HINTS = [
+    hints.TimeHint(time=0, hint=[hints.TextHint(text="Загадка уровня")]),
+    hints.TimeHint(time=10, hint=[hints.TextHint(text="Подсказка про сахарный дворец")]),
+    hints.TimeHint(time=20, hint=[hints.TextHint(text="Совсем простая подсказка")]),
+]
+
+PREVIEW_HINTS_DATA = {
+    "hints": PREVIEW_HINTS,
+    "numerated_hints": PREVIEW_NUMERATED_HINTS,
+    "time": 10,
+    "has_hints": True,
+}
+
+PREVIEW_EFFECTS = action.Effects(
+    id=UUID("00000000-0000-0000-0000-000000000001"),
+    hints_=[hints.TextHint(text="Бонусная подсказка")],
+    bonus_minutes=-5.0,
+    level_up=False,
+    next_level=None,
+)
+PREVIEW_ROUTED_EFFECTS = action.Effects(
+    id=UUID("00000000-0000-0000-0000-000000000002"),
+    hints_=[hints.TextHint(text="Бонусная подсказка")],
+    bonus_minutes=-5.0,
+    level_up=True,
+    next_level="Fluttershy",
+)
+PREVIEW_TIMER = action.LevelTimerEffectsCondition(action_time=30, effects=PREVIEW_EFFECTS)
+PREVIEW_TIMERS = [PREVIEW_TIMER]
+PREVIEW_KEY_EFFECTS_CONDITION = action.KeyEffectsCondition(
+    keys={"СХБОНУС"},
+    effects=PREVIEW_EFFECTS,
+)
+PREVIEW_EFFECTS_CONDITIONS = list(enumerate([PREVIEW_KEY_EFFECTS_CONDITION]))
+
+PREVIEW_EFFECTS_DATA = {
+    "dialog_data": {"effect_id": str(PREVIEW_ROUTED_EFFECTS.id)},
+    "bonus_minutes": PREVIEW_ROUTED_EFFECTS.bonus_minutes,
+    "level_up": PREVIEW_ROUTED_EFFECTS.level_up,
+    "next_level": PREVIEW_ROUTED_EFFECTS.next_level,
+    "hints": PREVIEW_ROUTED_EFFECTS.hints_,
+    "level_id": "Pinky Pie",
+    "game_id": 1,
+}
+
+PREVIEW_LEVEL = dto.Level(
+    db_id=1,
+    name_id="Pinky Pie",
+    author=PREVIEW_AUTHOR,
+    scenario=LevelScenario(
+        id="Pinky Pie",
+        time_hints=HintsList(PREVIEW_TIME_HINTS),
+        conditions=Conditions([action.KeyWinCondition(PREVIEW_KEYS)]),
+        __model_version__=1,
+    ),
+    game_id=PREVIEW_GAME.id,
+    number_in_game=0,
+)
+PREVIEW_LEVELS = [PREVIEW_LEVEL]
+PREVIEW_MANAGED_LEVEL = {
+    "level": PREVIEW_LEVEL,
+    "time_hints": PREVIEW_TIME_HINTS,
+    "org": PREVIEW_ORG,
+}
+
+PREVIEW_LEVEL_SCN = {
+    "level_id": PREVIEW_LEVEL.name_id,
+    "keys": PREVIEW_KEYS,
+    "timers": PREVIEW_TIMERS,
+    "effects_key": [PREVIEW_KEY_EFFECTS_CONDITION],
+    "win_timer": None,
+    "time_hints": PREVIEW_TIME_HINTS,
+}
+
+PREVIEW_FULL_GAME = PREVIEW_SIMPLE_GAME.to_full_game(
+    levels=PREVIEW_LEVELS,  # type: ignore[arg-type]
+)
+
+PREVIEW_WAIVERS = {
+    PREVIEW_TEAM: [
+        dto.VotedPlayer(player=PREVIEW_AUTHOR, pit=PREVIEW_TEAM_PLAYER),
+        dto.VotedPlayer(player=PREVIEW_PLAYER, pit=PREVIEW_SELECTED_TEAM_PLAYER),
+    ],
+}
+PREVIEW_VOTE = Played.yes
+
+PREVIEW_LEVEL_TIME = dto.LevelTimeOnGame(
+    id=1,
+    game=PREVIEW_SIMPLE_GAME,
+    team=PREVIEW_TEAM,
+    level_number=0,
+    start_at=PREVIEW_NOW - timedelta(minutes=17),
+    is_finished=False,
+    hint=dto.SpyHintInfo(number=1, time=10),
+    name_id=PREVIEW_LEVEL.name_id,
+)
+PREVIEW_FINISHED_LEVEL_TIME = dto.LevelTimeOnGame(
+    id=2,
+    game=PREVIEW_SIMPLE_GAME,
+    team=PREVIEW_ANOTHER_TEAM,
+    level_number=1,
+    start_at=PREVIEW_NOW - timedelta(minutes=3),
+    is_finished=True,
+    hint=None,
+    name_id=None,
+)
+PREVIEW_SPY_STAT = {PREVIEW_LEVEL_TIME.level_number: [PREVIEW_LEVEL_TIME]}
+
+PREVIEW_RESULTS_MEDIA = MediaAttachment(
+    file_id=MediaId(file_id="preview-results-file-id"),
+    type=ContentType.PHOTO,
+)
+
 TIMES_PRESET = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
 
 

--- a/shvatka/tgbot/dialogs/profile/dialogs.py
+++ b/shvatka/tgbot/dialogs/profile/dialogs.py
@@ -9,6 +9,7 @@ from shvatka.tgbot.dialogs.profile.getters import (
     player_stat_getter,
     player_one_time_url_getter,
 )
+from shvatka.tgbot.dialogs.preview_data import PREVIEW_AUTHOR, PREVIEW_PLAYER_STAT
 from shvatka.tgbot.dialogs.profile.handlers import (
     save_new_username,
     validate_username,
@@ -52,6 +53,7 @@ profile_dialog = Dialog(
         Cancel(Const("🔙Выход")),
         state=states.ProfileSG.main,
         getter=player_stat_getter,
+        preview_data=PREVIEW_PLAYER_STAT,
     ),
     Window(
         Const("Введи адрес электронной почты, который хочешь привязать к аккаунту"),
@@ -97,6 +99,7 @@ profile_dialog = Dialog(
         ),
         state=states.ProfileSG.username,
         getter=player_getter,
+        preview_data={"player": PREVIEW_AUTHOR},
     ),
     Window(
         Jinja("{{player.username}}\nДля входа нажми на кнопку ниже"),
@@ -111,5 +114,6 @@ profile_dialog = Dialog(
         ),
         state=states.ProfileSG.one_time_login,
         getter=(player_getter, player_one_time_url_getter),
+        preview_data={"player": PREVIEW_AUTHOR, "url": "https://shvatka.ru/login?token=1"},
     ),
 )

--- a/shvatka/tgbot/dialogs/team_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_manage/dialogs.py
@@ -10,6 +10,11 @@ from .getters import (
     get_team_with_players,
     get_selected_player,
 )
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_MY_TEAM,
+    PREVIEW_SELECTED_TEAM_PLAYER_DATA,
+    PREVIEW_TEAM_WITH_PLAYERS,
+)
 from .handlers import (
     rename_team_handler,
     change_desc_team_handler,
@@ -79,6 +84,7 @@ captains_bridge = Dialog(
         Cancel(Const("🔙Назад")),
         state=states.CaptainsBridgeSG.main,
         getter=get_my_team_,
+        preview_data=PREVIEW_MY_TEAM,
     ),
     Window(
         Jinja("Переименовать команду 🚩<b>{{team.name}}</b>"),
@@ -86,6 +92,7 @@ captains_bridge = Dialog(
         TextInput(id="rename", on_success=rename_team_handler),
         getter=get_my_team_,
         state=states.CaptainsBridgeSG.name,
+        preview_data=PREVIEW_MY_TEAM,
     ),
     Window(
         Jinja("Изменить девиз команды 🚩<b>{{team.name}}</b>"),
@@ -93,6 +100,7 @@ captains_bridge = Dialog(
         TextInput(id="change_desc", on_success=change_desc_team_handler),
         getter=get_my_team_,
         state=states.CaptainsBridgeSG.description,
+        preview_data=PREVIEW_MY_TEAM,
     ),
     Window(
         Jinja("Игроки команды 🚩<b>{{team.name}}</b>"),
@@ -117,6 +125,7 @@ captains_bridge = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.CaptainsBridgeSG.main),
         getter=get_team_with_players,
         state=states.CaptainsBridgeSG.players,
+        preview_data=PREVIEW_TEAM_WITH_PLAYERS,
     ),
     Window(
         Jinja("Чтобы добавить игрока нажми на кнопку в самом внизу, затем выбери пользователя"),
@@ -129,6 +138,7 @@ captains_bridge = Dialog(
         ),
         getter=get_my_team_,
         state=states.CaptainsBridgeSG.add_player,
+        preview_data=PREVIEW_MY_TEAM,
     ),
     Window(
         TEAM_PLAYER_CARD,
@@ -184,6 +194,7 @@ captains_bridge = Dialog(
         SwitchTo(Const("🔙Назад"), id="back", state=states.CaptainsBridgeSG.players),
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.player,
+        preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
     ),
     Window(
         TEAM_PLAYER_CARD,
@@ -200,6 +211,7 @@ captains_bridge = Dialog(
         ),
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.confirm_delete,
+        preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
     ),
     Window(
         TEAM_PLAYER_CARD,
@@ -216,6 +228,7 @@ captains_bridge = Dialog(
         ),
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.player_role,
+        preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
     ),
     Window(
         TEAM_PLAYER_CARD,
@@ -232,5 +245,6 @@ captains_bridge = Dialog(
         ),
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.player_emoji,
+        preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
     ),
 )

--- a/shvatka/tgbot/dialogs/team_view/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_view/dialogs.py
@@ -13,6 +13,7 @@ from .handlers import (
     on_leave_team,
 )
 from shvatka.tgbot.dialogs.common import BOOL_VIEW
+from shvatka.tgbot.dialogs.preview_data import PREVIEW_TEAM_CARD, PREVIEW_TEAMS
 
 team_view = Dialog(
     Window(
@@ -37,6 +38,7 @@ team_view = Dialog(
         Cancel(Const("🔙Назад")),
         getter=teams_getter,
         state=states.TeamsSg.list,
+        preview_data={"teams": PREVIEW_TEAMS, "active": True, "archive": False},
     ),
     Window(
         Jinja(
@@ -60,6 +62,7 @@ team_view = Dialog(
         Cancel(Const("🔙Выход")),
         getter=team_getter,
         state=states.TeamsSg.one,
+        preview_data=PREVIEW_TEAM_CARD,
     ),
     Window(
         Const("Отметь типы команд для отображения"),
@@ -76,6 +79,7 @@ team_view = Dialog(
         SwitchTo(Const("🔙Назад"), state=states.TeamsSg.list, id="to_list"),
         getter=filter_getter,
         state=states.TeamsSg.filter,
+        preview_data={"active": True, "archive": False},
     ),
 )
 
@@ -91,6 +95,7 @@ my_team_view = Dialog(
         Cancel(Const("🔙Назад")),
         getter=team_getter,
         state=states.MyTeamSg.team,
+        preview_data=PREVIEW_TEAM_CARD,
     ),
     on_start=on_start_my_team,
 )

--- a/shvatka/tgbot/dialogs/time_hint/dialogs.py
+++ b/shvatka/tgbot/dialogs/time_hint/dialogs.py
@@ -28,7 +28,11 @@ from .handlers import (
     delete_single_hint,
     delete_whole_time_hint,
 )
-from shvatka.tgbot.dialogs.preview_data import TIMES_PRESET, PreviewSwitchTo
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_HINTS_DATA,
+    TIMES_PRESET,
+    PreviewSwitchTo,
+)
 
 time_hint = Dialog(
     Window(
@@ -73,7 +77,7 @@ time_hint = Dialog(
         Back(text=Const("⏱️Изменить время")),
         getter=get_hints,
         state=states.TimeHintSG.hint,
-        preview_data={"has_hints": True},
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     on_start=hint_on_start,
 )
@@ -122,12 +126,14 @@ time_hint_edit = Dialog(
         Cancel(text=Const("🔙Вернуться, ничего не менять")),
         getter=get_hints,
         state=states.TimeHintEditSG.details,
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     Window(
         Jinja("Введи новое время выхода подсказки"),
         MessageInput(func=process_edit_time_message),
         getter=get_hints,
         state=states.TimeHintEditSG.time,
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     Window(
         Jinja("Подсказка выходящая в {{time}} мин."),
@@ -146,6 +152,7 @@ time_hint_edit = Dialog(
         ),
         getter=get_hints,
         state=states.TimeHintEditSG.add_part,
+        preview_data=PREVIEW_HINTS_DATA,
     ),
     on_start=hint_edit_on_start,
 )

--- a/shvatka/tgbot/dialogs/timers/dialogs.py
+++ b/shvatka/tgbot/dialogs/timers/dialogs.py
@@ -32,6 +32,13 @@ from .handlers import (
     save_timer,
     delete_timer,
 )
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_EFFECTS,
+    PREVIEW_LEVEL,
+    PREVIEW_TIMER,
+    PREVIEW_TIMERS,
+    TIMES_PRESET,
+)
 from shvatka.tgbot.dialogs.time_hint.getters import get_available_times
 
 timers_dialog = Dialog(
@@ -72,6 +79,10 @@ timers_dialog = Dialog(
         Cancel(Const("🔙Назад")),
         getter=get_timers,
         state=states.LevelTimersSG.menu,
+        preview_data={
+            "level_id": PREVIEW_LEVEL.name_id,
+            "timers": PREVIEW_TIMERS,
+        },
     ),
     on_process_result=process_timers_result,
     on_start=on_start_timers,
@@ -99,6 +110,10 @@ timer_dialog = Dialog(
         Cancel(text=Const("🔙Вернуться, не сохранять")),
         state=states.LevelTimerSG.menu,
         getter=get_timer,
+        preview_data={
+            "time": PREVIEW_TIMER.action_time,
+            "effects": PREVIEW_EFFECTS,
+        },
     ),
     Window(
         Const("Время выхода подсказки (можно выбрать или ввести)"),
@@ -127,6 +142,7 @@ timer_dialog = Dialog(
         Cancel(text=Const("🔙Вернуться, не сохранять")),
         state=states.LevelTimerSG.timer,
         getter=get_available_times,
+        preview_data={"times": TIMES_PRESET},
     ),
     on_process_result=on_process_timer_result,
     on_start=on_start_timer,

--- a/shvatka/tgbot/states.py
+++ b/shvatka/tgbot/states.py
@@ -52,7 +52,6 @@ class LevelTimersSG(StatesGroup):
 class LevelTimerSG(StatesGroup):
     menu = State()
     timer = State()
-    effects = State()
 
 
 class BonusHintSG(StatesGroup):
@@ -176,7 +175,6 @@ class ProfileSG(StatesGroup):
     main = State()
     username = State()
     one_time_login = State()
-    password = State()
     email = State()
     email_code = State()
 

--- a/shvatka/tgbot/views/jinja_filters/__init__.py
+++ b/shvatka/tgbot/views/jinja_filters/__init__.py
@@ -16,8 +16,8 @@ from shvatka.core.views.texts import (
 )
 
 
-def setup_jinja(bot: Bot):
-    filters: Mapping[str, Callable[..., str]] = {
+def get_filters() -> Mapping[str, Callable[..., str]]:
+    return {
         "user_timezone": datetime_filter,
         "time_user_timezone": time_user_timezone,
         "player_emoji": get_emoji,
@@ -30,7 +30,10 @@ def setup_jinja(bot: Bot):
         "time_hints": render_time_hints,
         "effects": render_effects,
     }
+
+
+def setup_jinja(bot: Bot):
     setup_jinja_internal(
         bot,
-        filters=filters,
+        filters=get_filters(),
     )

--- a/tests/unit/test_dialogs_preview.py
+++ b/tests/unit/test_dialogs_preview.py
@@ -1,0 +1,46 @@
+import re
+
+import pytest
+from aiogram import Router
+from aiogram_dialog.manager.message_manager import MessageManager
+from aiogram_dialog.setup import collect_dialogs
+
+from shvatka.tgbot.dialogs import setup as setup_dialogs_router
+from shvatka.tgbot.dialogs.preview import render_dialogs_preview
+
+
+@pytest.fixture(scope="module")
+def dialogs_router() -> Router:
+    # dialogs are module-level singletons, they can be attached to a router only once
+    router = Router(name="preview")
+    setup_dialogs_router(router, MessageManager())
+    return router
+
+
+def test_every_state_has_window(dialogs_router: Router) -> None:
+    orphans = [
+        state.state
+        for dialog in collect_dialogs(dialogs_router)
+        for state in dialog.states_group().__states__
+        if state not in dialog.states()
+    ]
+    assert orphans == []
+
+
+@pytest.mark.asyncio
+async def test_render_preview(dialogs_router: Router, tmp_path) -> None:
+    """Every window renders from its preview_data, without a bot or a database."""
+    file = tmp_path / "preview.html"
+
+    await render_dialogs_preview(dialogs_router, str(file))
+
+    rendered = file.read_text(encoding="utf-8")
+    windows = {
+        state
+        for dialog in collect_dialogs(dialogs_router)
+        for state in (s.state for s in dialog.states())
+    }
+    assert windows
+    for state in windows:
+        assert f'id="{state}"' in rendered, f"{state} is missing in the preview"
+    assert not re.search(r'<div class="text">\s*</div>', rendered), "empty window text rendered"

--- a/tests/unit/test_dialogs_preview.py
+++ b/tests/unit/test_dialogs_preview.py
@@ -1,26 +1,21 @@
 import re
 
 import pytest
-from aiogram import Router
-from aiogram_dialog.manager.message_manager import MessageManager
-from aiogram_dialog.setup import collect_dialogs
+from aiogram_dialog import Dialog
 
-from shvatka.tgbot.dialogs import setup as setup_dialogs_router
+from shvatka.tgbot.dialogs import collect_all_dialogs
 from shvatka.tgbot.dialogs.preview import render_dialogs_preview
 
 
-@pytest.fixture(scope="module")
-def dialogs_router() -> Router:
-    # dialogs are module-level singletons, they can be attached to a router only once
-    router = Router(name="preview")
-    setup_dialogs_router(router, MessageManager())
-    return router
+@pytest.fixture
+def dialogs() -> list[Dialog]:
+    return collect_all_dialogs()
 
 
-def test_every_state_has_window(dialogs_router: Router) -> None:
+def test_every_state_has_window(dialogs: list[Dialog]) -> None:
     orphans = [
         state.state
-        for dialog in collect_dialogs(dialogs_router)
+        for dialog in dialogs
         for state in dialog.states_group().__states__
         if state not in dialog.states()
     ]
@@ -28,18 +23,14 @@ def test_every_state_has_window(dialogs_router: Router) -> None:
 
 
 @pytest.mark.asyncio
-async def test_render_preview(dialogs_router: Router, tmp_path) -> None:
+async def test_render_preview(dialogs: list[Dialog], tmp_path) -> None:
     """Every window renders from its preview_data, without a bot or a database."""
     file = tmp_path / "preview.html"
 
-    await render_dialogs_preview(dialogs_router, str(file))
+    await render_dialogs_preview(dialogs, str(file))
 
     rendered = file.read_text(encoding="utf-8")
-    windows = {
-        state
-        for dialog in collect_dialogs(dialogs_router)
-        for state in (s.state for s in dialog.states())
-    }
+    windows = {state.state for dialog in dialogs for state in dialog.states()}
     assert windows
     for state in windows:
         assert f'id="{state}"' in rendered, f"{state} is missing in the preview"


### PR DESCRIPTION
## What

`aiogram_dialog` never calls a window's getter while rendering a preview — it uses `preview_data` instead. Only 8 of 75 windows had it, so rendering a preview crashed on the first window it reached (`MainMenuSG:main`, `'player' is undefined`).

This adds `preview_data` to every window with a getter, and makes preview rendering an actual thing the project does.

## Changes

**`shvatka/tgbot/dialogs/preview_data.py`** — grown from 3 fixtures into the shared set the dialogs draw on: players (with and without stat), teams and team players with permissions, games (`Game` / `PreviewGame` / `FullGame`), organizers, levels with a scenario, hints, time hints, effects, timers, key-effect conditions, waivers, spy level-times, forum user/team. Composite dicts (`PREVIEW_PLAYER_STAT`, `PREVIEW_MY_TEAM`, `PREVIEW_HINTS_DATA`, …) are shared by the windows whose getters return the same shape. `PREVIEW_NOW` is a fixed timestamp, so two renders produce the same page.

**`shvatka/tgbot/dialogs/*/dialogs.py`** — `preview_data=` on every window that has a getter (17 packages). A few windows that already had it were incomplete and rendered partially — e.g. `CompletedGamesPanelSG:game` was missing `webapp_url` for its `WebApp` button, `GameScheduleSG:confirm` was missing `scheduled_datetime`, `LevelSG:menu` had only `level_id` and died on `{{timers | length}}`.

**`shvatka/tgbot/dialogs/preview.py`** (new) — `render_dialogs_preview()`. Preview rendering has neither a `Bot` nor a `Dispatcher`, so the `Jinja` widget falls back to the library-wide default environment; this registers our filters (`user_timezone`, `player_emoji`, `game_status`, `hints`, `effects`, …) on it. Writes `out/shvatka-dialogs-preview.html`.

**`shvatka/tgbot/views/jinja_filters/__init__.py`** — filter mapping extracted into `get_filters()` so both `setup_jinja(bot)` and the preview use one list.

**`shvatka/tgbot/dialogs/__init__.py`** — `render_all()` renders the preview alongside the transitions graph. Preview goes first: it needs no graphviz, so it is still produced when `dot` is unavailable.

**`shvatka/tgbot/states.py`** — dropped `ProfileSG.password` and `LevelTimerSG.effects`. Both were declared but had no window and no reference anywhere in the codebase; the preview renders every state of a group, so they surfaced as `UnregisteredWindowError`.

**`.github/workflows/test.yml`** — the transitions job uploads the preview page as part of the same artifact.

**`AGENTS.md`** — new convention: a window with a getter needs `preview_data`, every state needs a window.

## Testing

`tests/unit/test_dialogs_preview.py` renders all 75 windows and asserts each appears in the page with non-empty text, plus a check that no state lacks a window. Verified the guard bites: removing one `preview_data` fails the test.

- `pytest tests/unit` — 239 passed
- `ruff format --check .`, `ruff check .`, `mypy .` — clean

## Note, not fixed here

The preview surfaced a cosmetic bug it seemed out of scope to fix: `GamePublishSG:prepare` and `OrgSpySG:main` print `{{game.status}}` raw, so an organizer sees `GameStatus.getting_waivers` instead of `сбор вейверов` — they're missing the `| game_status` filter the other windows use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MepsAotK8FkwvH3eDVN15Z)_