### PR TITLE
Declare handler-driven transitions in the dialogs diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,16 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   and fails when one is missing; `python -m shvatka.tgbot.dialogs.__init__`
   writes the page to `out/shvatka-dialogs-preview.html`. Each state of a
   `StatesGroup` must have a window too — the same test asserts it.
+- **A handler that jumps to another window must declare it in
+  `preview_add_transitions`.** The transitions diagram is built from the
+  `Start` / `SwitchTo` / `Next` / `Back` / `Cancel` widgets it can see in a
+  window; a `manager.start(...)` / `manager.switch_to(...)` inside an
+  `on_click` / `on_success` / `MessageInput` handler is invisible to it, so
+  add `PreviewStart(state)` / `PreviewSwitchTo(state)` (and `Cancel()` when the
+  handler closes the dialog as its normal outcome — not for error-only
+  `done()` paths). `tests/unit/test_dialogs_transitions.py` fails on an
+  undeclared jump; `python -m shvatka.tgbot.dialogs.__init__` writes the
+  diagram to `out/shvatka-dialogs.png` (needs graphviz).
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes

--- a/shvatka/tgbot/dialogs/game_orgs/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_orgs/dialogs.py
@@ -18,6 +18,7 @@ from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_ORG_PERMISSIONS,
     PREVIEW_ORGS,
     PREVIEW_SIMPLE_GAME,
