### PR TITLE
Support spoiler for photo, video and animation hint parts

### DIFF
--- a/shvatka/core/models/dto/hints/hint_part.py
+++ b/shvatka/core/models/dto/hints/hint_part.py
@@ -76,6 +76,7 @@ class FileMixin:
 class PhotoHint(BaseHint, CaptionMixin, FileMixin):
     type: Literal["photo"] = HintType.photo.name
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def get_guids(self) -> list[str]:
         return [self.file_guid]

--- a/shvatka/core/models/dto/hints/hint_part.py
+++ b/shvatka/core/models/dto/hints/hint_part.py
@@ -104,6 +104,7 @@ class AudioHint(BaseHint, CaptionMixin, ThumbMixin, FileMixin):
 class VideoHint(BaseHint, CaptionMixin, ThumbMixin, FileMixin):
     type: Literal["video"] = HintType.video.name
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def get_guids(self) -> list[str]:
         result = [self.file_guid]
@@ -125,6 +126,7 @@ class DocumentHint(BaseHint, CaptionMixin, ThumbMixin, FileMixin):
 class AnimationHint(BaseHint, CaptionMixin, ThumbMixin, FileMixin):
     type: Literal["animation"] = HintType.animation.name
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def get_guids(self) -> list[str]:
         result = [self.file_guid]

--- a/shvatka/tgbot/models/hint.py
+++ b/shvatka/tgbot/models/hint.py
@@ -80,11 +80,13 @@ class VenueHintView(BaseHintLinkView, BaseHintContentView):
 class PhotoLinkView(BaseHintLinkView, CaptionViewMixin):
     file_id: str | None
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "photo": self.file_id,
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             **self.caption_kwargs(),
         }
 
@@ -93,11 +95,13 @@ class PhotoLinkView(BaseHintLinkView, CaptionViewMixin):
 class PhotoContentView(BaseHintContentView, CaptionViewMixin):
     content: BinaryIO
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "photo": _get_input_file(self.content),
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             **self.caption_kwargs(),
         }
 

--- a/shvatka/tgbot/models/hint.py
+++ b/shvatka/tgbot/models/hint.py
@@ -135,12 +135,14 @@ class AudioContentView(BaseHintContentView, CaptionViewMixin):
 class VideoLinkView(BaseHintLinkView, CaptionViewMixin):
     file_id: str | None
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
     thumb: str | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "video": self.file_id,
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             **self.caption_kwargs(),
         }
 
@@ -149,12 +151,14 @@ class VideoLinkView(BaseHintLinkView, CaptionViewMixin):
 class VideoContentView(BaseHintContentView, CaptionViewMixin):
     content: BinaryIO
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
     thumb: BinaryIO | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "video": _get_input_file(self.content),
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             "thumbnail": _get_input_file(self.thumb),
             **self.caption_kwargs(),
         }
@@ -190,11 +194,13 @@ class AnimationLinkView(BaseHintLinkView, CaptionViewMixin):
     file_id: str | None
     thumb: str | None = None
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "animation": self.file_id,
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             **self.caption_kwargs(),
         }
 
@@ -204,11 +210,13 @@ class AnimationContentView(BaseHintContentView, CaptionViewMixin):
     content: BinaryIO
     thumb: BinaryIO | None = None
     show_caption_above_media: bool | None = None
+    has_spoiler: bool | None = None
 
     def specific_kwargs(self) -> dict[str, Any]:
         return {
             "animation": _get_input_file(self.content),
             "show_caption_above_media": self.show_caption_above_media,
+            "has_spoiler": self.has_spoiler,
             "thumbnail": _get_input_file(self.thumb),
             **self.caption_kwargs(),
         }

--- a/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
+++ b/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
@@ -93,6 +93,7 @@ class HintContentResolver:
                     file_id=await self._resolve_file_id(hint_.file_guid),
                     caption=hint_.caption,
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     thumb=await self._resolve_thumb_file_id(hint_.thumb_guid),
                 )
             case DocumentHint():
@@ -108,6 +109,7 @@ class HintContentResolver:
                     file_id=await self._resolve_file_id(hint_.file_guid),
                     caption=hint_.caption,
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     thumb=await self._resolve_thumb_file_id(hint_.thumb_guid),
                 )
             case VoiceHint():
@@ -186,6 +188,7 @@ class HintContentResolver:
                 return VideoContentView(
                     content=await self._resolve_bytes(hint_.file_guid),
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     caption=hint_.caption,
                 )
             case DocumentHint():
