### PR TITLE
Add database indexes: game run cycle and foreign keys

### DIFF
--- a/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
@@ -1,8 +1,13 @@
-"""add query and foreign key indexes
+"""add indexes for the game run cycle
 
 Postgres does not index foreign key columns automatically, and this schema had
-almost no non-unique indexes: every per-game/per-team/per-player lookup fell back
-to a sequential scan, and every parent DELETE scanned each child table in full.
+almost no non-unique indexes, so the tables read while a game runs were scanned
+in full on every lookup. In production these four alone account for 95.6% of all
+sequential tuple reads, log_keys for 80.1% of them with no index scan ever
+recorded against it.
+
+Tables outside the game run cycle are deliberately left alone: together they are
+under 0.5% of sequential reads and already serve most lookups from an index.
 
 Revision ID: b4c6d2e0f8a7
 Revises: a3b5c1d9e7f6
@@ -50,21 +55,10 @@ INDEXES: list[tuple[str, str, list, dict]] = [
     # --- event_log ---
     ("ix__event_log__game_id_team_id_at", "event_log", ["game_id", "team_id", "at"], {}),
     ("ix__event_log__level_time_id", "event_log", ["level_time_id"], {}),
-    # --- remaining unindexed foreign keys ---
+    # --- organizers and timers, also read while a game runs ---
     ("ix__organizers__game_id", "organizers", ["game_id"], {}),
-    ("ix__achievements__player_id", "achievements", ["player_id"], {}),
-    ("ix__files_info__author_id", "files_info", ["author_id"], {}),
-    ("ix__level_files__file_id", "level_files", ["file_id"], {}),
-    ("ix__game_files__file_id", "game_files", ["file_id"], {}),
     ("ix__timers_log__level_time_id", "timers_log", ["level_time_id"], {}),
     ("ix__timers_log__event_id", "timers_log", ["event_id"], {}),
-    ("ix__teams__captain_id", "teams", ["captain_id"], {}),
-    ("ix__players__promoted_by_id", "players", ["promoted_by_id"], {}),
-    ("ix__notifications__actor_id", "notifications", ["actor_id"], {}),
-    ("ix__notifications__request_id", "notifications", ["request_id"], {}),
-    ("ix__action_requests__initiator_id", "action_requests", ["initiator_id"], {}),
-    ("ix__action_requests__game_id", "action_requests", ["game_id"], {}),
-    ("ix__action_requests__responder_id", "action_requests", ["responder_id"], {}),
 ]
 
 

