### PR TITLE
Take the current game from CurrentGameProvider, not middleware data

### DIFF
--- a/.github/ISSUE_TEMPLATE/tgbot-regression-pass.md
+++ b/.github/ISSUE_TEMPLATE/tgbot-regression-pass.md
@@ -60,6 +60,24 @@ matter, so each check names the account to use.
 - [ ] **C** — on a fresh invite, «не согласен» declines and edits the message.
 - [ ] **A** — invite B to be an organizer inline; your own click gives «ну и смысл?», B's acceptance makes them an org and refreshes B's open main menu. `is_inviter` + `BgManagerFactory`
 
+### Game-state gating
+
+`GameStatusFilter` is the widest filter in the bot: `disable_router_on_game`
+mounts it on the message, callback_query and inline_query of nearly every
+router, so almost every update passes through it. Its two failure modes are
+opposite and both quiet — answer `False` too often and the bot goes mute
+outside games, answer `True` too often and commands that must be blocked
+during a game become available. Test it in both game states, not just one.
+
+- [ ] With **no active game**: `/start`, `/team`, `/teams`, `/create_team`, `/my_games` all respond. `GameStatusFilter(running=False)`
+- [ ] With a game in **getting_waivers**: the same commands still respond — the routers are disabled only once a game is *started*, not merely active.
+- [ ] With a game **started**: those same commands go quiet. If `/create_team` still answers mid-game, the filter is inverted. `running=False`, inverse
+- [ ] With a game **started**: a correct key from a team chat is still accepted — the play router is gated the other way. `GameStatusFilter(running=True)`
+- [ ] After the game **finishes**: the normal commands answer again.
+- [ ] During **getting_waivers**: `/waivers` and `/approve_waivers` work; outside that status they do not. `GameStatusFilter(status=getting_waivers)`
+- [ ] **org** — during a started game, `/spy` opens and the spy view lists teams by level. `OrgFilter` + spy getters
+- [ ] **org** — the spy «Лог ключей» button builds its Telegraph page. spy `keys_handler`
+
 ## 2. Identity is still written on every update
 
 Resolving the identity is a write: it upserts the user and the chat, and creates

--- a/shvatka/tgbot/dialogs/game_spy/getters.py
+++ b/shvatka/tgbot/dialogs/game_spy/getters.py
@@ -3,10 +3,10 @@ from datetime import datetime
 
 from aiogram_dialog import DialogManager
 
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.identity import IdentityProvider
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
-from shvatka.core.models import dto
 from shvatka.core.services.game_stat import get_game_spy
 from shvatka.core.services.organizers import get_by_player
 from shvatka.core.utils.datetime_utils import tz_utc