+    PreviewSwitchTo,
 )
 
 game_orgs = Dialog(
@@ -52,6 +53,7 @@ game_orgs = Dialog(
             "orgs": PREVIEW_ORGS,
             "inline_query": "add-game-org-token",
         },
+        preview_add_transitions=[PreviewSwitchTo(states.GameOrgsSG.org_menu)],
     ),
     Window(
         Multi(

--- a/shvatka/tgbot/dialogs/game_scn/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_scn/dialogs.py
@@ -102,7 +102,7 @@ game_editor = Dialog(
         getter=select_full_game,
         preview_data={"game": PREVIEW_FULL_GAME, "levels": PREVIEW_LEVELS},
         preview_add_transitions=[
-            PreviewStart(states.LevelTestSG.wait_key),
+            PreviewStart(states.LevelManageSG.menu),
         ],
     ),
     Window(

--- a/shvatka/tgbot/dialogs/merge/dialogs.py
+++ b/shvatka/tgbot/dialogs/merge/dialogs.py
@@ -12,6 +12,7 @@ from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_FORUM_TEAMS,
     PREVIEW_FORUM_USER,
     PREVIEW_TEAM,
+    PreviewSwitchTo,
 )
 
 merge_teams_dialog = Dialog(
@@ -50,6 +51,7 @@ merge_teams_dialog = Dialog(
         getter=(get_team, get_forum_teams),
         state=states.MergeTeamsSG.list_forum,
         preview_data={"team": PREVIEW_TEAM, "forum_teams": PREVIEW_FORUM_TEAMS},
+        preview_add_transitions=[PreviewSwitchTo(states.MergeTeamsSG.confirm)],
     ),
     Window(
         Jinja(
@@ -96,6 +98,7 @@ merge_player_dialog = Dialog(
         Cancel(Const("🔙Я передумал, не надо")),
         MessageInput(func=player_link_handler, content_types=ContentType.TEXT),
         state=states.MergePlayersSG.input,
+        preview_add_transitions=[PreviewSwitchTo(states.MergePlayersSG.confirm)],
     ),
     Window(
         Jinja("Объединить свои достижения с {{forum_user.name}}?"),

--- a/shvatka/tgbot/dialogs/profile/dialogs.py
+++ b/shvatka/tgbot/dialogs/profile/dialogs.py
@@ -9,7 +9,11 @@ from shvatka.tgbot.dialogs.profile.getters import (
     player_stat_getter,
     player_one_time_url_getter,
 )
-from shvatka.tgbot.dialogs.preview_data import PREVIEW_AUTHOR, PREVIEW_PLAYER_STAT
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_AUTHOR,
+    PREVIEW_PLAYER_STAT,
+    PreviewSwitchTo,
+)
 from shvatka.tgbot.dialogs.profile.handlers import (
     save_new_username,
     validate_username,
@@ -69,6 +73,7 @@ profile_dialog = Dialog(
             on_error=email_invalid,
         ),
         state=states.ProfileSG.email,
+        preview_add_transitions=[PreviewSwitchTo(states.ProfileSG.email_code)],
     ),
     Window(
         Const("Введи код подтверждения, отправленный на указанную почту"),

--- a/shvatka/tgbot/dialogs/team_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_manage/dialogs.py
@@ -14,6 +14,8 @@ from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_MY_TEAM,
     PREVIEW_SELECTED_TEAM_PLAYER_DATA,
     PREVIEW_TEAM_WITH_PLAYERS,
+    PreviewStart,
+    PreviewSwitchTo,
 )
 from .handlers import (
     rename_team_handler,
@@ -85,6 +87,7 @@ captains_bridge = Dialog(
         state=states.CaptainsBridgeSG.main,
         getter=get_my_team_,
         preview_data=PREVIEW_MY_TEAM,
+        preview_add_transitions=[PreviewStart(states.MergeTeamsSG.main)],
     ),
     Window(
         Jinja("Переименовать команду 🚩<b>{{team.name}}</b>"),
@@ -126,6 +129,7 @@ captains_bridge = Dialog(
         getter=get_team_with_players,
         state=states.CaptainsBridgeSG.players,
         preview_data=PREVIEW_TEAM_WITH_PLAYERS,
+        preview_add_transitions=[PreviewSwitchTo(states.CaptainsBridgeSG.player)],
     ),
     Window(
         Jinja("Чтобы добавить игрока нажми на кнопку в самом внизу, затем выбери пользователя"),
@@ -229,6 +233,7 @@ captains_bridge = Dialog(
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.player_role,
         preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
+        preview_add_transitions=[PreviewSwitchTo(states.CaptainsBridgeSG.player)],
     ),
     Window(
         TEAM_PLAYER_CARD,
@@ -246,5 +251,6 @@ captains_bridge = Dialog(
         getter=get_selected_player,
         state=states.CaptainsBridgeSG.player_emoji,
         preview_data=PREVIEW_SELECTED_TEAM_PLAYER_DATA,
+        preview_add_transitions=[PreviewSwitchTo(states.CaptainsBridgeSG.player)],
     ),
 )

--- a/shvatka/tgbot/dialogs/team_view/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_view/dialogs.py
@@ -13,7 +13,12 @@ from .handlers import (
     on_leave_team,
 )
 from shvatka.tgbot.dialogs.common import BOOL_VIEW
-from shvatka.tgbot.dialogs.preview_data import PREVIEW_TEAM_CARD, PREVIEW_TEAMS
+from shvatka.tgbot.dialogs.preview_data import (
+    PREVIEW_TEAM_CARD,
+    PREVIEW_TEAMS,
+    PreviewStart,
+    PreviewSwitchTo,
+)
 
 team_view = Dialog(
     Window(
@@ -39,6 +44,7 @@ team_view = Dialog(
         getter=teams_getter,
         state=states.TeamsSg.list,
         preview_data={"teams": PREVIEW_TEAMS, "active": True, "archive": False},
+        preview_add_transitions=[PreviewSwitchTo(states.TeamsSg.one)],
     ),
     Window(
         Jinja(
@@ -63,6 +69,7 @@ team_view = Dialog(
         getter=team_getter,
         state=states.TeamsSg.one,
         preview_data=PREVIEW_TEAM_CARD,
+        preview_add_transitions=[PreviewStart(states.PlayerSg.main)],
     ),
     Window(
         Const("Отметь типы команд для отображения"),

--- a/shvatka/tgbot/dialogs/time_hint/dialogs.py
+++ b/shvatka/tgbot/dialogs/time_hint/dialogs.py
@@ -78,6 +78,8 @@ time_hint = Dialog(
         getter=get_hints,
         state=states.TimeHintSG.hint,
         preview_data=PREVIEW_HINTS_DATA,
+        # 'to_next_hint' closes the dialog, returning the collected hint
+        preview_add_transitions=[Cancel()],
     ),
     on_start=hint_on_start,
 )
@@ -134,6 +136,7 @@ time_hint_edit = Dialog(
         getter=get_hints,
         state=states.TimeHintEditSG.time,
         preview_data=PREVIEW_HINTS_DATA,
+        preview_add_transitions=[PreviewSwitchTo(states.TimeHintEditSG.details)],
     ),
     Window(
         Jinja("Подсказка выходящая в {{time}} мин."),

--- a/shvatka/tgbot/dialogs/timers/dialogs.py
+++ b/shvatka/tgbot/dialogs/timers/dialogs.py
@@ -38,6 +38,7 @@ from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_TIMER,
     PREVIEW_TIMERS,
     TIMES_PRESET,
+    PreviewStart,
 )
 from shvatka.tgbot.dialogs.time_hint.getters import get_available_times
 
@@ -83,6 +84,7 @@ timers_dialog = Dialog(
             "level_id": PREVIEW_LEVEL.name_id,
             "timers": PREVIEW_TIMERS,
         },
+        preview_add_transitions=[PreviewStart(states.LevelTimerSG.menu)],
     ),
     on_process_result=process_timers_result,
     on_start=on_start_timers,
@@ -114,6 +116,7 @@ timer_dialog = Dialog(
             "time": PREVIEW_TIMER.action_time,
             "effects": PREVIEW_EFFECTS,
         },
+        preview_add_transitions=[PreviewStart(states.EffectsSG.menu)],
     ),
     Window(
         Const("Время выхода подсказки (можно выбрать или ввести)"),

--- a/tests/unit/test_dialogs_transitions.py
+++ b/tests/unit/test_dialogs_transitions.py
@@ -1,0 +1,137 @@
+"""Guard the transitions diagram against handler-driven jumps nobody declared.
+
+`render_transitions` only sees Start/SwitchTo/Next/Back/Cancel widgets in a
+window's keyboard plus its `preview_add_transitions`. What a handler does at
+runtime (`manager.start(...)` / `manager.switch_to(...)`) is invisible, so every
+such jump has to be declared with PreviewStart / PreviewSwitchTo.
+
+This is a static check: it reads the dialog modules instead of importing them,
+so a jump is spotted even when no test ever clicks that button.
+"""
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DIALOGS_ROOT = REPO_ROOT / "shvatka/tgbot/dialogs"
+HANDLER_KWARGS = frozenset({"on_click", "on_success", "on_error", "func"})
+TRANSITION_WIDGETS = frozenset({"Start", "SwitchTo", "PreviewStart", "PreviewSwitchTo"})
+JUMP_METHODS = frozenset({"start", "switch_to"})
+
+
+def _state_name(node: ast.AST) -> str | None:
+    """`states.SomeSG.window` -> `"SomeSG:window"`."""
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "states"
+    ):
+        return f"{node.value.attr}:{node.attr}"
+    return None
+
+
+def _states_in(node: ast.AST) -> set[str]:
+    return {name for child in ast.walk(node) if (name := _state_name(child))}
+
+
+@dataclass
+class Func:
+    jumps: set[str] = field(default_factory=set)
+    calls: set[str] = field(default_factory=set)
+
+
+def _parse_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> Func:
+    func = Func()
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        if isinstance(call.func, ast.Attribute):
+            if call.func.attr in JUMP_METHODS:
+                func.jumps |= _states_in(call)
+        elif isinstance(call.func, ast.Name):
+            func.calls.add(call.func.id)
+    return func
+
+
+def _parse_functions(path: Path) -> dict[str, Func]:
+    """Every function of a module, with the states it jumps to."""
+    functions = {
+        node.name: _parse_function(node)
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    # handlers often jump through a local helper, so follow calls inside the module
+    for _ in range(len(functions)):
+        for func in functions.values():
+            for callee in func.calls:
+                if callee in functions:
+                    func.jumps |= functions[callee].jumps
+    return functions
+
+
+_MODULES: dict[str, dict[str, Func]] = {}
+
+
+def _module(dotted: str) -> dict[str, Func]:
+    if dotted not in _MODULES:
+        path = REPO_ROOT / (dotted.replace(".", "/") + ".py")
+        _MODULES[dotted] = _parse_functions(path) if path.exists() else {}
+    return _MODULES[dotted]
+
+
+def _imported_from(path: Path) -> dict[str, str]:
+    """Local name -> module it was imported from."""
+    package = ".".join(path.parent.relative_to(REPO_ROOT).parts)
+    imports: dict[str, str] = {}
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            module = f"{package}.{node.module}" if node.module else package
+        else:
+            module = node.module or ""
+        for alias in node.names:
+            imports[alias.asname or alias.name] = module
+    return imports
+
+
+def _undeclared_jumps(path: Path) -> list[str]:
+    imports = _imported_from(path)
+    problems: list[str] = []
+    for window in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if not (isinstance(window, ast.Call) and getattr(window.func, "id", None) == "Window"):
+            continue
+        state = next((_state_name(kw.value) for kw in window.keywords if kw.arg == "state"), None)
+        declared: set[str] = set()
+        handlers: set[str] = set()
+        for node in ast.walk(window):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) in TRANSITION_WIDGETS:
+                declared |= _states_in(node)
+            if (
+                isinstance(node, ast.keyword)
+                and node.arg in HANDLER_KWARGS
+                and isinstance(node.value, ast.Name)
+            ):
+                handlers.add(node.value.id)
+        declared.add(state)
+
+        for handler in sorted(handlers):
+            func = _module(imports.get(handler, "")).get(handler)
+            if func is None:
+                continue
+            problems.extend(
+                f"{state}: {handler} jumps to {target}, add it to preview_add_transitions"
+                for target in sorted(func.jumps - declared)
+            )
+    return problems
+
+
+def test_handler_jumps_are_declared() -> None:
+    paths = sorted(DIALOGS_ROOT.glob("*/dialogs.py"))
+    assert paths, "no dialog modules found"
+
+    problems = [problem for path in paths for problem in _undeclared_jumps(path)]
+
+    assert problems == []


### PR DESCRIPTION
## What

You were right — `preview_add_transitions` was missing in a fair few places.

`render_transitions` builds the diagram from the `Start` / `SwitchTo` / `Next` / `Back` / `Cancel` widgets it finds in a window, plus that window's `preview_add_transitions`. A `manager.start(...)` / `manager.switch_to(...)` inside an `on_click`, `on_success` or `MessageInput` handler is invisible to it. **14 such jumps were never declared**, which left 7 windows as unreachable islands on the diagram:

`PlayerSg:main`, `TeamsSg:one`, `GameOrgsSG:org_menu`, `ProfileSG:email_code`, `MergeTeamsSG:main`, `MergeTeamsSG:confirm`, `MergePlayersSG:confirm`.

After this change every one of the 75 windows has at least one incoming edge.

## The missing edges

| window | handler | jumps to | declared as |
| --- | --- | --- | --- |
| `GameOrgsSG:orgs_list` | `select_org` | `GameOrgsSG:org_menu` | `PreviewSwitchTo` |
| `ProfileSG:email` | `on_email_entered` | `ProfileSG:email_code` | `PreviewSwitchTo` |
| `MergeTeamsSG:list_forum` | `select_forum_team` | `MergeTeamsSG:confirm` | `PreviewSwitchTo` |
| `MergePlayersSG:input` | `player_link_handler` | `MergePlayersSG:confirm` | `PreviewSwitchTo` |
| `TeamsSg:list` | `select_team` | `TeamsSg:one` | `PreviewSwitchTo` |
| `TeamsSg:one` | `select_player` | `PlayerSg:main` | `PreviewStart` |
| `CaptainsBridgeSG:main` | `start_merge` | `MergeTeamsSG:main` | `PreviewStart` |
| `CaptainsBridgeSG:players` | `select_player` | `CaptainsBridgeSG:player` | `PreviewSwitchTo` |
| `CaptainsBridgeSG:player_role` | `change_role_handler` | `CaptainsBridgeSG:player` | `PreviewSwitchTo` |
| `CaptainsBridgeSG:player_emoji` | `change_emoji_handler` | `CaptainsBridgeSG:player` | `PreviewSwitchTo` |
| `TimeHintEditSG:time` | `process_edit_time_message` | `TimeHintEditSG:details` | `PreviewSwitchTo` |
| `LevelTimersSG:menu` | `start_edit_timer` / `start_new_timer` | `LevelTimerSG:menu` | `PreviewStart` |
| `LevelTimerSG:menu` | `start_effects` | `EffectsSG:menu` | `PreviewStart` |
| `TimeHintSG:hint` | `on_finish` | closes the dialog | `Cancel()` |

## One correction

`GameEditSG:current_levels` declared `PreviewStart(states.LevelTestSG.wait_key)`, but its `edit_level` handler starts `LevelManageSG.menu` and nothing in that window reaches level testing. Pointed it at the state the handler actually starts. (`LevelManageSG:menu` keeps its own, correct, edge to `LevelTestSG:wait_key`.)

## Deliberately not declared

Four `done()` calls in `team_manage/handlers.py` (`rename_team_handler`, `change_desc_team_handler`, `change_role_handler`, `change_emoji_handler`) are the `if team is None: logger.warning(...); return` error path, not a normal exit. Declaring `Cancel()` for them would draw edges that don't represent real navigation, so they're left alone.

## Testing

`tests/unit/test_dialogs_transitions.py` is a static check: it parses the dialog modules with `ast`, resolves every `on_click` / `on_success` / `on_error` / `func` handler through the importing module (names collide across packages — there are two different `select_player`s), follows intra-module helper calls, and fails on any jump no widget declares. The message names the window, the handler and the target:

```
TeamsSg:one: select_player jumps to PlayerSg:main, add it to preview_add_transitions
```

Verified it bites by deleting one declaration.

- `pytest tests/unit` — 240 passed
- `ruff format --check .`, `ruff check .`, `mypy .` — clean
- Rendered both outputs with graphviz installed; checked in-degree of all 75 windows before (7 orphans) and after (0).

`AGENTS.md` gets the convention alongside the `preview_data` one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MepsAotK8FkwvH3eDVN15Z)_