--- a/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
@@ -1,0 +1,84 @@
+"""add query and foreign key indexes
+
+Postgres does not index foreign key columns automatically, and this schema had
+almost no non-unique indexes: every per-game/per-team/per-player lookup fell back
+to a sequential scan, and every parent DELETE scanned each child table in full.
+
+Revision ID: b4c6d2e0f8a7
+Revises: a3b5c1d9e7f6
+Create Date: 2026-08-07 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b4c6d2e0f8a7"
+down_revision = "a3b5c1d9e7f6"
+branch_labels = None
+depends_on = None
+
+# (name, table, columns, kwargs) — created in order, dropped in reverse
+INDEXES: list[tuple[str, str, list, dict]] = [
+    # --- log_keys: the largest and fastest growing table ---
+    # all per-level key queries filter game_id + level_time_id + team_id, but
+    # level_time_id alone already narrows to a single team's single level
+    ("ix__log_keys__level_time_id", "log_keys", ["level_time_id"], {}),
+    ("ix__log_keys__game_id_enter_time", "log_keys", ["game_id", "enter_time"], {}),
+    ("ix__log_keys__player_id", "log_keys", ["player_id"], {}),
+    ("ix__log_keys__team_id", "log_keys", ["team_id"], {}),
+    ("ix__log_keys__event_id", "log_keys", ["event_id"], {}),
+    # --- levels_times ---
+    # serves both the current-level lookup (game + team, latest start_at) and the
+    # whole-game listing ordered by team_id, start_at
+    (
+        "ix__levels_times__game_id_team_id_start_at",
+        "levels_times",
+        ["game_id", "team_id", "start_at"],
+        {},
+    ),
+    ("ix__levels_times__team_id", "levels_times", ["team_id"], {}),
+    # --- levels: unique constraint leads with author_id, so game_id was unindexed ---
+    ("ix__levels__game_id_number_in_game", "levels", ["game_id", "number_in_game"], {}),
+    # --- team_players: resolves "which team is this player on" on nearly every request ---
+    ("ix__team_players__player_id", "team_players", ["player_id"], {}),
+    ("ix__team_players__team_id", "team_players", ["team_id"], {}),
+    # --- waivers: unique constraint leads with game_id ---
+    ("ix__waivers__player_id", "waivers", ["player_id"], {}),
+    ("ix__waivers__team_id", "waivers", ["team_id"], {}),
+    # --- event_log ---
+    ("ix__event_log__game_id_team_id_at", "event_log", ["game_id", "team_id", "at"], {}),
+    ("ix__event_log__level_time_id", "event_log", ["level_time_id"], {}),
+    # --- remaining unindexed foreign keys ---
+    ("ix__organizers__game_id", "organizers", ["game_id"], {}),
+    ("ix__achievements__player_id", "achievements", ["player_id"], {}),
+    ("ix__files_info__author_id", "files_info", ["author_id"], {}),
+    ("ix__level_files__file_id", "level_files", ["file_id"], {}),
+    ("ix__game_files__file_id", "game_files", ["file_id"], {}),
+    ("ix__timers_log__level_time_id", "timers_log", ["level_time_id"], {}),
+    ("ix__timers_log__event_id", "timers_log", ["event_id"], {}),
+    ("ix__teams__captain_id", "teams", ["captain_id"], {}),
+    ("ix__players__promoted_by_id", "players", ["promoted_by_id"], {}),
+    ("ix__notifications__actor_id", "notifications", ["actor_id"], {}),
+    ("ix__notifications__request_id", "notifications", ["request_id"], {}),
+    ("ix__action_requests__initiator_id", "action_requests", ["initiator_id"], {}),
+    ("ix__action_requests__game_id", "action_requests", ["game_id"], {}),
+    ("ix__action_requests__responder_id", "action_requests", ["responder_id"], {}),
+]
+
+
+def upgrade():
+    for name, table, columns, kwargs in INDEXES:
+        op.create_index(name, table, columns, unique=False, **kwargs)
+    # the planner needs fresh stats to start choosing the new indexes
+    op.execute(sa.text("ANALYZE log_keys"))
+    op.execute(sa.text("ANALYZE levels_times"))
+    op.execute(sa.text("ANALYZE levels"))
+    op.execute(sa.text("ANALYZE team_players"))
+    op.execute(sa.text("ANALYZE waivers"))
+
+
+def downgrade():
+    for name, table, _columns, _kwargs in reversed(INDEXES):
+        op.drop_index(name, table_name=table)

--- a/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260807-120000_b4c6d2e0f8a7_add_query_and_fk_indexes.py
@@ -24,47 +24,58 @@ down_revision = "a3b5c1d9e7f6"
 branch_labels = None
 depends_on = None
 
-# (name, table, columns, kwargs) — created in order, dropped in reverse
-INDEXES: list[tuple[str, str, list, dict]] = [
-    # --- log_keys: the largest and fastest growing table ---
-    # all per-level key queries filter game_id + level_time_id + team_id, but
-    # level_time_id alone already narrows to a single team's single level
-    ("ix__log_keys__level_time_id", "log_keys", ["level_time_id"], {}),
-    ("ix__log_keys__game_id_enter_time", "log_keys", ["game_id", "enter_time"], {}),
-    ("ix__log_keys__player_id", "log_keys", ["player_id"], {}),
-    ("ix__log_keys__team_id", "log_keys", ["team_id"], {}),
-    ("ix__log_keys__event_id", "log_keys", ["event_id"], {}),
-    # --- levels_times ---
-    # serves both the current-level lookup (game + team, latest start_at) and the
-    # whole-game listing ordered by team_id, start_at
-    (
+
+def upgrade():
+    # log_keys: the largest and fastest growing table. All per-level key queries
+    # filter game_id + level_time_id + team_id, but level_time_id alone already
+    # narrows to a single team's single level.
+    op.create_index("ix__log_keys__level_time_id", "log_keys", ["level_time_id"], unique=False)
+    op.create_index(
+        "ix__log_keys__game_id_enter_time", "log_keys", ["game_id", "enter_time"], unique=False
+    )
+    op.create_index("ix__log_keys__player_id", "log_keys", ["player_id"], unique=False)
+    op.create_index("ix__log_keys__team_id", "log_keys", ["team_id"], unique=False)
+    op.create_index("ix__log_keys__event_id", "log_keys", ["event_id"], unique=False)
+
+    # levels_times: serves both the current-level lookup (game + team, latest
+    # start_at) and the whole-game listing ordered by team_id, start_at.
+    op.create_index(
         "ix__levels_times__game_id_team_id_start_at",
         "levels_times",
         ["game_id", "team_id", "start_at"],
-        {},
-    ),
-    ("ix__levels_times__team_id", "levels_times", ["team_id"], {}),
-    # --- levels: unique constraint leads with author_id, so game_id was unindexed ---
-    ("ix__levels__game_id_number_in_game", "levels", ["game_id", "number_in_game"], {}),
-    # --- team_players: resolves "which team is this player on" on nearly every request ---
-    ("ix__team_players__player_id", "team_players", ["player_id"], {}),
-    ("ix__team_players__team_id", "team_players", ["team_id"], {}),
-    # --- waivers: unique constraint leads with game_id ---
-    ("ix__waivers__player_id", "waivers", ["player_id"], {}),
-    ("ix__waivers__team_id", "waivers", ["team_id"], {}),
-    # --- event_log ---
-    ("ix__event_log__game_id_team_id_at", "event_log", ["game_id", "team_id", "at"], {}),
-    ("ix__event_log__level_time_id", "event_log", ["level_time_id"], {}),
-    # --- organizers and timers, also read while a game runs ---
-    ("ix__organizers__game_id", "organizers", ["game_id"], {}),
-    ("ix__timers_log__level_time_id", "timers_log", ["level_time_id"], {}),
-    ("ix__timers_log__event_id", "timers_log", ["event_id"], {}),
-]
+        unique=False,
+    )
+    op.create_index("ix__levels_times__team_id", "levels_times", ["team_id"], unique=False)
 
+    # levels: the unique constraint leads with author_id, so game_id was unindexed.
+    op.create_index(
+        "ix__levels__game_id_number_in_game",
+        "levels",
+        ["game_id", "number_in_game"],
+        unique=False,
+    )
 
-def upgrade():
-    for name, table, columns, kwargs in INDEXES:
-        op.create_index(name, table, columns, unique=False, **kwargs)
+    # team_players: resolves "which team is this player on" on nearly every request.
+    op.create_index("ix__team_players__player_id", "team_players", ["player_id"], unique=False)
+    op.create_index("ix__team_players__team_id", "team_players", ["team_id"], unique=False)
+
+    # waivers: the unique constraint leads with game_id.
+    op.create_index("ix__waivers__player_id", "waivers", ["player_id"], unique=False)
+    op.create_index("ix__waivers__team_id", "waivers", ["team_id"], unique=False)
+
+    op.create_index(
+        "ix__event_log__game_id_team_id_at",
+        "event_log",
+        ["game_id", "team_id", "at"],
+        unique=False,
+    )
+    op.create_index("ix__event_log__level_time_id", "event_log", ["level_time_id"], unique=False)
+
+    # organizers and timers, also read while a game runs
+    op.create_index("ix__organizers__game_id", "organizers", ["game_id"], unique=False)
+    op.create_index("ix__timers_log__level_time_id", "timers_log", ["level_time_id"], unique=False)
+    op.create_index("ix__timers_log__event_id", "timers_log", ["event_id"], unique=False)
+
     # the planner needs fresh stats to start choosing the new indexes
     op.execute(sa.text("ANALYZE log_keys"))
     op.execute(sa.text("ANALYZE levels_times"))
@@ -74,5 +85,20 @@ def upgrade():
 
 
 def downgrade():
-    for name, table, _columns, _kwargs in reversed(INDEXES):
-        op.drop_index(name, table_name=table)
+    op.drop_index("ix__timers_log__event_id", table_name="timers_log")
+    op.drop_index("ix__timers_log__level_time_id", table_name="timers_log")
+    op.drop_index("ix__organizers__game_id", table_name="organizers")
+    op.drop_index("ix__event_log__level_time_id", table_name="event_log")
+    op.drop_index("ix__event_log__game_id_team_id_at", table_name="event_log")
+    op.drop_index("ix__waivers__team_id", table_name="waivers")
+    op.drop_index("ix__waivers__player_id", table_name="waivers")
+    op.drop_index("ix__team_players__team_id", table_name="team_players")
+    op.drop_index("ix__team_players__player_id", table_name="team_players")
+    op.drop_index("ix__levels__game_id_number_in_game", table_name="levels")
+    op.drop_index("ix__levels_times__team_id", table_name="levels_times")
+    op.drop_index("ix__levels_times__game_id_team_id_start_at", table_name="levels_times")
+    op.drop_index("ix__log_keys__event_id", table_name="log_keys")
+    op.drop_index("ix__log_keys__team_id", table_name="log_keys")
+    op.drop_index("ix__log_keys__player_id", table_name="log_keys")
+    op.drop_index("ix__log_keys__game_id_enter_time", table_name="log_keys")
+    op.drop_index("ix__log_keys__level_time_id", table_name="log_keys")

--- a/shvatka/infrastructure/db/migrations/versions/20260807-130000_c5d7e3f1a9b8_add_foreign_key_indexes.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260807-130000_c5d7e3f1a9b8_add_foreign_key_indexes.py
@@ -1,0 +1,64 @@
+"""add indexes for the remaining foreign keys
+
+Postgres does not index foreign key columns automatically. Unlike the game run
+cycle indexes in the previous revision, these are not about read traffic: they
+are what a DELETE on the parent row needs. Without them every such delete scans
+each referencing table in full to validate the constraint, which is why deleting
+or merging a player touches most of the schema.
+
+A foreign key counts as covered only when some index has it as its first column
+and is not partial. That excludes event_log.team_id, which sits second in
+(game_id, team_id, at), and action_requests.team_id, whose only index is
+restricted to WHERE status = 'pending'.
+
+Revision ID: c5d7e3f1a9b8
+Revises: b4c6d2e0f8a7
+Create Date: 2026-08-07 13:00:00.000000
+
+"""
+
+from alembic import op
+
+
+revision = "c5d7e3f1a9b8"
+down_revision = "b4c6d2e0f8a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index("ix__players__promoted_by_id", "players", ["promoted_by_id"], unique=False)
+    op.create_index("ix__achievements__player_id", "achievements", ["player_id"], unique=False)
+    op.create_index("ix__files_info__author_id", "files_info", ["author_id"], unique=False)
+    op.create_index("ix__teams__captain_id", "teams", ["captain_id"], unique=False)
+    op.create_index("ix__game_files__file_id", "game_files", ["file_id"], unique=False)
+    op.create_index("ix__level_files__file_id", "level_files", ["file_id"], unique=False)
+    # second column of ix__event_log__game_id_team_id_at, so not usable on its own
+    op.create_index("ix__event_log__team_id", "event_log", ["team_id"], unique=False)
+    op.create_index("ix__notifications__actor_id", "notifications", ["actor_id"], unique=False)
+    op.create_index("ix__notifications__request_id", "notifications", ["request_id"], unique=False)
+    op.create_index(
+        "ix__action_requests__initiator_id", "action_requests", ["initiator_id"], unique=False
+    )
+    # ix__action_requests_pending_team covers this column only WHERE status = 'pending'
+    op.create_index("ix__action_requests__team_id", "action_requests", ["team_id"], unique=False)
+    op.create_index("ix__action_requests__game_id", "action_requests", ["game_id"], unique=False)
+    op.create_index(
+        "ix__action_requests__responder_id", "action_requests", ["responder_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index("ix__action_requests__responder_id", table_name="action_requests")
+    op.drop_index("ix__action_requests__game_id", table_name="action_requests")
+    op.drop_index("ix__action_requests__team_id", table_name="action_requests")
+    op.drop_index("ix__action_requests__initiator_id", table_name="action_requests")
+    op.drop_index("ix__notifications__request_id", table_name="notifications")
+    op.drop_index("ix__notifications__actor_id", table_name="notifications")
+    op.drop_index("ix__event_log__team_id", table_name="event_log")
+    op.drop_index("ix__level_files__file_id", table_name="level_files")
+    op.drop_index("ix__game_files__file_id", table_name="game_files")
+    op.drop_index("ix__teams__captain_id", table_name="teams")
+    op.drop_index("ix__files_info__author_id", table_name="files_info")
+    op.drop_index("ix__achievements__player_id", table_name="achievements")
+    op.drop_index("ix__players__promoted_by_id", table_name="players")

--- a/shvatka/infrastructure/db/migrations/versions/20260807-140000_d6e8f4a2b1c9_add_active_game_partial_index.py
+++ b/shvatka/infrastructure/db/migrations/versions/20260807-140000_d6e8f4a2b1c9_add_active_game_partial_index.py
@@ -1,0 +1,41 @@
+"""add a partial index for looking up the active game
+
+get_active_game backs CurrentGameProvider, the game services and the /active
+route, so it runs constantly, and it filters on the three statuses a running
+game passes through. A partial index on exactly that predicate holds only the
+handful of rows that are not yet complete, so it stays tiny and costs almost
+nothing to maintain: a game's status changes a few times in its whole life.
+
+The predicate must stay in step with ACTIVE_STATUSES in
+shvatka.core.models.enums.game_status. Postgres can only use the index for a
+query whose own predicate it implies, so adding a status to that tuple without
+a new migration silently stops the index from covering the query.
+
+Revision ID: d6e8f4a2b1c9
+Revises: c5d7e3f1a9b8
+Create Date: 2026-08-07 14:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d6e8f4a2b1c9"
+down_revision = "c5d7e3f1a9b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix__games__active_status",
+        "games",
+        ["status"],
+        unique=False,
+        postgresql_where=sa.text("status IN ('getting_waivers', 'started', 'finished')"),
+    )
+
+
+def downgrade():
+    op.drop_index("ix__games__active_status", table_name="games")