@@ -201,6 +204,7 @@ class HintContentResolver:
                     content=await self._resolve_bytes(hint_.file_guid),
                     caption=hint_.caption,
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     thumb=await self._resolve_thumb_bytes(hint_.thumb_guid),
                 )
             case VoiceHint():

--- a/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
+++ b/shvatka/tgbot/views/hint_factory/hint_content_resolver.py
@@ -77,6 +77,7 @@ class HintContentResolver:
                 return PhotoLinkView(
                     file_id=await self._resolve_file_id(hint_.file_guid),
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     caption=hint_.caption,
                 )
             case AudioHint():
@@ -171,6 +172,7 @@ class HintContentResolver:
                 return PhotoContentView(
                     content=await self._resolve_bytes(hint_.file_guid),
                     show_caption_above_media=hint_.show_caption_above_media,
+                    has_spoiler=hint_.has_spoiler,
                     caption=hint_.caption,
                 )
             case AudioHint():

--- a/shvatka/tgbot/views/hint_factory/hint_parser.py
+++ b/shvatka/tgbot/views/hint_factory/hint_parser.py
@@ -69,6 +69,7 @@ class HintParser:
                     file_guid=guid,
                     thumb_guid=thumb.guid if thumb else None,
                     show_caption_above_media=parse_bool_default(message.show_caption_above_media),
+                    has_spoiler=message.has_media_spoiler,
                 )
             case ContentType.DOCUMENT:
                 assert message.document
@@ -86,6 +87,7 @@ class HintParser:
                     file_guid=guid,
                     thumb_guid=thumb.guid if thumb else None,
                     show_caption_above_media=parse_bool_default(message.show_caption_above_media),
+                    has_spoiler=message.has_media_spoiler,
                 )
             case ContentType.VOICE:
                 return hints.VoiceHint(caption=message.html_text, file_guid=guid)

--- a/shvatka/tgbot/views/hint_factory/hint_parser.py
+++ b/shvatka/tgbot/views/hint_factory/hint_parser.py
@@ -51,6 +51,7 @@ class HintParser:
                     caption=message.html_text,
                     file_guid=guid,
                     show_caption_above_media=parse_bool_default(message.show_caption_above_media),
