### PR TITLE
Build the test container from the app's own provider list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,29 @@ Rules for new work:
   separate `check_dao` (its own session) for reading back state — use it for
   assertions so you observe committed data, and keep `dao` for the action.
 
+### The test container is the app container plus overrides
+
+`tests/fixtures/di.py` builds the integration container from
+`get_root_app_providers(...)` — the very list `create_root_app` runs on — and
+only then adds the test doubles. Don't copy provider lists into tests: a new app
+provider must reach the tests without touching `tests/`.
+
+Test doubles live in `get_test_override_providers()` and go **last**: dishka
+rejects `override=True` for something nobody provided yet.
+
+- Replacing an app dependency → `@provide(override=True)` **in the same scope**
+  as the factory being replaced. A different scope leaves the original factory
+  alive in its own registry and it wins there — the override silently does
+  nothing.
+- A double that's only passed to services by hand (`GameLogWriterMock`,
+  `MemoryFileStorage`) is provided under its own concrete type, without
+  `override=True`, so container-resolved code keeps using the real
+  implementation.
+- The container is built with `STRICT_VALIDATION`, so an override that overrides
+  nothing (or a shadowed factory) fails the build instead of quietly changing
+  behavior. `tests/unit/test_di.py` builds every container (api, bot, root,
+  tests) and is the fast check that DI still holds together.
+
 Run locally:
 
 ```shell

--- a/shvatka/infrastructure/di/__init__.py
+++ b/shvatka/infrastructure/di/__init__.py
@@ -1,4 +1,4 @@
-from shvatka.common.factory import UrlProvider
+from shvatka.common.factory import DCFProvider, UrlProvider
 from shvatka.infrastructure.di.bot import BotProvider
 from shvatka.infrastructure.di.config import ConfigProvider, DbConfigProvider
 from shvatka.infrastructure.di.db import DbProvider, RedisProvider, DAOProvider
@@ -23,6 +23,7 @@ def get_providers(paths_env):
         DbConfigProvider(),
         DbProvider(),
         UrlProvider(),
+        DCFProvider(),
         DAOProvider(),
         RedisProvider(),
         FileClientProvider(),

--- a/shvatka/main_factory.py
+++ b/shvatka/main_factory.py
@@ -98,6 +98,15 @@ def get_complex_only_providers() -> list[Provider]:
     ]
 
 
+def get_root_app_providers(paths_env: str) -> list[Provider]:
+    return [
+        *get_providers(paths_env),
+        *get_bot_specific_providers(),
+        *get_api_specific_providers(),
+        *get_complex_only_providers(),
+    ]
+
+
 def create_root_app(paths: Paths) -> FastAPI:
     started_at = time.monotonic()
     api_config = load_api_config(paths)
@@ -108,10 +117,7 @@ def create_root_app(paths: Paths) -> FastAPI:
 
     app = create_app(api_config)
     dishka = make_async_container(
-        *get_providers("SHVATKA_PATH"),
-        *get_bot_specific_providers(),
-        *get_api_specific_providers(),
-        *get_complex_only_providers(),
+        *get_root_app_providers("SHVATKA_PATH"),
         validation_settings=STRICT_VALIDATION,
     )
     setup_application(app, dishka)

--- a/shvatka/tgbot/main_factory.py
+++ b/shvatka/tgbot/main_factory.py
@@ -23,7 +23,7 @@ from dishka.integrations.aiogram import setup_dishka, AiogramMiddlewareData
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from shvatka.common.factory import TelegraphProvider, DCFProvider
+from shvatka.common.factory import TelegraphProvider
 from shvatka.core.interfaces.clients.file_storage import FileStorage
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.views.game import GameLogWriter, GameView, GameViewPreparer, OrgNotifier
@@ -79,7 +79,6 @@ def get_bot_specific_providers() -> list[Provider]:
         DpProvider(),
         DialogManagerProvider(),
         TelegraphProvider(),
-        DCFProvider(),
         GameToolsProvider(),
         UserGetterProvider(),
         BotIdpProvider(),

--- a/tests/fixtures/db_provider.py
+++ b/tests/fixtures/db_provider.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class TestDbProvider(Provider):
     scope = Scope.APP
 
-    @provide
+    @provide(override=True)
     def get_db_config(self, config: Config) -> Iterable[TrueConfig]:
         if url := os.getenv("SHVATKA_TEST_DB_URL"):
             db_config = DBConfig(url)
@@ -44,7 +44,7 @@ class TestDbProvider(Provider):
         finally:
             postgres.stop()
 
-    @provide
+    @provide(override=True)
     def get_redis_config(self, config: Config) -> Iterable[RedisConfig]:
         if port := os.getenv("SHVATKA_TEST_REDIS_PORT"):
             yield RedisConfig(url="localhost", port=int(port))
@@ -61,7 +61,7 @@ class TestDbProvider(Provider):
         finally:
             redis_container.stop()
 
-    @provide(scope=Scope.REQUEST)
+    @provide(scope=Scope.REQUEST, override=True)
     async def get_dao(
         self,
         session: AsyncSession,

--- a/tests/fixtures/di.py
+++ b/tests/fixtures/di.py
@@ -1,0 +1,36 @@
+from dishka import Provider
+
+from shvatka.main_factory import get_root_app_providers
+from tests.fixtures.db_provider import TestDbProvider
+from tests.fixtures.file_storage import MemoryFileStorageProvider
+from tests.mocks.bot import MockBotProvider, MockMessageManagerProvider
+from tests.mocks.di import MocksProvider
+
+TEST_PATHS_ENV = "SHVATKA_TEST_PATH"
+
+
+def get_test_providers() -> list[Provider]:
+    """The very same providers as the real app has, with test doubles on top.
+
+    Everything the app can provide must stay providable in tests, so the list
+    is not copied here — it is reused as is and only what tests can't afford
+    (real db, real telegram, real scheduler) is overridden afterwards.
+    """
+    return [
+        *get_root_app_providers(TEST_PATHS_ENV),
+        *get_test_override_providers(),
+    ]
+
+
+def get_test_override_providers() -> list[Provider]:
+    """Test doubles. Each one overrides (``override=True``) an app dependency.
+
+    Must go last: dishka forbids overriding what wasn't provided before.
+    """
+    return [
+        TestDbProvider(),
+        MemoryFileStorageProvider(),
+        MockBotProvider(),
+        MockMessageManagerProvider(),
+        MocksProvider(),
+    ]

--- a/tests/fixtures/file_storage.py
+++ b/tests/fixtures/file_storage.py
@@ -1,6 +1,5 @@
 from dishka import Provider, Scope, provide
 
-from shvatka.core.interfaces.clients.file_storage import FileStorage
 from shvatka.core.models import enums
 from shvatka.core.models.dto import hints
 from tests.fixtures.scn_fixtures import GUID
@@ -19,8 +18,11 @@ FILE_META = hints.FileMeta(
 
 
 class MemoryFileStorageProvider(Provider):
+    """Not an override: the app's local storage stays for container-resolved
+    code (it's the one tested against a real dir), the in-memory one is for
+    services called by hand.
+    """
+
     scope = Scope.APP
 
-    @provide
-    def get_file_storage(self) -> FileStorage:
-        return MemoryFileStorage()
+    memory_storage = provide(MemoryFileStorage)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,102 +9,31 @@ from aiogram.client.session.base import BaseSession
 from aiogram_dialog.api.protocols import MessageManagerProtocol
 from alembic.command import upgrade
 from alembic.config import Config as AlembicConfig
-from dishka import make_async_container, AsyncContainer, Provider, Scope
+from dishka import make_async_container, AsyncContainer, STRICT_VALIDATION
 from telegraph.aio import Telegraph
 
-from shvatka.api.app.dependencies import (
-    AuthProvider,
-    AdminInteractorProvider,
-    ApiConfigProvider,
-    OtherApiProvider,
-)
 from shvatka.common import Paths
-from shvatka.common.factory import DCFProvider, TelegraphProvider, UrlProvider
-from shvatka.core.interfaces.clients.file_storage import FileStorage, FileGateway
+from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
-from shvatka.core.views.game import GameLogWriter
 from shvatka.infrastructure.db.config.models.db import DBConfig
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.infrastructure.db.dao.memory.level_testing import LevelTestingData
-from shvatka.infrastructure.di import (
-    ConfigProvider,
-    DbProvider,
-    RedisProvider,
-    FileClientProvider,
-    GamePlayProvider,
-    PrinterProvider,
-    WaiverProvider,
-    ContextProvider,
-    DAOProvider,
-    PlayerProvider,
-    TeamProvider,
-    MailProvider,
-    EmailInteractorProvider,
-    NotificationProvider,
-    RequestProvider,
-    SearchProvider,
-)
-from shvatka.infrastructure.di.interactors import GameEditProvider
-from shvatka.main_factory import ComplexOnlyProvider
-from shvatka.tgbot.main_factory import DpProvider, GameToolsProvider, BotIdpProvider
-from shvatka.infrastructure.db.factory import LockProvider
 from shvatka.tgbot.username_resolver.user_getter import UserGetter
 from shvatka.tgbot.views.hint_factory.hint_parser import HintParser
-from tests.fixtures.db_provider import TestDbProvider
-from tests.fixtures.file_storage import MemoryFileStorageProvider
-from tests.mocks.bot import MockMessageManagerProvider, MockBotProvider
+from tests.fixtures.di import get_test_providers
 from tests.mocks.datetime_mock import ClockMock
 from tests.mocks.file_storage import MemoryFileStorage
 from tests.mocks.game_log import GameLogWriterMock
-from tests.mocks.scheduler_mock import SchedulerMock
-from tests.mocks.user_getter import UserGetterMock
 
 logger = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(scope="session")
 async def dishka():
-    mock_provider = Provider(scope=Scope.APP)
-    mock_provider.provide(GameLogWriterMock, provides=GameLogWriter)
-    mock_provider.provide(UserGetterMock, provides=UserGetter)
-    mock_provider.provide(SchedulerMock, provides=Scheduler)
-    mock_provider.provide(ClockMock)
     container = make_async_container(
-        ConfigProvider("SHVATKA_TEST_PATH"),
-        DAOProvider(),
-        OtherApiProvider(),
-        ApiConfigProvider(),
-        DbProvider(),
-        RedisProvider(),
-        FileClientProvider(),
-        AuthProvider(),
-        AdminInteractorProvider(),
-        MemoryFileStorageProvider(),
-        DpProvider(),
-        MockBotProvider(),
-        MockMessageManagerProvider(),
-        LockProvider(),
-        DCFProvider(),
-        UrlProvider(),
-        TelegraphProvider(),
-        ContextProvider(),
-        GamePlayProvider(),
-        GameEditProvider(),
-        WaiverProvider(),
-        PlayerProvider(),
-        TeamProvider(),
-        NotificationProvider(),
-        RequestProvider(),
-        MailProvider(),
-        EmailInteractorProvider(),
-        PrinterProvider(),
-        GameToolsProvider(),
-        BotIdpProvider(),
-        ComplexOnlyProvider(),
-        TestDbProvider(),
-        SearchProvider(),
-        mock_provider,
+        *get_test_providers(),
+        validation_settings=STRICT_VALIDATION,
     )
     yield container
     await container.close()
@@ -210,14 +139,14 @@ def upgrade_schema_db(alembic_config: AlembicConfig):
 
 
 @pytest_asyncio.fixture(scope="session")
-async def file_storage(dishka: AsyncContainer) -> FileStorage:
-    return await dishka.get(FileStorage)
+async def file_storage(dishka: AsyncContainer) -> MemoryFileStorage:
+    return await dishka.get(MemoryFileStorage)
 
 
 @pytest.fixture
 def hint_parser(
     dao: HolderDao,
-    file_storage: FileStorage,
+    file_storage: MemoryFileStorage,
     bot: Bot,
 ) -> HintParser:
     return HintParser(dao=dao.file_info, file_storage=file_storage, bot=bot)
@@ -229,13 +158,18 @@ async def file_gateway(dishka_request: AsyncContainer) -> FileGateway:
 
 
 @pytest_asyncio.fixture
-async def game_log(dishka: AsyncContainer) -> GameLogWriter:
-    return await dishka.get(GameLogWriter)
+async def game_log(dishka: AsyncContainer) -> GameLogWriterMock:
+    return await dishka.get(GameLogWriterMock)
 
 
 @pytest.fixture(autouse=True)
 def clean_up_memory(file_storage: MemoryFileStorage):
     file_storage.storage.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_up_game_log(game_log: GameLogWriterMock):
+    game_log.requests.clear()
 
 
 @pytest_asyncio.fixture

--- a/tests/mocks/bot.py
+++ b/tests/mocks/bot.py
@@ -15,7 +15,7 @@ from shvatka.tgbot.views.jinja_filters import setup_jinja
 class MockMessageManagerProvider(Provider):
     scope = Scope.APP
 
-    @provide
+    @provide(override=True)
     def get_manager(self) -> MessageManagerProtocol:
         return MockMessageManager()
 
@@ -28,12 +28,12 @@ class MockBotProvider(Provider):
         session = mock.AsyncMock(BaseSession)
         return session
 
-    @provide
+    @provide(override=True)
     async def get_bot(self, config: TgBotConfig, session: BaseSession) -> Bot:
         bot = Bot(token=config.bot.token, session=session)
         setup_jinja(bot)
         return bot
 
-    @provide
+    @provide(override=True)
     async def bot_alert(self, bot: Bot, config: BotConfig) -> BotAlert:
         return BotAlert(bot, config.log_chat)

--- a/tests/mocks/di.py
+++ b/tests/mocks/di.py
@@ -1,0 +1,31 @@
+from dishka import Provider, Scope, provide
+
+from shvatka.core.interfaces.scheduler import LevelTestScheduler, Scheduler
+from shvatka.tgbot.username_resolver.user_getter import UserGetter
+from tests.mocks.datetime_mock import ClockMock
+from tests.mocks.game_log import GameLogWriterMock
+from tests.mocks.scheduler_mock import LevelSchedulerMock, SchedulerMock
+from tests.mocks.user_getter import UserGetterMock
+
+
+class MocksProvider(Provider):
+    """Replaces everything talking to the outer world with in-memory mocks."""
+
+    scope = Scope.APP
+
+    clock = provide(ClockMock)
+    # not an override: the app's own (complex) writer stays in place for
+    # container-resolved code, the mock is for services called by hand
+    game_log = provide(GameLogWriterMock)
+
+    @provide(override=True)
+    def user_getter(self) -> UserGetter:
+        return UserGetterMock()
+
+    @provide(override=True)
+    def scheduler(self) -> Scheduler:
+        return SchedulerMock()
+
+    @provide(override=True)
+    def level_test_scheduler(self) -> LevelTestScheduler:
+        return LevelSchedulerMock()

--- a/tests/mocks/scheduler_mock.py
+++ b/tests/mocks/scheduler_mock.py
@@ -65,3 +65,9 @@ class SchedulerMock(Scheduler):
         self, team: dto.Team, lt_id: int, effects: action.Effects, run_at: datetime
     ):
         pass
+
+    async def start(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/tests/unit/test_di.py
+++ b/tests/unit/test_di.py
@@ -1,0 +1,23 @@
+from typing import Callable
+
+import pytest
+from dishka import STRICT_VALIDATION, Provider, make_async_container
+
+from shvatka.api.app.dependencies import get_api_providers
+from shvatka.main_factory import get_root_app_providers
+from shvatka.tgbot.main_factory import get_bot_providers
+from tests.fixtures.di import get_test_providers
+
+
+@pytest.mark.parametrize(
+    "providers_factory",
+    [
+        pytest.param(lambda: get_api_providers("SHVATKA_PATH"), id="api"),
+        pytest.param(lambda: get_bot_providers("SHVATKA_PATH"), id="bot"),
+        pytest.param(lambda: get_root_app_providers("SHVATKA_PATH"), id="root"),
+        pytest.param(get_test_providers, id="tests"),
+    ],
+)
+def test_container_can_be_built(providers_factory: Callable[[], list[Provider]]):
+    """Every dependency is resolvable and every test double really overrides one."""
+    make_async_container(*providers_factory(), validation_settings=STRICT_VALIDATION)


### PR DESCRIPTION
Closes #181.

## What

`tests/integration/conftest.py` kept a hand-written copy of the dishka provider list, and it had drifted from the app: no `BotProvider`, no `SchedulerProvider`, no `DbConfigProvider`, no `DialogManagerProvider`/`UserGetterProvider`. Some doubles also only shadowed a dependency in one scope while the real factory still won in another (`GameLogWriter` was the mock at APP scope, but container-resolved code at REQUEST scope got `ComplexGameLogWriter`) — nothing warned about it.

Now:

- `tests/fixtures/di.py` builds the container from `get_root_app_providers(...)` — the same list `create_root_app` runs on — and appends the test doubles.
- Test doubles carry `override=True`, and the container is built with `STRICT_VALIDATION`, so a double that overrides nothing, or is registered in a scope where it can't win, fails the build instead of quietly doing nothing.
- `shvatka/main_factory.py` gets `get_root_app_providers(paths_env)`, so the app list lives in exactly one place.

Overridden (testcontainers / mocks / stubs): db + redis config and `HolderDao` (`TestDbProvider`), `Bot`/`BaseSession`/`BotAlert`, `MessageManagerProtocol`, `Scheduler` + `LevelTestScheduler`, `UserGetter`.

Not overridden, deliberately: `MemoryFileStorage` and `GameLogWriterMock` are provided under their own concrete types. They are the doubles tests pass to services by hand; container-resolved code keeps the real implementations, exactly as before — `test_game_file_missing_on_disk_not_cached` and `test_my_game_full` depend on the request-scoped `LocalFileStorage` being real.

## Drive-by fix

The standalone API app could not start: `get_api_providers()` had no `Retort` provider, so `make_async_container` failed graph validation at startup. `DCFProvider` moves from the bot-specific list to the shared `get_providers()`, which fixes the API app and keeps every container providing it exactly once.

## Tests

`tests/unit/test_di.py` builds all four containers (api, bot, root, tests) with `STRICT_VALIDATION` — a fast, docker-free check that the provider lists and the overrides stay consistent.

Full suite run locally against a real Postgres + Redis (`SHVATKA_TEST_DB_URL` / `SHVATKA_TEST_REDIS_PORT`): 570 passed. `ruff format --check`, `ruff check` and `mypy` are clean.

## Docs

AGENTS.md gets the convention: reuse the app's provider list, put doubles last, `override=True` in the same scope as the factory being replaced.

---
_Generated by [Claude Code](https://claude.ai/code/session_013dQ1bum4B2FS8pgKsrsxTw)_