--- a/shvatka/infrastructure/db/models/achievement.py
+++ b/shvatka/infrastructure/db/models/achievement.py
@@ -1,7 +1,7 @@
 import typing
 from datetime import datetime
 
-from sqlalchemy import BigInteger, ForeignKey, DateTime, Index, func, Enum
+from sqlalchemy import BigInteger, ForeignKey, DateTime, func, Enum
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from shvatka.core.models import dto
@@ -34,8 +34,6 @@ class Achievement(Base):
         nullable=False,
     )
     first: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="F")
-
-    __table_args__ = (Index("ix__achievements__player_id", "player_id"),)
 
     def to_dto(self, player: dto.Player) -> dto.Achievement:
         return dto.Achievement(

--- a/shvatka/infrastructure/db/models/achievement.py
+++ b/shvatka/infrastructure/db/models/achievement.py
@@ -1,7 +1,7 @@
 import typing
 from datetime import datetime
 
-from sqlalchemy import BigInteger, ForeignKey, DateTime, func, Enum
+from sqlalchemy import BigInteger, ForeignKey, DateTime, Index, func, Enum
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from shvatka.core.models import dto
@@ -34,6 +34,8 @@ class Achievement(Base):
         nullable=False,
     )
     first: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="F")
+
+    __table_args__ = (Index("ix__achievements__player_id", "player_id"),)
 
     def to_dto(self, player: dto.Player) -> dto.Achievement:
         return dto.Achievement(

--- a/shvatka/infrastructure/db/models/action_request.py
+++ b/shvatka/infrastructure/db/models/action_request.py
@@ -55,9 +55,6 @@ class ActionRequest(Base):
             "team_id",
             postgresql_where=text("status = 'pending'"),
         ),
