### PR TITLE
Shrink SHMiddlewareData to what handlers really read

### DIFF
--- a/shvatka/tgbot/dialogs/game_manage/getters.py
+++ b/shvatka/tgbot/dialogs/game_manage/getters.py
@@ -9,7 +9,7 @@ from aiogram_dialog.api.entities import MediaAttachment, MediaId
 from dishka import AsyncContainer, FromDishka
 from dishka.integrations.aiogram import CONTAINER_NAME
 from dishka.integrations.aiogram_dialog import inject
-from telegraph import Telegraph
+from telegraph.aio import Telegraph
 
 from shvatka.common.url_factory import UrlFactory
 from shvatka.core.interfaces.identity import IdentityProvider
@@ -67,7 +67,7 @@ async def get_game_waivers(dao: HolderDao, dialog_manager: DialogManager, **_):
 async def get_game_keys(
     dao: HolderDao,
     dialog_manager: DialogManager,
-    telegraph: Telegraph,
+    telegraph: FromDishka[Telegraph],
     identity: FromDishka[IdentityProvider],
     **_,
 ):
@@ -90,7 +90,7 @@ async def get_game_results(
     dialog_manager: DialogManager,
     dao: HolderDao,
     identity: FromDishka[IdentityProvider],
-    results_painter: ResultsPainter,
+    results_painter: FromDishka[ResultsPainter],
     **_,
 ):
     data: dict[str, Any] = dialog_manager.start_data  # type: ignore[assignment]

--- a/shvatka/tgbot/dialogs/game_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/game_manage/handlers.py
@@ -82,10 +82,11 @@ async def show_zip_scn(
     widget: Button,
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
+    file_gateway: FromDishka[FileGateway],
 ):
     await c.answer()
     game_id = manager.dialog_data["game_id"]
-    await common_show_zip(c, game_id, manager, identity)
+    await common_show_zip(c, game_id, manager, identity, file_gateway)
 
 
 @inject
@@ -94,10 +95,11 @@ async def show_my_zip_scn(
     widget: Button,
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
+    file_gateway: FromDishka[FileGateway],
 ):
     await c.answer()
     game_id = manager.dialog_data["my_game_id"]
-    await common_show_zip(c, game_id, manager, identity)
+    await common_show_zip(c, game_id, manager, identity, file_gateway)
 
 
 @inject