@@ -16,11 +16,12 @@ from shvatka.infrastructure.db.dao.holder import HolderDao
 @inject
 async def get_org(
     dao: HolderDao,
-    game: dto.Game,
     dialog_manager: DialogManager,
     identity: FromDishka[IdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
     **_,
 ):
+    game = await current_game.get_required_game()
     player = await identity.get_required_player()
     if dialog_manager.middleware_data.get("org", None) is not None:
         org = dialog_manager.middleware_data["org"]
@@ -36,11 +37,12 @@ async def get_org(
 @inject
 async def get_spy(
     dao: HolderDao,
-    game: dto.Game,
     dialog_manager: DialogManager,
     identity: FromDishka[IdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
     **_,
 ):
+    game = await current_game.get_required_game()
     player = await identity.get_required_player()
     stat = sorted(
         await get_game_spy(game, player, dao.game_stat),

--- a/shvatka/tgbot/dialogs/game_spy/handlers.py
+++ b/shvatka/tgbot/dialogs/game_spy/handlers.py
@@ -6,8 +6,8 @@ from aiogram_dialog.widgets.kbd import Button
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.identity import IdentityProvider
-from shvatka.core.models import dto
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.views.keys import create_keys_page
@@ -22,9 +22,10 @@ async def keys_handler(
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
     telegraph: FromDishka[Telegraph],
+    current_game: FromDishka[CurrentGameProvider],
 ):
     await c.answer()
-    game: dto.Game = manager.middleware_data["game"]
+    game = await current_game.get_required_game()
     page = await create_keys_page(
         game=game, telegraph=telegraph, dao=dao, salt=game.manage_token[:8], identity=identity
     )

--- a/shvatka/tgbot/filters/game_status.py
+++ b/shvatka/tgbot/filters/game_status.py
@@ -3,7 +3,10 @@ from typing import Any
 
 from aiogram.filters import BaseFilter
 from aiogram.types import Message
+from dishka import FromDishka
+from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.models import dto
 from shvatka.core.models.enums import GameStatus
 
@@ -14,7 +17,11 @@ class GameStatusFilter(BaseFilter):
     running: bool | None = None
     status: GameStatus | None = None
 
-    async def __call__(self, message: Message, game: dto.Game) -> bool | dict[str, Any]:
+    @inject
+    async def __call__(
+        self, message: Message, current_game: FromDishka[CurrentGameProvider]
+    ) -> bool | dict[str, Any]:
+        game = await current_game.get_game()
         if self.active is not None:
             return self.check_active(game)
         if self.running is not None:
@@ -23,17 +30,17 @@ class GameStatusFilter(BaseFilter):
             return self.check_by_status(game)
         return True
 
-    def check_active(self, game: dto.Game) -> bool:
+    def check_active(self, game: dto.Game | None) -> bool:
         if game is not None and game.is_active():
             return bool(self.active)
         return not self.active
 
-    def check_running(self, game: dto.Game) -> bool:
+    def check_running(self, game: dto.Game | None) -> bool:
         if game is not None and game.is_started():
             return bool(self.running)
         return not self.running
 
-    def check_by_status(self, game: dto.Game) -> bool:
+    def check_by_status(self, game: dto.Game | None) -> bool:
         if game is None:
             return False
         return game.status == self.status

--- a/shvatka/tgbot/filters/is_org.py
+++ b/shvatka/tgbot/filters/is_org.py
@@ -6,6 +6,7 @@ from aiogram.types import Message
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.services.organizers import get_by_player_or_none
@@ -30,10 +31,11 @@ class OrgFilter(BaseFilter):
     async def __call__(  # noqa: C901
         self,
         message: Message,
-        game: dto.Game | None,
         dao: HolderDao,
         identity: FromDishka[IdentityProvider],
+        current_game: FromDishka[CurrentGameProvider],
     ) -> bool | dict[str, Any]:
+        game = await current_game.get_game()
         if not game or not game.is_active():
             return False
         if self.only_for_running_game and not game.is_started():

--- a/shvatka/tgbot/handlers/waivers.py
+++ b/shvatka/tgbot/handlers/waivers.py
@@ -48,12 +48,13 @@ from shvatka.tgbot.views.waiver import (
 @inject
 async def start_waivers(
     message: Message,
-    game: dto.Game,
     dao: HolderDao,
     bot: Bot,
     identity_provider: FromDishka[TgBotIdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
     interactor: FromDishka[TeamWaiversDraftReaderInteractor],
 ):
+    game = await current_game.get_required_game()
     try:
         waiver_results = await interactor(game_id=game.id, identity=identity_provider)
         check_allow_approve_waivers(await identity_provider.get_required_full_team_player())
@@ -106,12 +107,13 @@ async def add_vote_handler(
 @inject
 async def start_approve_waivers_cmd_handler(
     _: Message,
-    game: dto.Game,
     dao: HolderDao,
     bot: Bot,
     identity_provider: FromDishka[TgBotIdentityProvider],
     read_interactor: FromDishka[TeamWaiversDraftReaderInteractor],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     user = await identity_provider.get_required_user()
     team = await get_my_team(player, dao.team_player)
@@ -131,12 +133,13 @@ async def start_approve_waivers_cmd_handler(
 async def start_approve_waivers_cb_handler(
     c: CallbackQuery,
     callback_data: kb.WaiverToApproveCD,
-    game: dto.Game,
     dao: HolderDao,
     bot: Bot,
     identity_provider: FromDishka[TgBotIdentityProvider],
     read_interactor: FromDishka[TeamWaiversDraftReaderInteractor],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     user = await identity_provider.get_required_user()
     check_same_game(callback_data, game, player)
@@ -159,11 +162,12 @@ async def start_approve_waivers_cb_handler(
 async def waiver_main_menu(
     c: CallbackQuery,
     callback_data: kb.WaiverMainCD,
-    game: dto.Game,
     dao: HolderDao,
     identity_provider: FromDishka[TgBotIdentityProvider],
     read_interactor: FromDishka[TeamWaiversDraftReaderInteractor],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -181,12 +185,13 @@ async def waiver_main_menu(
 async def confirm_approve_waivers_handler(
     c: CallbackQuery,
     callback_data: kb.WaiverConfirmCD,
-    game: dto.Game,
     dao: HolderDao,
     bot: Bot,
     identity_provider: FromDishka[TgBotIdentityProvider],
     interactor: FromDishka[TeamWaiversDraftReaderInteractor],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -208,11 +213,12 @@ async def confirm_approve_waivers_handler(
 async def cancel_waivers_handler(
     c: CallbackQuery,
     callback_data: kb.WaiverConfirmCD,
-    game: dto.Game,
     dao: HolderDao,
     bot: Bot,
     identity_provider: FromDishka[TgBotIdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -227,10 +233,11 @@ async def cancel_waivers_handler(
 async def waiver_user_menu(
     c: CallbackQuery,
     callback_data: kb.WaiverManagePlayerCD,
-    game: dto.Game,
     dao: HolderDao,
     identity_provider: FromDishka[TgBotIdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -251,11 +258,12 @@ async def waiver_user_menu(
 async def waiver_remove_user_vote(
     c: CallbackQuery,
     callback_data: kb.WaiverRemovePlayerCD,
-    game: dto.Game,
     dao: HolderDao,
     identity_provider: FromDishka[TgBotIdentityProvider],
     read_interactor: FromDishka[TeamWaiversDraftReaderInteractor],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -275,10 +283,11 @@ async def waiver_remove_user_vote(
 async def waiver_add_force_menu(
     c: CallbackQuery,
     callback_data: kb.WaiverRemovePlayerCD,
-    game: dto.Game,
     dao: HolderDao,
     identity_provider: FromDishka[TgBotIdentityProvider],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)
@@ -299,11 +308,12 @@ async def waiver_add_force_menu(
 async def add_force_player(
     c: CallbackQuery,
     callback_data: kb.WaiverAddPlayerForceCD,
-    game: dto.Game,
     dao: HolderDao,
     identity_provider: FromDishka[TgBotIdentityProvider],
     waiver_vote_adder_dao: FromDishka[WaiverVoteAdder],
+    current_game: FromDishka[CurrentGameProvider],
 ):
+    game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
     check_same_game(callback_data, game, player)
     team = await get_my_team(player, dao.team_player)

--- a/shvatka/tgbot/middlewares/data_load_middleware.py
+++ b/shvatka/tgbot/middlewares/data_load_middleware.py
@@ -3,7 +3,6 @@ from typing import Callable, Any, Awaitable
 from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
 
-from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.tgbot.services.identity import TgBotIdentityProvider
 from shvatka.tgbot.utils.data import SHMiddlewareData
 
@@ -27,12 +26,10 @@ class LoadDataMiddleware(BaseMiddleware):
     ) -> Any:
         dishka = data["dishka_container"]
         identity_provider = await dishka.get(TgBotIdentityProvider)
-        current_game = await dishka.get(CurrentGameProvider)
 
         await identity_provider.get_chat()
         # loads (and so upserts) the user on the way to the player
         await identity_provider.get_player()
 
-        data["game"] = await current_game.get_game()
         result = await handler(event, data)  # type: ignore[arg-type]
         return result

--- a/shvatka/tgbot/utils/data.py
+++ b/shvatka/tgbot/utils/data.py
@@ -5,7 +5,6 @@ from aiogram_dialog.api.entities import Stack, Context
 from aiogram_dialog.context.storage import StorageProxy
 from dishka import AsyncContainer
 
-from shvatka.core.models import dto
 from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
@@ -22,10 +21,10 @@ class SHMiddlewareData(DialogMiddlewareData, total=False):
 
     Only what a lot of handlers need belongs here — anything else is requested
     from the container with ``FromDishka`` at the single place that uses it.
-    Who is acting comes from ``IdentityProvider``, not from this dict.
+    Who is acting comes from ``IdentityProvider`` and what is being played from
+    ``CurrentGameProvider``, not from this dict.
     """
 
     dishka_container: AsyncContainer
     retort: Retort
     dao: HolderDao
-    game: dto.Game | None

--- a/tests/unit/test_filters_identity.py
+++ b/tests/unit/test_filters_identity.py
@@ -6,11 +6,14 @@ They are wired through ``@inject``, which only works because aiogram passes
 disable a command rather than fail, so drive them through the real machinery.
 """
 
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from aiogram import Router
 from aiogram.dispatcher.event.handler import FilterObject
+from aiogram.types import Chat, Message
 from dishka import Provider, Scope, make_async_container, provide
 from dishka.integrations.aiogram import CONTAINER_NAME
 
@@ -23,6 +26,7 @@ from shvatka.tgbot.filters.game_status import GameStatusFilter
 from shvatka.tgbot.filters.is_inviter import is_inviter
 from shvatka.tgbot.filters.is_team import IsTeamFilter
 from shvatka.tgbot.filters.team_player import TeamPlayerFilter
+from shvatka.tgbot.utils.router import disable_router_on_game
 
 PLAYER = dto.Player(id=1, can_be_author=True, is_dummy=False, username="harry")
 NO_AUTHOR = dto.Player(id=2, can_be_author=False, is_dummy=False, username="ron")
@@ -169,3 +173,47 @@ async def test_game_status_active():
     assert await call(GameStatusFilter(active=True), identity(), current_game(None)) is False
     started = current_game(game(GameStatus.started))
     assert await call(GameStatusFilter(active=True), identity(), started) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active_game", "reaches_handlers"),
+    [(None, True), (GameStatus.getting_waivers, True), (GameStatus.started, False)],
+)
+async def test_disable_router_on_game_through_root_filters(active_game, reaches_handlers):
+    """`disable_router_on_game` registers *root* filters, not handler filters.
+
+    Those run through `check_root_filters`, so an `@inject` that worked on a
+    handler filter is not by itself proof that this path works — and this one
+    gates nearly every router in the bot.
+    """
+    router = Router(name="test")
+    disable_router_on_game(router)
+    provider = current_game(game(active_game) if active_game else None)
+
+    class Providers(Provider):
+        scope = Scope.REQUEST
+
+        @provide
+        def idp(self) -> IdentityProvider:
+            return identity()
+
+        @provide
+        def cg(self) -> CurrentGameProvider:
+            return provider
+
+    event = Message(
+        message_id=1,
+        date=datetime.now(tz=timezone.utc),
+        chat=Chat(id=1, type="private"),
+        text="/start",
+    )
+    container = make_async_container(Providers())
+    try:
+        async with container() as request_container:
+            passed, _ = await router.message.check_root_filters(
+                event, **{CONTAINER_NAME: request_container}
+            )
+    finally:
+        await container.close()
+    assert bool(passed) is reaches_handlers

--- a/tests/unit/test_filters_identity.py
+++ b/tests/unit/test_filters_identity.py
@@ -14,9 +14,12 @@ from aiogram.dispatcher.event.handler import FilterObject
 from dishka import Provider, Scope, make_async_container, provide
 from dishka.integrations.aiogram import CONTAINER_NAME
 
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
+from shvatka.core.models.enums import GameStatus
 from shvatka.tgbot.filters.can_be_author import can_be_author
+from shvatka.tgbot.filters.game_status import GameStatusFilter
 from shvatka.tgbot.filters.is_inviter import is_inviter
 from shvatka.tgbot.filters.is_team import IsTeamFilter
 from shvatka.tgbot.filters.team_player import TeamPlayerFilter
@@ -38,13 +41,40 @@ def identity(
     return idp
 
 
-async def call(filter_: Any, idp: AsyncMock, **kwargs: Any) -> Any:
+def game(status: GameStatus) -> dto.Game:
+    return dto.Game(
+        id=1,
+        author=PLAYER,
+        name="Alice",
+        status=status,
+        manage_token="token",
+        start_at=None,
+        number=1,
+        results=dto.GameResults(
+            published_chanel_id=None, results_picture_file_id=None, keys_url=None
+        ),
+    )
+
+
+def current_game(active: dto.Game | None) -> AsyncMock:
+    provider = AsyncMock(CurrentGameProvider)
+    provider.get_game.return_value = active
+    return provider
+
+
+async def call(
+    filter_: Any, idp: AsyncMock, game_provider: AsyncMock | None = None, **kwargs: Any
+) -> Any:
     class IdpProvider(Provider):
         scope = Scope.REQUEST
 
         @provide
         def idp(self) -> IdentityProvider:
             return idp
+
+        @provide
+        def current_game(self) -> CurrentGameProvider:
+            return game_provider or current_game(None)
 
     container = make_async_container(IdpProvider())
     try:
@@ -95,3 +125,47 @@ async def test_is_inviter(inviter_id, expected):
     callback_data = AsyncMock()
     callback_data.inviter_id = inviter_id
     assert await call(is_inviter, identity(), callback_data=callback_data) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active_game", "expected"),
+    [
+        (None, True),
+        (GameStatus.getting_waivers, True),
+        (GameStatus.started, False),
+        (GameStatus.finished, True),
+    ],
+)
+async def test_disable_router_on_game(active_game, expected):
+    """`GameStatusFilter(running=False)` gates almost every router in the bot."""
+    provider = current_game(game(active_game) if active_game else None)
+    assert await call(GameStatusFilter(running=False), identity(), provider) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active_game", "expected"),
+    [(None, False), (GameStatus.getting_waivers, False), (GameStatus.started, True)],
+)
+async def test_game_status_running(active_game, expected):
+    provider = current_game(game(active_game) if active_game else None)
+    assert await call(GameStatusFilter(running=True), identity(), provider) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("active_game", "expected"),
+    [(None, False), (GameStatus.getting_waivers, True), (GameStatus.started, False)],
+)
+async def test_game_status_by_status(active_game, expected):
+    provider = current_game(game(active_game) if active_game else None)
+    filter_ = GameStatusFilter(status=GameStatus.getting_waivers)
+    assert await call(filter_, identity(), provider) is expected
+
+
+@pytest.mark.asyncio
+async def test_game_status_active():
+    assert await call(GameStatusFilter(active=True), identity(), current_game(None)) is False
+    started = current_game(game(GameStatus.started))
+    assert await call(GameStatusFilter(active=True), identity(), started) is True


### PR DESCRIPTION
Follow-up to #343 and #344. The active game was loaded into middleware data on every update and read back by name; `CurrentGameProvider` already answers it, is request-scoped and caches, so the copy was a second source of truth. `SHMiddlewareData` is now down to `dishka_container`, `dao`, `retort`.

## The one that matters: `GameStatusFilter`

`disable_router_on_game` mounts it on `message`, `callback_query` and `inline_query` of nearly every router, so it runs for almost every update:

```python
def disable_router_on_game(router: Router):
    router.message.filter(GameStatusFilter(running=False))
    ...
```

It resolves the game itself now. Same cost — `CurrentGameProviderImpl` caches in `self.cache` and is `Scope.REQUEST`, exactly like the middleware's single load — but an update that reaches no such router stops paying for it at all.

I'd flagged this filter earlier as possibly needing a design change, on the worry that it was a `MagicData` magic filter that can't take DI. It isn't — it's a plain `BaseFilter`, so `@inject` works on `__call__` the same way it does for the filters converted in #344.

`OrgFilter` gets the same treatment.

## Waiver handlers

Ten handlers took `game: dto.Game` from the dict; they now ask for `get_required_game()`. Their whole router is gated on `GameStatusFilter(status=GameStatus.getting_waivers)`, so a game is guaranteed by the time they run — raising `HaveNotActiveGame` is strictly better than passing `None` on under an annotation that claimed `dto.Game`.

## Dialogs

`game_spy`'s `get_org`/`get_spy` getters and its `keys_handler` were the only dialog consumers.

No window is affected. I checked all 17 windows that render `{{game...}}` or branch on `F["game"]`: every one already gets `game` from its own getter (`get_main`, `get_completed_game`, `get_game_waivers`, `get_game_results`, `get_game_keys`, `get_game`, `get_game_datetime`, `get_orgs`, `select_full_game`, `get_release`, `get_org`, …), so nothing was relying on the middleware key to render. Notably `game_spy.get_org` was both a consumer and the supplier for its window — it keeps supplying `game` after resolving it from the provider.

## What's left in the dict

`dishka_container`, `dao`, `retort`. `LoadDataMiddleware` now does nothing but trigger the identity upserts, and `InitMiddleware` is down to `dao` + `retort`.

## Testing

- `ruff format --check .` / `ruff check .` / `mypy .` — clean (785 files)
- `pytest tests/unit` — 343 passed
- `test_filters_identity` now covers `GameStatusFilter`, including the `running=False` shape `disable_router_on_game` uses; verified it goes red when the filter stops consulting the provider

Worth running §1 of the **Bot regression pass** template against this one — `GameStatusFilter` gates almost every command in the bot, and a wrong answer there is silent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc8f5cmC2a9Gop3jEE9i2G)_