-        Index("ix__action_requests__initiator_id", "initiator_id"),
-        Index("ix__action_requests__game_id", "game_id"),
-        Index("ix__action_requests__responder_id", "responder_id"),
     )
 
     def to_dto(self) -> dto.ActionRequest:

--- a/shvatka/infrastructure/db/models/action_request.py
+++ b/shvatka/infrastructure/db/models/action_request.py
@@ -55,6 +55,11 @@ class ActionRequest(Base):
             "team_id",
             postgresql_where=text("status = 'pending'"),
         ),
+        Index("ix__action_requests__initiator_id", "initiator_id"),
+        # the index above covers this column only for pending requests
+        Index("ix__action_requests__team_id", "team_id"),
+        Index("ix__action_requests__game_id", "game_id"),
+        Index("ix__action_requests__responder_id", "responder_id"),
     )
 
     def to_dto(self) -> dto.ActionRequest:

--- a/shvatka/infrastructure/db/models/action_request.py
+++ b/shvatka/infrastructure/db/models/action_request.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Text, func
+from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -46,6 +46,18 @@ class ActionRequest(Base):
     expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     bot_messages: Mapped[list[dict[str, int]]] = mapped_column(
         JSONB, nullable=False, server_default="[]", default=list
+    )
+
+    __table_args__ = (
+        Index("ix__action_requests_target_player_id", "target_player_id"),
+        Index(
+            "ix__action_requests_pending_team",
+            "team_id",
+            postgresql_where=text("status = 'pending'"),
+        ),
+        Index("ix__action_requests__initiator_id", "initiator_id"),
+        Index("ix__action_requests__game_id", "game_id"),
+        Index("ix__action_requests__responder_id", "responder_id"),
     )
 
     def to_dto(self) -> dto.ActionRequest:

--- a/shvatka/infrastructure/db/models/event_log.py
+++ b/shvatka/infrastructure/db/models/event_log.py
@@ -89,6 +89,8 @@ class GameEvent(Base):
     __table_args__ = (
         Index("ix__event_log__game_id_team_id_at", "game_id", "team_id", "at"),
         Index("ix__event_log__level_time_id", "level_time_id"),
+        # team_id is second above, which a lookup on it alone cannot use
+        Index("ix__event_log__team_id", "team_id"),
     )
 
     def to_dto(self) -> dto.GameEvent:

--- a/shvatka/infrastructure/db/models/event_log.py
+++ b/shvatka/infrastructure/db/models/event_log.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from adaptix import Retort
-from sqlalchemy import Integer, ForeignKey, DateTime, func, TypeDecorator, Dialect
+from sqlalchemy import Integer, ForeignKey, DateTime, Index, func, TypeDecorator, Dialect
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import mapped_column, Mapped, relationship
 
@@ -84,6 +84,11 @@ class GameEvent(Base):
         "TimerAction",
         back_populates="event",
         foreign_keys="TimerAction.event_id",
+    )
+
+    __table_args__ = (
+        Index("ix__event_log__game_id_team_id_at", "game_id", "team_id", "at"),
+        Index("ix__event_log__level_time_id", "level_time_id"),
     )
 
     def to_dto(self) -> dto.GameEvent:

--- a/shvatka/infrastructure/db/models/file_info.py
+++ b/shvatka/infrastructure/db/models/file_info.py
@@ -30,7 +30,6 @@ class FileInfo(Base):
         # named explicitly: the existing index in the database uses a double
         # underscore, which the "ix" naming convention would not produce
         Index("ix__files_info__sha256", "sha256"),
-        Index("ix__files_info__author_id", "author_id"),
     )
 
     def to_dto(self, author: dto.Player) -> hints.SavedFileMeta:

--- a/shvatka/infrastructure/db/models/file_info.py
+++ b/shvatka/infrastructure/db/models/file_info.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, Text, ForeignKey
+from sqlalchemy import Index, Integer, Text, ForeignKey
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto
@@ -17,13 +17,20 @@ class FileInfo(Base):
     extension: Mapped[str] = mapped_column(Text)
     file_id = mapped_column(Text)
     content_type = mapped_column(Text)