+                    has_spoiler=message.has_media_spoiler,
                 )
             case ContentType.AUDIO:
                 assert message.audio

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -252,6 +252,7 @@ async def test_game_hints(
                     "caption": "привет",
                     "file_guid": "a3bc9b96-3bb8-4dbc-b996-ce1015e66e53",
                     "show_caption_above_media": None,
+                    "has_spoiler": None,
                     "type": "photo",
                 }
             ],

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -163,6 +163,65 @@ async def test_scenario_files_round_trip(
 
 
 @pytest.mark.asyncio
+async def test_photo_hint_spoiler_round_trip(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+):
+    """A photo hint uploaded with ``has_spoiler`` keeps it when read back."""
+    game = await create_game(author=author, name="draft with spoiler", dao=dao.game_creator)
+    cookies = auth_cookies(auth, author)
+    up = await client.post(
+        f"/cdn/games/{game.id}/files",
+        files={"file": ("pic.png", b"\x89PNG\r\n\x1a\n binary", "image/png")},
+        cookies=cookies,
+    )
+    assert up.status_code == 200, up.text
+    f = up.json()
+    scenario = {
+        "name": "with spoiler",
+        "__model_version__": 1,
+        "files": [
+            {
+                "guid": f["guid"],
+                "original_filename": f["original_filename"],
+                "extension": f["extension"],
+            }
+        ],
+        "levels": [
+            {
+                "id": "first",
+                "__model_version__": 1,
+                "conditions": [{"type": "WIN_KEY", "keys": ["SH123"]}],
+                "time_hints": [
+                    {
+                        "time": 0,
+                        "hint": [
+                            {
+                                "type": "photo",
+                                "file_guid": f["guid"],
+                                "caption": "pic",
+                                "has_spoiler": True,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    put = await client.put(f"/games/my/{game.id}/scenario", json=scenario, cookies=cookies)
+    assert put.status_code == 200, put.text
+
+    got = await client.get(f"/games/my/{game.id}", cookies=cookies)
+    assert got.status_code == 200, got.text
+    hint = got.json()["levels"][0]["scenario"]["time_hints"][0]["hint"][0]
+    assert hint["has_spoiler"] is True
+    stored = await dao.game.get_full(game.id)
+    assert stored.levels[0].scenario.time_hints[0].hint[0].has_spoiler is True
+
+
+@pytest.mark.asyncio
 async def test_change_scenario(
     client: AsyncClient,
     auth: AuthProperties,

--- a/tests/integration/bot_full/test_hint_sender.py
+++ b/tests/integration/bot_full/test_hint_sender.py
@@ -220,6 +220,49 @@ async def test_send_by_content_when_file_id_missing(
 
 
 @pytest.mark.asyncio
+async def test_send_photo_with_spoiler_by_id(
+    hint_sender: HintSender,
+    harry: dto.Player,
+    bot_session: BaseSession,
+):
+    await hint_sender.resolver.dao.upsert(file=FILE_META, author=harry)
+    await hint_sender.resolver.dao.commit()
+
+    await hint_sender.send_hint(PhotoHint(file_guid=GUID, has_spoiler=True), CHAT_ID)
+
+    session = typing.cast(MagicMock, bot_session)
+    call = session.mock_calls.pop()
+    request = call.args[1]
+    assert request.__api_method__ == "sendPhoto"
+    assert request.photo == FILE_ID
+    assert request.has_spoiler is True
+
+
+@pytest.mark.asyncio
+async def test_send_photo_with_spoiler_by_content(
+    hint_sender: HintSender,
+    harry: dto.Player,
+    bot_session: BaseSession,
+):
+    await hint_sender.resolver.storage.put_content(FILE_META.local_file_name, BytesIO(b"12345"))
+    await hint_sender.resolver.dao.upsert(file=FILE_META, author=harry)
+    await hint_sender.resolver.dao.commit()
+    session = typing.cast(MagicMock, bot_session)
+    session.side_effect = [
+        TelegramAPIError(message="", method=SendPhoto),
+        {},
+    ]
+
+    await hint_sender.send_hint(PhotoHint(file_guid=GUID, has_spoiler=True), CHAT_ID)
+
+    call = session.mock_calls.pop()
+    request = call.args[1]
+    assert request.__api_method__ == "sendPhoto"
+    assert request.photo is not None
+    assert request.has_spoiler is True
+
+
+@pytest.mark.asyncio
 async def test_send_hints_returns_all_sent_messages(
     hint_sender: HintSender,
     bot_session: BaseSession,

--- a/tests/integration/bot_full/test_hint_sender.py
+++ b/tests/integration/bot_full/test_hint_sender.py
@@ -59,6 +59,17 @@ PARAMETERS = [
     (SendVideoNote, VideoNoteHint(file_guid=GUID), "sendVideoNote", "video_note"),
     (SendSticker, StickerHint(file_guid=GUID), "sendSticker", "sticker"),
 ]
+# telegram supports a spoiler only for these three
+SPOILER_PARAMETERS = [
+    (SendPhoto, PhotoHint(file_guid=GUID, has_spoiler=True), "sendPhoto", "photo"),
+    (SendVideo, VideoHint(file_guid=GUID, has_spoiler=True), "sendVideo", "video"),
+    (
+        SendAnimation,
+        AnimationHint(file_guid=GUID, has_spoiler=True),
+        "sendAnimation",
+        "animation",
+    ),
+]
 
 
 @pytest_asyncio.fixture
@@ -220,28 +231,38 @@ async def test_send_by_content_when_file_id_missing(
 
 
 @pytest.mark.asyncio
-async def test_send_photo_with_spoiler_by_id(
+@pytest.mark.parametrize(("tg_method", "hint", "method_name", "content_type"), SPOILER_PARAMETERS)
+async def test_send_spoiler_by_id(
     hint_sender: HintSender,
     harry: dto.Player,
+    hint: BaseHint,
+    tg_method: type[TelegramMethod[TelegramType]],
+    method_name: str,
+    content_type: str,
     bot_session: BaseSession,
 ):
     await hint_sender.resolver.dao.upsert(file=FILE_META, author=harry)
     await hint_sender.resolver.dao.commit()
 
-    await hint_sender.send_hint(PhotoHint(file_guid=GUID, has_spoiler=True), CHAT_ID)
+    await hint_sender.send_hint(hint, CHAT_ID)
 
     session = typing.cast(MagicMock, bot_session)
     call = session.mock_calls.pop()
     request = call.args[1]
-    assert request.__api_method__ == "sendPhoto"
-    assert request.photo == FILE_ID
+    assert request.__api_method__ == method_name
+    assert getattr(request, content_type) == FILE_ID
     assert request.has_spoiler is True
 
 
 @pytest.mark.asyncio
-async def test_send_photo_with_spoiler_by_content(
+@pytest.mark.parametrize(("tg_method", "hint", "method_name", "content_type"), SPOILER_PARAMETERS)
+async def test_send_spoiler_by_content(
     hint_sender: HintSender,
     harry: dto.Player,
+    hint: BaseHint,
+    tg_method: type[TelegramMethod[TelegramType]],
+    method_name: str,
+    content_type: str,
     bot_session: BaseSession,
 ):
     await hint_sender.resolver.storage.put_content(FILE_META.local_file_name, BytesIO(b"12345"))
@@ -249,16 +270,16 @@ async def test_send_photo_with_spoiler_by_content(
     await hint_sender.resolver.dao.commit()
     session = typing.cast(MagicMock, bot_session)
     session.side_effect = [
-        TelegramAPIError(message="", method=SendPhoto),
+        TelegramAPIError(message="", method=tg_method),
         {},
     ]
 
-    await hint_sender.send_hint(PhotoHint(file_guid=GUID, has_spoiler=True), CHAT_ID)
+    await hint_sender.send_hint(hint, CHAT_ID)
 
     call = session.mock_calls.pop()
     request = call.args[1]
-    assert request.__api_method__ == "sendPhoto"
-    assert request.photo is not None
+    assert request.__api_method__ == method_name
+    assert getattr(request, content_type) is not None
     assert request.has_spoiler is True
 
 

--- a/tests/unit/test_hint_parser.py
+++ b/tests/unit/test_hint_parser.py
@@ -1,10 +1,12 @@
+import typing
 from datetime import datetime, timezone
 from io import BytesIO
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from aiogram import Bot
-from aiogram.types import Chat, Message, PhotoSize
+from aiogram.types import Animation, Chat, Message, PhotoSize, Video
 
 from shvatka.core.models import dto
 from shvatka.core.models.dto import hints
@@ -13,6 +15,19 @@ from shvatka.tgbot.views.hint_factory.hint_parser import HintParser
 from tests.mocks.file_storage import MemoryFileStorage
 
 AUTHOR = dto.Player(id=1, can_be_author=True, is_dummy=False)
+PHOTO = {"photo": [PhotoSize(file_id="FILE_ID", file_unique_id="unique", width=1, height=1)]}
+VIDEO = {"video": Video(file_id="FILE_ID", file_unique_id="unique", width=1, height=1, duration=1)}
+ANIMATION = {
+    "animation": Animation(
+        file_id="FILE_ID", file_unique_id="unique", width=1, height=1, duration=1
+    )
+}
+SPOILERABLE = [
+    (PHOTO, hints.PhotoHint),
+    (VIDEO, hints.VideoHint),
+    (ANIMATION, hints.AnimationHint),
+]
+SpoilerHint: typing.TypeAlias = hints.PhotoHint | hints.VideoHint | hints.AnimationHint
 
 
 @pytest.fixture
@@ -23,28 +38,38 @@ def hint_parser() -> HintParser:
     return HintParser(dao=dao, file_storage=MemoryFileStorage(), bot=bot)
 
 
-def photo_message(**kwargs) -> Message:
+def media_message(**kwargs) -> Message:
     return Message(
         message_id=1,
         date=datetime.now(tz=timezone.utc),
         chat=Chat(id=1, type="private"),
-        photo=[PhotoSize(file_id="FILE_ID", file_unique_id="unique", width=1, height=1)],
         **kwargs,
     )
 
 
 @pytest.mark.asyncio
-async def test_parse_photo_with_spoiler(hint_parser: HintParser):
-    hint = await hint_parser.parse(photo_message(has_media_spoiler=True), AUTHOR)
+@pytest.mark.parametrize(("media", "hint_type"), SPOILERABLE)
+async def test_parse_media_with_spoiler(
+    hint_parser: HintParser,
+    media: dict[str, Any],
+    hint_type: type[hints.BaseHint],
+):
+    hint = await hint_parser.parse(media_message(**media, has_media_spoiler=True), AUTHOR)
 
-    assert isinstance(hint, hints.PhotoHint)
-    assert hint.has_spoiler is True
+    assert isinstance(hint, hint_type)
+    assert typing.cast(SpoilerHint, hint).has_spoiler is True
 
 
 @pytest.mark.asyncio
-async def test_parse_photo_without_spoiler(hint_parser: HintParser):
-    hint = await hint_parser.parse(photo_message(caption="подпись"), AUTHOR)
+@pytest.mark.parametrize(("media", "hint_type"), SPOILERABLE)
+async def test_parse_media_without_spoiler(
+    hint_parser: HintParser,
+    media: dict[str, Any],
+    hint_type: type[hints.BaseHint],
+):
+    hint = await hint_parser.parse(media_message(**media, caption="подпись"), AUTHOR)
 
-    assert isinstance(hint, hints.PhotoHint)
-    assert not hint.has_spoiler
-    assert hint.caption == "подпись"
+    assert isinstance(hint, hint_type)
+    parsed = typing.cast(SpoilerHint, hint)
+    assert not parsed.has_spoiler
+    assert parsed.caption == "подпись"

--- a/tests/unit/test_hint_parser.py
+++ b/tests/unit/test_hint_parser.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import AsyncMock
+
+import pytest
+from aiogram import Bot
+from aiogram.types import Chat, Message, PhotoSize
+
+from shvatka.core.models import dto
+from shvatka.core.models.dto import hints
+from shvatka.infrastructure.db.dao import FileInfoDao
+from shvatka.tgbot.views.hint_factory.hint_parser import HintParser
+from tests.mocks.file_storage import MemoryFileStorage
+
+AUTHOR = dto.Player(id=1, can_be_author=True, is_dummy=False)
+
+
+@pytest.fixture
+def hint_parser() -> HintParser:
+    bot = AsyncMock(Bot)
+    bot.download.return_value = BytesIO(b"12345")
+    dao = AsyncMock(FileInfoDao)
+    return HintParser(dao=dao, file_storage=MemoryFileStorage(), bot=bot)
+
+
+def photo_message(**kwargs) -> Message:
+    return Message(
+        message_id=1,
+        date=datetime.now(tz=timezone.utc),
+        chat=Chat(id=1, type="private"),
+        photo=[PhotoSize(file_id="FILE_ID", file_unique_id="unique", width=1, height=1)],
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_parse_photo_with_spoiler(hint_parser: HintParser):
+    hint = await hint_parser.parse(photo_message(has_media_spoiler=True), AUTHOR)
+
+    assert isinstance(hint, hints.PhotoHint)
+    assert hint.has_spoiler is True
+
+
+@pytest.mark.asyncio
+async def test_parse_photo_without_spoiler(hint_parser: HintParser):
+    hint = await hint_parser.parse(photo_message(caption="подпись"), AUTHOR)
+
+    assert isinstance(hint, hints.PhotoHint)
+    assert not hint.has_spoiler
+    assert hint.caption == "подпись"


### PR DESCRIPTION
## What

Telegram lets a photo, video or animation be sent under a spoiler (`has_media_spoiler` on the incoming message, `has_spoiler` on `sendPhoto` / `sendVideo` / `sendAnimation`). Until now that flag was dropped when an author sent such media as a hint part, so the hint was always delivered uncovered.

Now the spoiler is saved with the hint and re-applied when the hint is sent.

## Changes

- `shvatka/core/models/dto/hints/hint_part.py` — `PhotoHint`, `VideoHint` and `AnimationHint` gain `has_spoiler: bool | None = None`. Being regular fields they are serialized with the scenario (so they survive export/upload) and appear in the API responses that expose hints.
- `shvatka/tgbot/views/hint_factory/hint_parser.py` — reads `message.has_media_spoiler` when parsing a photo, video or animation message.
- `shvatka/tgbot/models/hint.py` — the link and content views of all three types carry `has_spoiler` and pass it to the send method, so the spoiler survives both the file_id path and the send-by-content fallback.
- `shvatka/tgbot/views/hint_factory/hint_content_resolver.py` — maps the field from the hint onto both views.

Scenarios written before this change simply have no `has_spoiler` key and load with the `None` default, so nothing about existing games changes. The other media types (document, audio, voice, video note, sticker) have no spoiler in the Bot API and are untouched.

## API

No API code change was needed: hints are exposed as the core dataclasses themselves (`hints.AnyHint` / `hints.TimeHint` in `shvatka/api/games/responses.py`), and `PUT /games/my/{id}/scenario` loads a raw scenario dict straight into them, so the new field is accepted and returned automatically. `test_photo_hint_spoiler_round_trip` pins that pass-through down.

## Tests

- `tests/unit/test_hint_parser.py` (new) — parsing photo/video/animation messages with and without `has_media_spoiler`.
- `tests/integration/bot_full/test_hint_sender.py` — sending each of the three hint types with `has_spoiler=True` sets `has_spoiler` on the outgoing request, both by file_id and by content.
- `tests/integration/api_full/test_game_edit.py` — a spoilered photo hint survives `PUT` → `GET` of the scenario.
- `tests/integration/api_full/test_game.py` — expected hint payload updated with the new key.

`ruff format --check`, `ruff check`, `mypy` and `pytest tests/unit` run clean locally; the integration suite needs Docker, which isn't available in this environment, so it's left to CI (it passed there on the previous commit).