### PR TITLE
Cut the silent minute before the first log line on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libmagic1 && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+# bake the matplotlib font cache into the image, otherwise every fresh
+# container spends seconds on "generated new fontManager" at the first import
+RUN python3 -c "from matplotlib import pyplot"
 COPY . ${CODE_PATH}/shvatka
 WORKDIR $CODE_PATH/shvatka
 RUN python3 -m compileall -q ${CODE_PATH}/shvatka/shvatka

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.13-bookworm AS builder
 ENV VIRTUAL_ENV=/opt/venv
 ENV CODE_PATH=/code
+# ship .pyc alongside the .py, otherwise every fresh container compiles the
+# whole venv on the first import, which more than doubles the startup time
+ENV UV_COMPILE_BYTECODE=1
 RUN pip install --no-cache-dir uv
 RUN python3 -m venv $VIRTUAL_ENV
 WORKDIR $CODE_PATH
@@ -23,5 +26,6 @@ RUN apt-get update && \
 COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
 COPY . ${CODE_PATH}/shvatka
 WORKDIR $CODE_PATH/shvatka
+RUN python3 -m compileall -q ${CODE_PATH}/shvatka/shvatka
 RUN echo "{\"vcs_hash\": \"${VCS_HASH}\", \"commit_at\": \"${COMMIT_AT}\", \"vcs_name\": \"${VCS_NAME}\", \"build_at\": \"${BUILD_AT}\" }" > version.yaml
 ENTRYPOINT ["python3", "-m", "shvatka"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
           cpus: "0.008"
         limits:
           memory: 800M
-          cpus: "0.15"
 
   shvatka-ui:
     container_name: "shvatka_ui-${ENV_NAME}"

--- a/shvatka/__main__.py
+++ b/shvatka/__main__.py
@@ -6,6 +6,7 @@ of the application (aiogram, pyrogram, matplotlib, sqlalchemy, ...) happens in
 complete silence and the process looks hung for tens of seconds.
 """
 
+import uvicorn
 import logging
 import time
 from typing import TYPE_CHECKING
@@ -31,8 +32,6 @@ def main() -> "FastAPI":
 
 
 def run():
-    import uvicorn
-
     uvicorn.run(
         "shvatka.__main__:main",
         host="0.0.0.0",  # noqa: S104

--- a/shvatka/__main__.py
+++ b/shvatka/__main__.py
@@ -1,84 +1,38 @@
+"""Entrypoint of the combined (api + tgbot webhook) application.
+
+This module is deliberately kept free of heavy imports: it must be able to
+configure logging before anything else is loaded, otherwise the whole import
+of the application (aiogram, pyrogram, matplotlib, sqlalchemy, ...) happens in
+complete silence and the process looks hung for tens of seconds.
+"""
+
 import logging
-from functools import partial
+import time
+from typing import TYPE_CHECKING
 
-import uvicorn
-from aiogram import Bot, Dispatcher
-from dishka import AsyncContainer, make_async_container, plotter, STRICT_VALIDATION
-from dishka.integrations.fastapi import setup_dishka
-from fastapi import FastAPI
-
-from shvatka.api.app.dependencies import get_api_specific_providers
-from shvatka.infrastructure.di import get_providers
-from shvatka.infrastructure.di.utils import warm_up
-from shvatka.main_factory import get_complex_only_providers
-from shvatka.tgbot.config.models.bot import WebhookConfig
-from shvatka.tgbot.config.parser.main import load_config as load_bot_config
-from shvatka.api.app.config.parser.main import load_config as load_api_config
-from shvatka.api.main_factory import (
-    get_paths,
-    create_app,
-)
 from shvatka.common.config.parser.logging_config import setup_logging
-from shvatka.tgbot.main_factory import (
-    resolve_update_types,
-    get_bot_specific_providers,
-)
-from shvatka.tgbot.utils.fastapi_webhook import setup_application, SimpleRequestHandler
+from shvatka.common.config.parser.paths import common_get_paths
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> FastAPI:
-    paths = get_paths()
-
+def main() -> "FastAPI":
+    paths = common_get_paths("API_PATH")
     setup_logging(paths)
-    api_config = load_api_config(paths)
-    bot_config = load_bot_config(paths)
-    webhook_config = bot_config.bot.webhook
-    if not webhook_config:
-        raise EnvironmentError("No webhook configuration provided")
+    logger.info("logging configured, loading application modules...")
+    started_at = time.monotonic()
+    from shvatka.main_factory import create_root_app
 
-    app = create_app(api_config)
-    dishka = make_async_container(
-        *get_providers("SHVATKA_PATH"),
-        *get_bot_specific_providers(),
-        *get_api_specific_providers(),
-        *get_complex_only_providers(),
-        validation_settings=STRICT_VALIDATION,
-    )
-    setup_application(app, dishka)
-    webhook_handler = SimpleRequestHandler(
-        handle_in_background=False,
-        secret_token=webhook_config.secret,
-    )
-    webhook_handler.register(app, webhook_config.path)
-
-    root_app = FastAPI()
-    root_app.mount(api_config.context_path, app)
-    setup = partial(on_startup, dishka, webhook_config)
-    root_app.router.add_event_handler("startup", setup)
-    setup_dishka(dishka, root_app)
-    logger.info(
-        "app prepared with dishka:\n%s",
-        plotter.render_d2(dishka),
-    )
-    return root_app
-
-
-async def on_startup(dishka: AsyncContainer, webhook_config: WebhookConfig):
-    webhook_url = webhook_config.web_url + webhook_config.path
-    logger.info("as webhook url used %s", webhook_url)
-    bot = await dishka.get(Bot)
-    dp = await dishka.get(Dispatcher)
-    await bot.set_webhook(
-        url=webhook_url,
-        secret_token=webhook_config.secret,
-        allowed_updates=resolve_update_types(dp),
-    )
-    await warm_up(dishka)
+    logger.info("application modules loaded in %.2f s", time.monotonic() - started_at)
+    return create_root_app(paths)
 
 
 def run():
+    import uvicorn
+
     uvicorn.run(
         "shvatka.__main__:main",
         host="0.0.0.0",  # noqa: S104

--- a/shvatka/api/__main__.py
+++ b/shvatka/api/__main__.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 from shvatka.common.config.parser.logging_config import setup_logging
 from shvatka.common.config.parser.paths import common_get_paths
 
+import uvicorn
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
@@ -39,8 +41,6 @@ def main() -> "FastAPI":
 
 
 def run():
-    import uvicorn
-
     uvicorn.run("shvatka.api.__main__:main", factory=True, log_config=None)
 
 

--- a/shvatka/api/__main__.py
+++ b/shvatka/api/__main__.py
@@ -1,22 +1,33 @@
+"""Entrypoint of the standalone api application.
+
+Kept free of heavy imports on purpose, see shvatka/__main__.py for details.
+"""
+
 import logging
+import time
+from typing import TYPE_CHECKING
 
-import uvicorn
-from fastapi import FastAPI
-
-from shvatka.api.app.config.parser.main import load_config
-from shvatka.api.app.dependencies import setup_di
-from shvatka.api.main_factory import (
-    create_app,
-)
 from shvatka.common.config.parser.logging_config import setup_logging
 from shvatka.common.config.parser.paths import common_get_paths
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> FastAPI:
+def main() -> "FastAPI":
     paths = common_get_paths("SHVATKA_API_PATH")
     setup_logging(paths)
+    logger.info("logging configured, loading application modules...")
+    started_at = time.monotonic()
+    from fastapi import FastAPI
+    from shvatka.api.app.config.parser.main import load_config
+    from shvatka.api.app.dependencies import setup_di
+    from shvatka.api.main_factory import create_app
+
+    logger.info("application modules loaded in %.2f s", time.monotonic() - started_at)
+
     api_config = load_config(paths)
 
     app = create_app(api_config)
@@ -28,6 +39,8 @@ def main() -> FastAPI:
 
 
 def run():
+    import uvicorn
+
     uvicorn.run("shvatka.api.__main__:main", factory=True, log_config=None)
 
 

--- a/shvatka/main_factory.py
+++ b/shvatka/main_factory.py
@@ -1,9 +1,23 @@
 import logging
+from functools import partial
 
-from dishka import Provider, Scope, AsyncContainer, provide
+from aiogram import Bot, Dispatcher
+from dishka import (
+    Provider,
+    Scope,
+    AsyncContainer,
+    provide,
+    make_async_container,
+    plotter,
+    STRICT_VALIDATION,
+)
 from dishka.exceptions import NoContextValueError
+from dishka.integrations.fastapi import setup_dishka
+from fastapi import FastAPI
 
+from shvatka.api.app.dependencies import get_api_specific_providers
 from shvatka.api.app.dependencies.auth import ApiIdentityProvider
+from shvatka.api.app.config.parser.main import load_config as load_api_config
 from shvatka.api.app.utils.web_input import (
     WebGameView,
     WebTeamNotifier,
@@ -11,6 +25,8 @@ from shvatka.api.app.utils.web_input import (
     WebGamePreparer,
     WebGameLogWriter,
 )
+from shvatka.api.main_factory import create_app
+from shvatka.common.config.models.paths import Paths
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.views.game import (
     GameView,
@@ -19,7 +35,16 @@ from shvatka.core.views.game import (
     GameLogWriter,
 )
 from shvatka.core.views.team import TeamNotifier
+from shvatka.infrastructure.di import get_providers
+from shvatka.infrastructure.di.utils import warm_up
+from shvatka.tgbot.config.models.bot import WebhookConfig
+from shvatka.tgbot.config.parser.main import load_config as load_bot_config
+from shvatka.tgbot.main_factory import (
+    resolve_update_types,
+    get_bot_specific_providers,
+)
 from shvatka.tgbot.services.identity import TgBotIdentityProvider
+from shvatka.tgbot.utils.fastapi_webhook import setup_application, SimpleRequestHandler
 from shvatka.tgbot.views.game import BotView, BotOrgNotifier, GameBotLog
 from shvatka.tgbot.views.team import BotTeamNotifier
 from shvatka.views import (
@@ -70,3 +95,50 @@ def get_complex_only_providers() -> list[Provider]:
     return [
         ComplexOnlyProvider(),
     ]
+
+
+def create_root_app(paths: Paths) -> FastAPI:
+    api_config = load_api_config(paths)
+    bot_config = load_bot_config(paths)
+    webhook_config = bot_config.bot.webhook
+    if not webhook_config:
+        raise EnvironmentError("No webhook configuration provided")
+
+    app = create_app(api_config)
+    dishka = make_async_container(
+        *get_providers("SHVATKA_PATH"),
+        *get_bot_specific_providers(),
+        *get_api_specific_providers(),
+        *get_complex_only_providers(),
+        validation_settings=STRICT_VALIDATION,
+    )
+    setup_application(app, dishka)
+    webhook_handler = SimpleRequestHandler(
+        handle_in_background=False,
+        secret_token=webhook_config.secret,
+    )
+    webhook_handler.register(app, webhook_config.path)
+
+    root_app = FastAPI()
+    root_app.mount(api_config.context_path, app)
+    setup = partial(on_startup, dishka, webhook_config)
+    root_app.router.add_event_handler("startup", setup)
+    setup_dishka(dishka, root_app)
+    logger.info(
+        "app prepared with dishka:\n%s",
+        plotter.render_d2(dishka),
+    )
+    return root_app
+
+
+async def on_startup(dishka: AsyncContainer, webhook_config: WebhookConfig):
+    webhook_url = webhook_config.web_url + webhook_config.path
+    logger.info("as webhook url used %s", webhook_url)
+    bot = await dishka.get(Bot)
+    dp = await dishka.get(Dispatcher)
+    await bot.set_webhook(
+        url=webhook_url,
+        secret_token=webhook_config.secret,
+        allowed_updates=resolve_update_types(dp),
+    )
+    await warm_up(dishka)

--- a/shvatka/main_factory.py
+++ b/shvatka/main_factory.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from functools import partial
 
 from aiogram import Bot, Dispatcher
@@ -98,6 +99,7 @@ def get_complex_only_providers() -> list[Provider]:
 
 
 def create_root_app(paths: Paths) -> FastAPI:
+    started_at = time.monotonic()
     api_config = load_api_config(paths)
     bot_config = load_bot_config(paths)
     webhook_config = bot_config.bot.webhook
@@ -125,7 +127,8 @@ def create_root_app(paths: Paths) -> FastAPI:
     root_app.router.add_event_handler("startup", setup)
     setup_dishka(dishka, root_app)
     logger.info(
-        "app prepared with dishka:\n%s",
+        "app prepared in %.2f s with dishka:\n%s",
+        time.monotonic() - started_at,
         plotter.render_d2(dishka),
     )
     return root_app

--- a/shvatka/tgbot/__main__.py
+++ b/shvatka/tgbot/__main__.py
@@ -1,16 +1,14 @@
+"""Entrypoint of the standalone (long polling) bot application.
+
+Kept free of heavy imports on purpose, see shvatka/__main__.py for details.
+"""
+
 import asyncio
 import logging
-
-from aiogram import Dispatcher, Bot
+import time
 
 from shvatka.common.config.parser.logging_config import setup_logging
 from shvatka.common.config.parser.paths import common_get_paths
-from shvatka.infrastructure.di.utils import warm_up
-
-from shvatka.tgbot.main_factory import (
-    resolve_update_types,
-    create_dishka,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +16,14 @@ logger = logging.getLogger(__name__)
 async def main():
     paths = common_get_paths("BOT_PATH")
     setup_logging(paths)
+    logger.info("logging configured, loading application modules...")
+    started_at = time.monotonic()
+    from aiogram import Dispatcher, Bot
+    from shvatka.infrastructure.di.utils import warm_up
+    from shvatka.tgbot.main_factory import resolve_update_types, create_dishka
+
+    logger.info("application modules loaded in %.2f s", time.monotonic() - started_at)
+
     dishka = create_dishka("BOT_PATH")
     dp = await dishka.get(Dispatcher)
     bot = await dishka.get(Bot)


### PR DESCRIPTION
## Why

Startup showed roughly a minute of complete silence before the first log line.

`shvatka/__main__.py` (and the api/tgbot entrypoints) imported the entire application at module level — aiogram, pyrogram, adaptix, matplotlib, sqlalchemy, openpyxl — and only called `setup_logging()` afterwards, inside `main()`. So every millisecond of the import happened with logging unconfigured and nothing on stdout, which is what made a slow boot look like a hang.

Cumulative subtree cost of each top-level package during a warm `import shvatka.main_factory` (py3.13, prod deps from `lock.txt`, unthrottled):

```
1.503s  aiogram
0.705s  pyrogram
0.502s  adaptix
0.167s  fastapi
0.148s  openpyxl
0.126s  aiohttp
0.100s  sqlalchemy
0.077s  matplotlib
```

~4.5 s of CPU in total, and the app cannot start without it. The minute came from multiplying that by the environment: `deploy.resources.limits.cpus: "0.15"` in `docker-compose.yml`.

## What changed

* **Every entrypoint is now a thin bootstrap.** `shvatka/__main__.py`, `shvatka/api/__main__.py` and `shvatka/tgbot/__main__.py` import only `setup_logging` + `common_get_paths` (plus `uvicorn`) at module level, configure logging, and then import the application inside `main()`, logging how long that import took. Time from process start to the first log line drops from ~11 s to ~0.3 s of CPU, and the remaining cost becomes a measured number instead of silence. This is what made the diagnosis below possible.
* **The combined app factory moved** out of `shvatka/__main__.py` into `shvatka.main_factory.create_root_app()`, together with `on_startup`, matching the existing `api/main_factory.py` and `tgbot/main_factory.py` convention. Behaviour is unchanged, the code was moved verbatim. `create_root_app` now also reports its own duration.
* **The image ships bytecode.** `UV_COMPILE_BYTECODE=1` in the builder stage (the venv is copied to the same `/opt/venv` path, so the `.pyc` stay valid) and `python3 -m compileall` over the app package in the final stage. Without it a fresh container recompiles the whole venv on first import: 10.7 s vs 4.8 s of CPU.
* **The matplotlib font cache is baked into the image.** It lives in `/root/.cache/matplotlib`, which is empty in every fresh container, costing ~2 s of `generated new fontManager` on the first import.
* **`limits.cpus` dropped from `docker-compose.yml`.** CPU is compressible — exceeding a quota only makes you slower, it does not endanger the host the way memory does — so the cap bought nothing while costing every burst, startup worst of all. `limits.memory` is kept, since that one is real protection.

## Measured in production

Before, with `cpus: "0.15"` — ~68 s of silence, then:

```
14:31:24 - shvatka.__main__ - INFO - application modules loaded in 67.70 s
```

After, same image, with the cap lifted:

```
14:51:19 - logging_config    - INFO - Logging configured successfully
14:51:19 - shvatka.__main__  - INFO - logging configured, loading application modules...
14:51:26 - font_manager      - DEBUG - Using fontManager instance from /root/.cache/matplotlib/fontlist-v390.json
14:51:28 - shvatka.__main__  - INFO - application modules loaded in 8.51 s
14:51:29 - shvatka.main_factory - INFO - app prepared in 1.10 s
```

**67.70 s → 8.51 s of import, ~10 s to ready instead of ~77 s.** The font cache line confirms the baked cache is hit rather than regenerated.

The scaling is essentially linear in the CPU quota: 4.5 s on an unthrottled reference machine, ~8.5 s on the deployment host at 1.5 CPU, ~68 s at 0.15. The CPU limit was the whole multiplier.

## Not addressed here

* Deferring `pyrogram` or `matplotlib` to first use was considered and rejected on measurement. `matplotlib` is only 0.077 s of marginal cost in context (numpy/PIL are already loaded by then), and `pyrogram` would gain nothing because `warm_up()` constructs `UserGetter`, whose `__init__` builds a `pyrogram.Client`. Neither is worth contorting the code for.
* `uvicorn` is imported at module level rather than inside `run()`. Measured at 0.155 s cumulative, so it costs ~0.05 s of the time-to-first-log-line and is not worth a lazy import.
* Root log level is `DEBUG` in `config_dist/logging.yml`. Measured: 33 lines during import, no measurable cost. Noise, not a performance problem. Left alone.

## Verification

* `ruff format --check` and `ruff check` clean on the touched files.
* `mypy` reports no new errors on the touched files (pre-existing missing-stub errors elsewhere are unchanged).
* `pytest tests/unit` — 240 passed.
* `python -m compileall shvatka` exits 0, so the new Dockerfile step will not fail the build.
* `UV_COMPILE_BYTECODE=1` verified to have the intended effect: the aiogram package goes from 0 to ~580 `.pyc` files in the built image.