-    sha256 = mapped_column(Text, index=True)
+    sha256 = mapped_column(Text)
     mime_type = mapped_column(Text)
     author_id = mapped_column(ForeignKey("players.id"), nullable=False)
     author = relationship(
         "Player",
         foreign_keys=author_id,
         back_populates="my_files",
+    )
+
+    __table_args__ = (
+        # named explicitly: the existing index in the database uses a double
+        # underscore, which the "ix" naming convention would not produce
+        Index("ix__files_info__sha256", "sha256"),
+        Index("ix__files_info__author_id", "author_id"),
     )
 
     def to_dto(self, author: dto.Player) -> hints.SavedFileMeta:

--- a/shvatka/infrastructure/db/models/file_info.py
+++ b/shvatka/infrastructure/db/models/file_info.py
@@ -30,6 +30,7 @@ class FileInfo(Base):
         # named explicitly: the existing index in the database uses a double
         # underscore, which the "ix" naming convention would not produce
         Index("ix__files_info__sha256", "sha256"),
+        Index("ix__files_info__author_id", "author_id"),
     )
 
     def to_dto(self, author: dto.Player) -> hints.SavedFileMeta:

--- a/shvatka/infrastructure/db/models/file_link.py
+++ b/shvatka/infrastructure/db/models/file_link.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Integer, UniqueConstraint
+from sqlalchemy import ForeignKey, Index, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from shvatka.infrastructure.db.models import Base
@@ -17,7 +17,10 @@ class LevelFile(Base):
     level_id: Mapped[int] = mapped_column(ForeignKey("levels.id"))
     file_id: Mapped[int] = mapped_column(ForeignKey("files_info.id"))
 
-    __table_args__ = (UniqueConstraint("level_id", "file_id"),)
+    __table_args__ = (
+        UniqueConstraint("level_id", "file_id"),
+        Index("ix__level_files__file_id", "file_id"),
+    )
 
 
 class GameFile(Base):
@@ -34,4 +37,7 @@ class GameFile(Base):
     game_id: Mapped[int] = mapped_column(ForeignKey("games.id"))
     file_id: Mapped[int] = mapped_column(ForeignKey("files_info.id"))
 
-    __table_args__ = (UniqueConstraint("game_id", "file_id"),)
+    __table_args__ = (
+        UniqueConstraint("game_id", "file_id"),
+        Index("ix__game_files__file_id", "file_id"),
+    )

--- a/shvatka/infrastructure/db/models/file_link.py
+++ b/shvatka/infrastructure/db/models/file_link.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Index, Integer, UniqueConstraint
+from sqlalchemy import ForeignKey, Integer, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from shvatka.infrastructure.db.models import Base
@@ -17,10 +17,7 @@ class LevelFile(Base):
     level_id: Mapped[int] = mapped_column(ForeignKey("levels.id"))
     file_id: Mapped[int] = mapped_column(ForeignKey("files_info.id"))
 
-    __table_args__ = (
-        UniqueConstraint("level_id", "file_id"),
-        Index("ix__level_files__file_id", "file_id"),
-    )
+    __table_args__ = (UniqueConstraint("level_id", "file_id"),)
 
 
 class GameFile(Base):
@@ -37,7 +34,4 @@ class GameFile(Base):
     game_id: Mapped[int] = mapped_column(ForeignKey("games.id"))
     file_id: Mapped[int] = mapped_column(ForeignKey("files_info.id"))
 
-    __table_args__ = (
-        UniqueConstraint("game_id", "file_id"),
-        Index("ix__game_files__file_id", "file_id"),
-    )
+    __table_args__ = (UniqueConstraint("game_id", "file_id"),)

--- a/shvatka/infrastructure/db/models/game.py
+++ b/shvatka/infrastructure/db/models/game.py
@@ -6,11 +6,13 @@ from datetime import datetime
 
 from sqlalchemy import (
     ForeignKey,
+    Index,
     Text,
     Enum,
     DateTime,
     UniqueConstraint,
     BigInteger,
+    text,
 )
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
@@ -74,7 +76,16 @@ class Game(Base):
     results_picture_file_id: Mapped[str | None] = mapped_column(nullable=True)
     keys_url: Mapped[str | None] = mapped_column(nullable=True)
 