@@ -156,11 +158,14 @@ async def show_transitions(
 
 
 async def common_show_zip(
-    c: CallbackQuery, game_id: int, manager: DialogManager, identity: IdentityProvider
+    c: CallbackQuery,
+    game_id: int,
+    manager: DialogManager,
+    identity: IdentityProvider,
+    file_gateway: FileGateway,
 ):
     dao: HolderDao = manager.middleware_data["dao"]
     retort: Retort = manager.middleware_data["retort"]
-    file_gateway: FileGateway = manager.middleware_data["file_gateway"]
     game_ = await game.get_game_package(game_id, identity, dao.game_packager, retort, file_gateway)
     zip_ = pack_scn(game_)
     assert isinstance(c.message, Message)

--- a/shvatka/tgbot/dialogs/game_scn/handlers.py
+++ b/shvatka/tgbot/dialogs/game_scn/handlers.py
@@ -55,11 +55,16 @@ async def process_name(m: Message, dialog_: Any, manager: DialogManager):
     await manager.next()
 
 
-async def process_zip_scn(m: Message, dialog_: Any, manager: DialogManager):
+@inject
+async def process_zip_scn(
+    m: Message,
+    dialog_: Any,
+    manager: DialogManager,
+    file_gateway: FromDishka[FileGateway],
+) -> None:
     player: dto.Player = manager.middleware_data["player"]
     dao: HolderDao = manager.middleware_data["dao"]
     bot: Bot = manager.middleware_data["bot"]
-    file_gateway: FileGateway = manager.middleware_data["file_gateway"]
     retort: Retort = manager.middleware_data["retort"]
     assert m.document
     document: IO[bytes] = await bot.download(m.document.file_id)  # type: ignore[assignment]

--- a/shvatka/tgbot/dialogs/level_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/level_manage/handlers.py
@@ -74,9 +74,15 @@ async def send_to_testing(c: CallbackQuery, widget: Any, manager: DialogManager,
     await c.answer("Приглашение отправлено")
 
 
-async def level_testing(c: CallbackQuery, button: Button, manager: DialogManager):
+@inject
+async def level_testing(
+    c: CallbackQuery,
+    button: Button,
+    manager: DialogManager,
+    scheduler: FromDishka[LevelTestScheduler],
+    view: FromDishka[LevelView],
+) -> None:
     await c.answer()
-    scheduler: LevelTestScheduler = manager.middleware_data["scheduler"]
     dao: HolderDao = manager.middleware_data["dao"]
     data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
     level_id = data["level_id"]
@@ -88,7 +94,6 @@ async def level_testing(c: CallbackQuery, button: Button, manager: DialogManager
         await manager.done()
         return
     suite = dto.LevelTestSuite(tester=org, level=level)
-    view: LevelView = manager.middleware_data["level_view"]
     await manager.start(state=states.LevelTestSG.wait_key, data={"level_id": level_id})
     await start_level_test(
         suite=suite, scheduler=scheduler, view=view, dao=dao.level_testing_complex

--- a/shvatka/tgbot/dialogs/starters/organizer.py
+++ b/shvatka/tgbot/dialogs/starters/organizer.py
@@ -1,6 +1,8 @@
 from aiogram import Router
 from aiogram.types import CallbackQuery
 from aiogram_dialog import DialogManager
+from dishka import FromDishka
+from dishka.integrations.aiogram import inject
 
 from shvatka.core.interfaces.scheduler import LevelTestScheduler
 from shvatka.core.models import dto
@@ -15,14 +17,15 @@ from shvatka.tgbot import states
 from shvatka.tgbot.utils.router import disable_router_on_game
 
 
+@inject
 async def start_test_level(
     c: CallbackQuery,
     player: dto.Player,
     callback_data: kb.LevelTestInviteCD,
     dao: HolderDao,
     dialog_manager: DialogManager,
-    scheduler: LevelTestScheduler,
-    level_view: LevelView,
+    scheduler: FromDishka[LevelTestScheduler],
+    level_view: FromDishka[LevelView],
 ):
     await c.answer()
     org = await get_org_by_id(callback_data.org_id, dao.organizer)

--- a/shvatka/tgbot/handlers/admin.py
+++ b/shvatka/tgbot/handlers/admin.py
@@ -13,10 +13,11 @@ from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.views.commands import MERGE_TEAMS, MERGE_PLAYERS
 
 
+@inject
 async def merge_teams_command(
     message: types.Message,
     command: CommandObject,
-    game_log: GameLogWriter,
+    game_log: FromDishka[GameLogWriter],
     dao: HolderDao,
 ):
     if not command.args:

--- a/shvatka/tgbot/handlers/game/add_organizer.py
+++ b/shvatka/tgbot/handlers/game/add_organizer.py
@@ -83,7 +83,7 @@ async def agree_to_be_org_handler(
     dao: FromDishka[HolderDao],
     bot: FromDishka[Bot],
     org_notifier: FromDishka[OrgNotifier],
-    bg_manager_factory: BgManagerFactory,
+    bg_manager_factory: FromDishka[BgManagerFactory],
 ):
     await c.answer()
     try:

--- a/shvatka/tgbot/handlers/merge.py
+++ b/shvatka/tgbot/handlers/merge.py
@@ -3,6 +3,7 @@ from functools import partial
 from aiogram import Router, Bot
 from aiogram.types import CallbackQuery, Message
 from aiogram_dialog.api.protocols import BgManagerFactory
+from dishka.integrations.aiogram import FromDishka, inject
 
 from shvatka.core.players.player import get_player_by_id, merge_players
 from shvatka.core.services.team import get_team_by_id, merge_teams
@@ -17,12 +18,13 @@ async def confirm_merge_not_superuser(callback_query: CallbackQuery):
     await callback_query.answer("Недостаточно прав, сорян", cache_time=3600)
 
 
+@inject
 async def confirm_merge_team(
     callback_query: CallbackQuery,
     callback_data: kb.TeamMergeCD,
     dao: HolderDao,
-    game_log: GameLogWriter,
-    bg_manager_factory: BgManagerFactory,
+    game_log: FromDishka[GameLogWriter],
+    bg_manager_factory: FromDishka[BgManagerFactory],
     bot: Bot,
 ):
     primary = await get_team_by_id(callback_data.primary_team_id, dao.team)
@@ -37,12 +39,13 @@ async def confirm_merge_team(
     await bg.update({})
 
 
+@inject
 async def confirm_merge_players(
     callback_query: CallbackQuery,
     callback_data: kb.PlayerMergeCD,
     dao: HolderDao,
-    game_log: GameLogWriter,
-    bg_manager_factory: BgManagerFactory,
+    game_log: FromDishka[GameLogWriter],
+    bg_manager_factory: FromDishka[BgManagerFactory],
     bot: Bot,
 ):
     primary = await get_player_by_id(callback_data.primary_player_id, dao.player)

--- a/shvatka/tgbot/handlers/player.py
+++ b/shvatka/tgbot/handlers/player.py
@@ -89,13 +89,14 @@ async def dismiss_promotion_handler(
     )
 
 
+@inject
 async def agree_promotion_handler(
     c: CallbackQuery,
     callback_data: kb.AgreePromotionCD,
     player: dto.Player,
     dao: HolderDao,
     bot: Bot,
-    bg_manager_factory: BgManagerFactory,
+    bg_manager_factory: FromDishka[BgManagerFactory],
 ):
     await c.answer()
     try:

--- a/shvatka/tgbot/handlers/team/manage.py
+++ b/shvatka/tgbot/handlers/team/manage.py
@@ -55,6 +55,7 @@ from shvatka.tgbot.views.user import render_small_card_link
 logger = logging.getLogger(__name__)
 
 
+@inject
 async def cmd_create_team(
     message: Message,
     chat: dto.Chat,
@@ -62,7 +63,7 @@ async def cmd_create_team(
     user: dto.User,
     dao: HolderDao,
     bot: Bot,
-    game_log: GameLogWriter,
+    game_log: FromDishka[GameLogWriter],
 ):
     logger.info("Player %s try create team in %s", player.id, chat.tg_id)
     if not await is_admin_filter(bot, chat, user):

--- a/shvatka/tgbot/main_factory.py
+++ b/shvatka/tgbot/main_factory.py
@@ -131,10 +131,7 @@ class DpProvider(Provider):
         bg_manager_factory = setup_handlers(dp, config, message_manager)
         self.bg_manager_factory = bg_manager_factory  # type: ignore[assignment]
         setup_dishka(container=dishka, router=dp)
-        setup_middlewares(
-            dp=dp,
-            bg_manager_factory=bg_manager_factory,
-        )
+        setup_middlewares(dp=dp)
         logger.info("Configured bot routers \n%s", print_router_tree(dp))
         return dp
 

--- a/shvatka/tgbot/middlewares/__init__.py
+++ b/shvatka/tgbot/middlewares/__init__.py
@@ -1,6 +1,4 @@
 from aiogram import Dispatcher
-from aiogram_dialog.api.protocols import BgManagerFactory
-from dishka import AsyncContainer
 
 
 from .bot_rights_middleware import BotRightsMiddleware
@@ -10,11 +8,8 @@ from .init_middleware import InitMiddleware
 from .load_team_player import TeamPlayerMiddleware
 
 
-def setup_middlewares(
-    dp: Dispatcher,
-    bg_manager_factory: BgManagerFactory,
-):
-    dp.update.middleware(InitMiddleware(bg_manager_factory=bg_manager_factory))
+def setup_middlewares(dp: Dispatcher):
+    dp.update.middleware(InitMiddleware())
     dp.update.middleware(LoadDataMiddleware())
     dp.message.middleware(FixTargetMiddleware())
     dp.my_chat_member.outer_middleware(BotRightsMiddleware())

--- a/shvatka/tgbot/middlewares/fix_target_middleware.py
+++ b/shvatka/tgbot/middlewares/fix_target_middleware.py
@@ -2,10 +2,12 @@ from typing import Callable, Any, Awaitable
 
 from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
+from dishka.integrations.aiogram import CONTAINER_NAME
 
 from shvatka.core.players.player import upsert_player
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.username_resolver.find_target_user import get_db_user_by_tg_user
+from shvatka.tgbot.username_resolver.user_getter import UserGetter
 
 
 class FixTargetMiddleware(BaseMiddleware):
@@ -17,6 +19,7 @@ class FixTargetMiddleware(BaseMiddleware):
     ) -> Any:
         if target := data.get("target"):
             dao: HolderDao = data["dao"]
-            target = await get_db_user_by_tg_user(target, data["user_getter"], dao)
+            user_getter = await data[CONTAINER_NAME].get(UserGetter)
+            target = await get_db_user_by_tg_user(target, user_getter, dao)
             data["target"] = await upsert_player(target, dao.player)
         return await handler(event, data)

--- a/shvatka/tgbot/middlewares/init_middleware.py
+++ b/shvatka/tgbot/middlewares/init_middleware.py
@@ -3,30 +3,17 @@ from typing import Callable, Any, Awaitable
 from adaptix import Retort
 from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
-from aiogram_dialog.api.protocols import BgManagerFactory
 
-from shvatka.core.interfaces.clients.file_storage import FileStorage, FileGateway
-from shvatka.core.interfaces.scheduler import Scheduler
-from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
-from shvatka.core.views.game import GameLogWriter
-from shvatka.core.views.level import LevelView
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.infrastructure.picture.results_painter import ResultsPainter
-from shvatka.tgbot.config.models.bot import BotConfig
-from shvatka.tgbot.config.models.main import TgBotConfig
-from shvatka.tgbot.username_resolver.user_getter import UserGetter
 from shvatka.tgbot.utils.data import SHMiddlewareData
-from shvatka.tgbot.views.hint_factory.hint_parser import HintParser
-from shvatka.tgbot.views.hint_sender import HintSender
-from shvatka.tgbot.views.telegraph import Telegraph
 
 
 class InitMiddleware(BaseMiddleware):
-    def __init__(
-        self,
-        bg_manager_factory: BgManagerFactory,
-    ) -> None:
-        self.bg_manager_factory = bg_manager_factory
+    """
+    Puts into middleware data only what handlers ask for by name too often to
+    be worth an explicit ``FromDishka``. Everything else is resolved lazily by
+    the handler that needs it, so an update doesn't pay for objects it ignores.
+    """
 
     async def __call__(  # type: ignore[override]
         self,
@@ -35,22 +22,7 @@ class InitMiddleware(BaseMiddleware):
         data: SHMiddlewareData,
     ) -> Any:
         dishka = data["dishka_container"]
-        file_storage = await dishka.get(FileStorage)
-        data["config"] = await dishka.get(BotConfig)
-        data["main_config"] = await dishka.get(TgBotConfig)
-        data["user_getter"] = await dishka.get(UserGetter)
-        data["retort"] = await dishka.get(Retort)
-        data["scheduler"] = await dishka.get(Scheduler)
-        data["locker"] = await dishka.get(KeyCheckerFactory)
-        data["file_storage"] = file_storage
-        data["telegraph"] = await dishka.get(Telegraph)
-        data["bg_manager_factory"] = self.bg_manager_factory
-        data["game_log"] = await dishka.get(GameLogWriter)
-        data["file_gateway"] = await dishka.get(FileGateway)
-        data["hint_sender"] = await dishka.get(HintSender)
-        data["level_view"] = await dishka.get(LevelView)
         data["dao"] = await dishka.get(HolderDao)
-        data["hint_parser"] = await dishka.get(HintParser)
-        data["results_painter"] = await dishka.get(ResultsPainter)
+        data["retort"] = await dishka.get(Retort)
         result = await handler(event, data)  # type: ignore[arg-type]
         return result

--- a/shvatka/tgbot/utils/data.py
+++ b/shvatka/tgbot/utils/data.py
@@ -2,24 +2,11 @@ from adaptix import Retort
 from aiogram.dispatcher.middlewares.data import MiddlewareData
 from aiogram_dialog import DialogManager
 from aiogram_dialog.api.entities import Stack, Context
-from aiogram_dialog.api.protocols import BgManagerFactory
 from aiogram_dialog.context.storage import StorageProxy
 from dishka import AsyncContainer
-from telegraph.aio import Telegraph
 
-from shvatka.core.interfaces.clients.file_storage import FileStorage, FileGateway
-from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.models import dto
-from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
-from shvatka.core.views.game import GameLogWriter
-from shvatka.core.views.level import LevelView
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.infrastructure.picture.results_painter import ResultsPainter
-from shvatka.tgbot.config.models.bot import BotConfig
-from shvatka.tgbot.config.models.main import TgBotConfig
-from shvatka.tgbot.username_resolver.user_getter import UserGetter
-from shvatka.tgbot.views.hint_factory.hint_parser import HintParser
-from shvatka.tgbot.views.hint_sender import HintSender
 
 
 class DialogMiddlewareData(MiddlewareData, total=False):
@@ -30,26 +17,19 @@ class DialogMiddlewareData(MiddlewareData, total=False):
 
 
 class SHMiddlewareData(DialogMiddlewareData, total=False):
-    config: BotConfig
-    main_config: TgBotConfig
+    """
+    Data every handler receives by name.
+
+    Only what a lot of handlers need belongs here — anything else is requested
+    from the container with ``FromDishka`` at the single place that uses it.
+    """
+
     dishka_container: AsyncContainer
-    user_getter: UserGetter
     retort: Retort
     dao: HolderDao
-    scheduler: Scheduler
-    locker: KeyCheckerFactory
-    file_storage: FileStorage
-    telegraph: Telegraph
-    hint_parser: HintParser
-    file_gateway: FileGateway
-    hint_sender: HintSender
-    level_view: LevelView
     user: dto.User | None
     chat: dto.Chat | None
     team: dto.Team | None
     player: dto.Player | None
     game: dto.Game | None
     team_player: dto.FullTeamPlayer | None
-    results_painter: ResultsPainter
-    game_log: GameLogWriter
-    bg_manager_factory: BgManagerFactory


### PR DESCRIPTION
`InitMiddleware` resolved 17 dependencies from the container on **every** update. An audit of who actually reads each key (AST scan over `shvatka/tgbot` for parameters injected by name + `middleware_data[...]` subscripts + Jinja/Format templates) found most of them unused or used in one place.

## What was removed

**Zero consumers** — written by the middleware, read by nobody:

| key | note |
| --- | --- |
| `main_config` | never read |
| `locker` | `level_manage` already pulls `KeyCheckerFactory` from the container |
| `hint_parser` | every dialog uses `FromDishka[HintParser]` |
| `file_storage` | only constructor/factory params, never handler params |
| `config` | handlers already use `FromDishka[BotConfig]`; the rest are `setup()` args |
| `hint_sender` | handlers already use `FromDishka[HintSender]` |

**One to four consumers** — migrated to `FromDishka` at the call site:

| key | consumers |
| --- | --- |
| `user_getter` | `FixTargetMiddleware` (resolves it from the container now) |
| `results_painter` | `game_manage/getters.get_game_results` |
| `telegraph` | `game_manage/getters.get_game_keys` |
| `scheduler`, `level_view` | `starters/organizer.start_test_level`, `level_manage.level_testing` |
| `file_gateway` | `game_manage.common_show_zip` (passed in by its two `@inject`ed callers), `game_scn.process_zip_scn` |
| `game_log` | `merge` ×2, `admin.merge_teams_command`, `team/manage.cmd_create_team` |
| `bg_manager_factory` | `merge` ×2, `player.agree_promotion_handler`, `game/add_organizer.agree_to_be_org_handler` |

`bg_manager_factory` was the only key not coming from the container. `DpProvider` already provides `BgManagerFactory`, so handlers take it from there and `InitMiddleware` no longer needs it as a constructor argument — `setup_middlewares(dp)` loses a parameter too.

What stays: `dishka_container`, `dao`, `retort`, and the identity entities (`user`/`chat`/`team`/`player`/`game`/`team_player`) — each with dozens of readers, several of them inside Jinja window templates.

## Why it's worth doing

Beyond the smaller surface, the resolutions weren't free. `get_hint_sender` is an `AsyncIterable` provider that opens its own `async_sessionmaker` session:

```python
async with pool() as session:
    yield HintSender(bot=bot, resolver=resolver, file_info_dao=FileInfoDao(session))
```

Every update — a `/start`, a dialog redraw, a callback — borrowed and closed a connection for a `HintSender` nothing was going to use.

## Drive-by fix

`get_game_keys` annotated `telegraph: Telegraph` importing the **sync** `telegraph.Telegraph`, while the middleware handed it the async client from `telegraph.aio`. Taking it from DI corrects the annotation.

## Testing

- `ruff format --check .` / `ruff check .` / `mypy .` — clean (782 files)
- `pytest tests/unit` — 315 passed, including `test_di` (all four containers build under `STRICT_VALIDATION`), `test_dialogs_preview` and `test_dialogs_transitions`
- Additionally asserted every newly `FromDishka`-injected type is registered in the bot, root and test containers

Aligned with two rules already in `AGENTS.md`: *"Don't add to middleware data new keys — prefer DI"* and *"In aiogram / aiogram_dialog handlers, take dependencies from DI rather than reaching into `manager.middleware_data`."*

## Not done

`dao` (76 handler params + 28 subscripts) and `retort` (11 + 9) are the same kind of candidate but far larger; converting them is a separate change if you want it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc8f5cmC2a9Gop3jEE9i2G)_