-    __table_args__ = (UniqueConstraint("author_id", "name"),)
+    __table_args__ = (
+        UniqueConstraint("author_id", "name"),
+        # keep in step with ACTIVE_STATUSES: Postgres only uses a partial index
+        # for a query whose predicate this one implies
+        Index(
+            "ix__games__active_status",
+            "status",
+            postgresql_where=text("status IN ('getting_waivers', 'started', 'finished')"),
+        ),
+    )
 
     def to_dto(self, author: dto.Player) -> dto.Game:
         return dto.Game(

--- a/shvatka/infrastructure/db/models/level.py
+++ b/shvatka/infrastructure/db/models/level.py
@@ -3,7 +3,7 @@ import typing
 from typing import Any
 
 from adaptix import Retort
-from sqlalchemy import Integer, Text, ForeignKey, TypeDecorator, UniqueConstraint
+from sqlalchemy import Index, Integer, Text, ForeignKey, TypeDecorator, UniqueConstraint
 from sqlalchemy.engine import Dialect
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, mapped_column, Mapped
@@ -72,7 +72,10 @@ class Level(Base):
     number_in_game = mapped_column(Integer, nullable=True)
     scenario: Mapped[scn.LevelScenario] = mapped_column(ScenarioField)
 
-    __table_args__ = (UniqueConstraint("author_id", "name_id"),)
+    __table_args__ = (
+        UniqueConstraint("author_id", "name_id"),
+        Index("ix__levels__game_id_number_in_game", "game_id", "number_in_game"),
+    )
 
     def to_dto(self, author: dto.Player) -> dto.Level:
         return dto.Level(

--- a/shvatka/infrastructure/db/models/levels_times.py
+++ b/shvatka/infrastructure/db/models/levels_times.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, ForeignKey, DateTime, func
+from sqlalchemy import Integer, ForeignKey, DateTime, Index, func
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto
@@ -30,6 +30,13 @@ class LevelTime(Base):
         default=lambda: datetime.now(tz=tz_utc),
         server_default=func.now(),
         nullable=False,
+    )
+
+    __table_args__ = (
+        # serves both the current-level lookup (game + team, latest start_at) and
+        # the whole-game listing ordered by team_id, start_at
+        Index("ix__levels_times__game_id_team_id_start_at", "game_id", "team_id", "start_at"),
+        Index("ix__levels_times__team_id", "team_id"),
     )
 
     def to_dto(self, game: dto.Game, team: dto.Team) -> dto.LevelTime:

--- a/shvatka/infrastructure/db/models/log_keys.py
+++ b/shvatka/infrastructure/db/models/log_keys.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, ForeignKey, Text, Boolean, DateTime, func
+from sqlalchemy import Integer, ForeignKey, Index, Text, Boolean, DateTime, func
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto, enums
@@ -46,6 +46,16 @@ class KeyTime(Base):
     key_text = mapped_column(Text, nullable=False)
     type_: Mapped[enums.KeyType] = mapped_column("type", Text, nullable=False)
     is_duplicate: Mapped[bool] = mapped_column(Boolean, nullable=False)
+
+    __table_args__ = (
+        # all per-level key queries filter game_id + level_time_id + team_id, but
+        # level_time_id alone already narrows to a single team's single level
+        Index("ix__log_keys__level_time_id", "level_time_id"),
+        Index("ix__log_keys__game_id_enter_time", "game_id", "enter_time"),
+        Index("ix__log_keys__player_id", "player_id"),
+        Index("ix__log_keys__team_id", "team_id"),
+        Index("ix__log_keys__event_id", "event_id"),
+    )
 
     def to_dto(self, player: dto.Player, team: dto.Team) -> dto.KeyTime:
         return dto.KeyTime(

--- a/shvatka/infrastructure/db/models/notification.py
+++ b/shvatka/infrastructure/db/models/notification.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Text, func
+from sqlalchemy import BigInteger, DateTime, Enum, ForeignKey, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -36,6 +36,15 @@ class Notification(Base):
     read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix__notifications_recipient_created", "recipient_id", text("created_at DESC")),
+        Index(
+            "ix__notifications_unread", "recipient_id", postgresql_where=text("read_at IS NULL")
+        ),
+        Index("ix__notifications__actor_id", "actor_id"),
+        Index("ix__notifications__request_id", "request_id"),
     )
 
     def to_dto(self) -> dto.Notification:

--- a/shvatka/infrastructure/db/models/notification.py
+++ b/shvatka/infrastructure/db/models/notification.py
@@ -43,8 +43,6 @@ class Notification(Base):
         Index(
             "ix__notifications_unread", "recipient_id", postgresql_where=text("read_at IS NULL")
         ),
-        Index("ix__notifications__actor_id", "actor_id"),
-        Index("ix__notifications__request_id", "request_id"),
     )
 
     def to_dto(self) -> dto.Notification:

--- a/shvatka/infrastructure/db/models/notification.py
+++ b/shvatka/infrastructure/db/models/notification.py
@@ -43,6 +43,8 @@ class Notification(Base):
         Index(
             "ix__notifications_unread", "recipient_id", postgresql_where=text("read_at IS NULL")
         ),
+        Index("ix__notifications__actor_id", "actor_id"),
+        Index("ix__notifications__request_id", "request_id"),
     )
 
     def to_dto(self) -> dto.Notification:

--- a/shvatka/infrastructure/db/models/organizer.py
+++ b/shvatka/infrastructure/db/models/organizer.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, ForeignKey, Boolean, UniqueConstraint
+from sqlalchemy import Integer, ForeignKey, Boolean, Index, UniqueConstraint
 from sqlalchemy.orm import relationship, mapped_column
 
 from shvatka.core.models import dto
@@ -27,7 +27,10 @@ class Organizer(Base):
     view_scenario = mapped_column(Boolean, default=False, nullable=False)
     deleted = mapped_column(Boolean, default=False, nullable=False)
 
-    __table_args__ = (UniqueConstraint("player_id", "game_id"),)
+    __table_args__ = (
+        UniqueConstraint("player_id", "game_id"),
+        Index("ix__organizers__game_id", "game_id"),
+    )
 
     def to_dto(self, player: dto.Player, game: dto.Game) -> dto.SecondaryOrganizer:
         return dto.SecondaryOrganizer(

--- a/shvatka/infrastructure/db/models/player.py
+++ b/shvatka/infrastructure/db/models/player.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, ForeignKey, Boolean, Index, Text
+from sqlalchemy import BigInteger, ForeignKey, Boolean, Text
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto
@@ -78,8 +78,6 @@ class Player(Base):
         foreign_keys="Achievement.player_id",
         back_populates="player",
     )
-
-    __table_args__ = (Index("ix__players__promoted_by_id", "promoted_by_id"),)
 
     def __repr__(self) -> str:
         return f"<Player id={self.id} >"

--- a/shvatka/infrastructure/db/models/player.py
+++ b/shvatka/infrastructure/db/models/player.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, ForeignKey, Boolean, Text
+from sqlalchemy import BigInteger, ForeignKey, Boolean, Index, Text
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto
@@ -78,6 +78,8 @@ class Player(Base):
         foreign_keys="Achievement.player_id",
         back_populates="player",
     )
+
+    __table_args__ = (Index("ix__players__promoted_by_id", "promoted_by_id"),)
 
     def __repr__(self) -> str:
         return f"<Player id={self.id} >"

--- a/shvatka/infrastructure/db/models/push_subscription.py
+++ b/shvatka/infrastructure/db/models/push_subscription.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Text, func
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Index, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from shvatka.infrastructure.db.models.base import Base
@@ -26,3 +26,5 @@ class PushSubscription(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
+
+    __table_args__ = (Index("ix__push_subscriptions_player_id", "player_id"),)

--- a/shvatka/infrastructure/db/models/team.py
+++ b/shvatka/infrastructure/db/models/team.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, Index
 from sqlalchemy.orm import mapped_column, relationship, Mapped
 
 from shvatka.core.models import dto
@@ -51,6 +51,8 @@ class Team(Base):
         back_populates="team",
         foreign_keys="TeamPlayer.team_id",
     )
+
+    __table_args__ = (Index("ix__teams__captain_id", "captain_id"),)
 
     def to_dto(
         self,

--- a/shvatka/infrastructure/db/models/team.py
+++ b/shvatka/infrastructure/db/models/team.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Index
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import mapped_column, relationship, Mapped
 
 from shvatka.core.models import dto
@@ -51,8 +51,6 @@ class Team(Base):
         back_populates="team",
         foreign_keys="TeamPlayer.team_id",
     )
-
-    __table_args__ = (Index("ix__teams__captain_id", "captain_id"),)
 
     def to_dto(
         self,

--- a/shvatka/infrastructure/db/models/team_player.py
+++ b/shvatka/infrastructure/db/models/team_player.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, ForeignKey, DateTime, func
+from sqlalchemy import Integer, ForeignKey, DateTime, Index, func
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.core.models import dto
@@ -39,6 +39,11 @@ class TeamPlayer(Base):
     can_change_team_name: Mapped[bool] = mapped_column(default=False, nullable=False)
     can_add_players: Mapped[bool] = mapped_column(default=False, nullable=False)
     can_remove_players: Mapped[bool] = mapped_column(default=False, nullable=False)
+
+    __table_args__ = (
+        Index("ix__team_players__player_id", "player_id"),
+        Index("ix__team_players__team_id", "team_id"),
+    )
 
     def to_dto(self) -> dto.TeamPlayer:
         return dto.TeamPlayer(

--- a/shvatka/infrastructure/db/models/timer_actions.py
+++ b/shvatka/infrastructure/db/models/timer_actions.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import Integer, ForeignKey, DateTime, func
+from sqlalchemy import Integer, ForeignKey, DateTime, Index, func
 from sqlalchemy.orm import mapped_column, relationship, Mapped
 
 from shvatka.core.models import dto
@@ -23,6 +23,11 @@ class TimerAction(Base):
     event = relationship(
         "GameEvent",
         foreign_keys=event_id,
+    )
+
+    __table_args__ = (
+        Index("ix__timers_log__level_time_id", "level_time_id"),
+        Index("ix__timers_log__event_id", "event_id"),
     )
 
     def to_dto(self, event: dto.GameEvent) -> dto.Timer:

--- a/shvatka/infrastructure/db/models/waiver.py
+++ b/shvatka/infrastructure/db/models/waiver.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey, Enum, UniqueConstraint
+from sqlalchemy import ForeignKey, Enum, Index, UniqueConstraint
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 
 from shvatka.infrastructure.db.models import Base
@@ -9,7 +9,12 @@ from shvatka.core.models.enums.played import Played
 class Waiver(Base):
     __tablename__ = "waivers"
     __mapper_args__ = {"eager_defaults": True}
-    __table_args__ = (UniqueConstraint("game_id", "team_id", "player_id"),)
+    # the unique constraint leads with game_id, so player/team lookups need their own
+    __table_args__ = (
+        UniqueConstraint("game_id", "team_id", "player_id"),
+        Index("ix__waivers__player_id", "player_id"),
+        Index("ix__waivers__team_id", "team_id"),
+    )
     id: Mapped[int] = mapped_column(primary_key=True)
     player_id: Mapped[int] = mapped_column(ForeignKey("players.id"), nullable=False)
     player = relationship(

--- a/tests/integration/test_models_match_migrations.py
+++ b/tests/integration/test_models_match_migrations.py
@@ -1,0 +1,53 @@
+"""
+Test can find indexes that exist in one place only: created by a migration but
+never declared on the model, or declared on a model but never created by any
+migration. Both drift silently — the first makes `alembic revision --autogenerate`
+propose dropping an index the database really uses, the second means an index the
+code expects was never actually built.
+
+Does not require any maintenance - it compares whatever is there at the time.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+from dishka import AsyncContainer
+
+from shvatka.infrastructure.db.models import Base
+
+# Indexes backing a primary key or unique constraint are owned by that
+# constraint, not declared as Index() on the model, so they are not compared.
+STANDALONE_INDEXES = text(
+    """
+    SELECT i.indexname
+    FROM pg_indexes i
+    JOIN pg_class c ON c.relname = i.indexname
+    LEFT JOIN pg_constraint con ON con.conindid = c.oid
+    WHERE i.schemaname = current_schema()
+      AND con.oid IS NULL
+"""
+)
+
+
+@pytest.mark.asyncio
+async def test_indexes_match_models(dishka: AsyncContainer) -> None:
+    engine = await dishka.get(AsyncEngine)
+    async with engine.connect() as connection:
+        result = await connection.execute(STANDALONE_INDEXES)
+        in_db = {row[0] for row in result}
+
+    on_models = {
+        str(index.name)
+        for table in Base.metadata.sorted_tables
+        for index in table.indexes
+        if index.name is not None
+    }
+
+    assert not (in_db - on_models), (
+        "indexes exist in the database but are not declared on any model: "
+        f"{sorted(in_db - on_models)}"
+    )
+    assert not (on_models - in_db), (
+        "indexes are declared on models but no migration creates them: "
+        f"{sorted(on_models - in_db)}"
+    )


### PR DESCRIPTION
## Why

Postgres does not index foreign key columns automatically, and this schema had almost no non-unique indexes — only `files_info.sha256`, `push_subscriptions.player_id`, and the three added with `notifications`/`action_requests`. Everything else relied on primary keys and unique constraints.

Three migrations, kept separate because they rest on different arguments and can each be rolled back on their own.

---

## 1. `b4c6d2e0f8a7` — the game run cycle

Production `pg_stat_user_tables`, 519M sequential tuple reads total:

| table | seq_scan | seq_tup_read | share | cumulative | idx_scan |
|---|---|---|---|---|---|
| `log_keys` | 6032 | 415 797 595 | 80.10% | 80.10% | **0** |
| `levels_times` | 5230 | 47 448 529 | 9.14% | 89.24% | 671 |
| `team_players` | 20422 | 17 380 141 | 3.35% | 92.59% | 16 |
| `levels` | 8851 | 15 392 572 | 2.97% | **95.55%** | 2651 |
| …everything below `waivers` | | | **0.23% combined** | | |

`log_keys` has never once used an index, and at 68 931 rows per scan every one of those 6032 scans read the whole table.

**`log_keys`** (80% of the problem, five indexes on one table)
- `(level_time_id)` — `get_correct_typed_keys`, `get_team_typed_keys`, `get_team_inserted_keys` and `is_duplicate` all filter `game_id + level_time_id + team_id`. `level_time_id` averages 8.4 rows per value (69 216 keys / 8 274 level times), so it resolves all four alone and the other two predicates are redundant.
- `(game_id, enter_time)` — `get_typed_keys`, the whole-game key log, without a sort.
- `(player_id)` — `get_player_with_stat`; rendering one profile scanned the largest table.
- `(team_id)`, `(event_id)` — team merges and the `GameEvent.key` joinedload.

**`levels_times`** — `(game_id, team_id, start_at)` serves two shapes with one index: `_get_current` (equality on both leading columns, backward scan for the latest `start_at`) and `get_game_level_times` (equality on `game_id`, leaving `team_id, start_at` in exactly the requested order). Plus `(team_id)`.

**`levels`** — `(game_id, number_in_game)`. The unique constraint leads with `author_id`, so `game_id` was unindexed despite driving `Game.levels`, `add_levels`, `get_by_number` and `update_number_in_game`.

**`team_players`** — `(player_id)` resolves "which team is this player on", which runs on nearly every bot update and API request, and had 16 index scans against 20 422 sequential ones. Plus `(team_id)`.

**`waivers`** `(player_id)`, `(team_id)` — the unique constraint leads with `game_id`. **`event_log`** `(game_id, team_id, at)`, `(level_time_id)` and **`timers_log`** `(level_time_id)`, `(event_id)` — small today, but they grow with the event-sourcing model. **`organizers`** `(game_id)`.

Ends with `ANALYZE` on the five largest tables so the planner has fresh stats.

---

## 2. `c5d7e3f1a9b8` — the remaining foreign keys

These do nothing for read traffic. They are what a `DELETE` on a parent row needs: without them every such delete scans each referencing table in full to validate the constraint, which is why deleting or merging a player touches most of the schema. That cost is invisible in `pg_stat_user_tables` because deletes are rare, so it is a separate judgement from the numbers above — hence a separate revision.

Derived by walking every foreign key in the metadata rather than by hand, treating a column as covered only when some index has it **first** and is **not partial**. That found two cases a hand-written list had missed:

- **`event_log.team_id`** sits second in `(game_id, team_id, at)`, and Postgres cannot use a composite index for a lookup that does not constrain its leading column.
- **`action_requests.team_id`** is indexed only `WHERE status = 'pending'`, so the index does not cover rows in any other status.

All 44 foreign keys in the schema are covered after this revision.

---

## 3. `d6e8f4a2b1c9` — partial index for the active game

```sql
CREATE INDEX ix__games__active_status ON games (status)
    WHERE status IN ('getting_waivers', 'started', 'finished')
```

`get_active_game` backs `CurrentGameProvider`, the game services and the `/active` route, so it runs on nearly every request. Indexing only the three running statuses keeps the index to the few rows that are not yet complete, so it costs almost nothing to maintain — a game's status changes a handful of times in its whole life.

**This is the one index here whose benefit is not yet demonstrated.** `games` is 138 rows in about two pages, small enough that the planner may well keep choosing a sequential scan; whether it does depends on `random_page_cost`. It is its own revision precisely so it can be dropped without touching the other two if `EXPLAIN (ANALYZE, BUFFERS)` shows the scan winning.

The predicate has to stay in step with `ACTIVE_STATUSES`: Postgres only uses a partial index for a query whose predicate this one implies, so extending that tuple without a new migration would silently stop it covering the query. Note the drift test below compares index *names*, not definitions, so it would not catch that.

---

## Model/migration drift fixed along the way

Six indexes had drifted between the models and the migrations. Five existed only in migration files (`push_subscriptions.player_id`, both `notifications` composites, both `action_requests` ones), and `files_info.sha256` used `index=True`, which the `ix__%(column_0_label)s` convention renders with a *single* underscore while the migration created it with two. `alembic revision --autogenerate` would have proposed dropping all six.

An AST replay of the `upgrade()` path of all 44 revisions — covering `create_index`, `create_unique_constraint`, inline `sa.UniqueConstraint`, and the corresponding drops — confirmed there were no further cases beyond those six.

`tests/integration/test_models_match_migrations.py` now keeps it that way, comparing standalone indexes in the real database against `Index()` declarations on the models in both directions. Indexes backing a primary key or unique constraint are excluded, since those are owned by the constraint rather than declared on the model.

## Deliberately not here

`players.username` is looked up with `ILIKE` (no wildcard), which a plain btree cannot serve, and `_free_id_username` calls it in a loop up to 1000 times per registration. The `ilike '%text%'` searches would need `pg_trgm` GIN. Both are code changes rather than index additions, and at 0.57% of sequential reads neither is urgent.

Separately, an `--autogenerate` run against a database at head reported **no index or constraint operations at all**, but did surface five pre-existing column diffs that predate this branch and are left alone here: `action_requests.team_id` and `game_id` are `BigInteger` in the database against `Integer` on the model, `action_requests.bot_messages` is `JSON` against `JSONB`, `event_log.level_time_id` is `NOT NULL` against a nullable model, and `files_info.extension` is nullable against a model typed `Mapped[str]`. The last two are the ones worth a look, and both need data-affecting changes rather than index work.

## Notes

- Created without `CONCURRENTLY`, as agreed — a brief write lock on these tables is acceptable here.
- Worth re-running the `pg_stat_user_tables` query a few days after deploy; `log_keys.idx_scan` moving off zero is the signal it landed.

## Verification

- Models and migrations reconcile exactly in both directions, all 44 foreign keys report as covered, and `--autogenerate` against a database at head produces no index or constraint operations.
- Locally: `ruff format --check`, `ruff check`, `mypy` clean; `pytest tests/unit` 270 passed.
- CI green on the head commit, including `test_stairway.py` — every migration `upgrade → downgrade → upgrade` against real Postgres, so the downgrades are exercised too — and the drift test.