### PR TITLE
Close dialogs whose state changed while the window waited

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -479,11 +479,12 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   start (a team id in `dialog_data`, a permission a button was shown for) may be
   false by the time the button is pressed. Don't `assert` it and don't quietly
   `done()`: raise `DialogOutdated` (`tgbot/dialogs/outdated.py`) from the getter
-  or the handler — `OutdatedDialogMiddleware` answers the user and closes the
-  dialog. For team state use the guards next to it (`get_actual_team`,
-  `get_actual_team_player`, `get_actual_teammate`) rather than rolling the check
-  by hand. Better still, don't cache the state: resolve it in the getter on
-  every render, the way `my_team_getter` does. See SHEP-0005.
+  or the handler — `OutdatedDialogMiddleware` answers the user and restarts them
+  in the main menu. For the acting player's team use
+  `get_actual_team_player(identity)` (it translates `PlayerNotInTeam` for you
+  and carries `.team`), and `get_actual_teammate` for anybody else. Better
+  still, don't cache the state: resolve it in the getter on every render, the
+  way `my_team_getter` does. See SHEP-0005.
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,6 +474,16 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   `done()` paths). `tests/unit/test_dialogs_transitions.py` fails on an
   undeclared jump; `python -m shvatka.tgbot.dialogs.__init__` writes the
   diagram to `out/shvatka-dialogs.png` (needs graphviz).
+- **A dialog re-checks the state it was opened for, and says so when it's gone.**
+  A telegram window stays clickable forever, so anything a dialog captured on
+  start (a team id in `dialog_data`, a permission a button was shown for) may be
+  false by the time the button is pressed. Don't `assert` it and don't quietly
+  `done()`: raise `DialogOutdated` (`tgbot/dialogs/outdated.py`) from the getter
+  or the handler — `OutdatedDialogMiddleware` answers the user and closes the
+  dialog. For team state use the guards next to it (`get_actual_team`,
+  `get_actual_team_player`, `get_actual_teammate`) rather than rolling the check
+  by hand. Better still, don't cache the state: resolve it in the getter on
+  every render, the way `my_team_getter` does. See SHEP-0005.
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes

--- a/docs/modules/shep/nav.adoc
+++ b/docs/modules/shep/nav.adoc
@@ -3,4 +3,5 @@
 ** xref:shep-0002-custom-key-prefixes.adoc[SHEP-0002 Custom key prefixes]
 ** xref:shep-0003-season-schedule.adoc[SHEP-0003 Season schedule]
 ** xref:shep-0004-parallel-levels.adoc[SHEP-0004 Parallel levels]
+** xref:shep-0005-outdated-dialogs.adoc[SHEP-0005 Outdated dialogs]
 ** xref:template.adoc[SHEP template]

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -42,6 +42,10 @@ came out of it*.
 | xref:shep-0004-parallel-levels.adoc[SHEP-0004]
 | Parallel levels
 | Draft
+
+| xref:shep-0005-outdated-dialogs.adoc[SHEP-0005]
+| Outdated dialogs
+| Accepted, partially implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0005-outdated-dialogs.adoc
+++ b/docs/modules/shep/pages/shep-0005-outdated-dialogs.adoc
@@ -1,0 +1,170 @@
+= SHEP-0005 — Outdated dialogs
+:navtitle: SHEP-0005 Outdated dialogs
+
+[cols="1,4"]
+|===
+| SHEP | 0005
+| Title | Outdated dialogs
+| Status | `Accepted`
+| Created | 2026-08-12
+| Updated | 2026-08-12
+| Related | issue #339
+|===
+
+== Summary
+
+A telegram window stays clickable forever, so the state a dialog was opened for
+can be gone by the time a button is pressed. Dialogs now say so explicitly: a
+getter or a handler raises `DialogOutdated`, and one middleware turns that into
+an alert for the user plus a closed dialog — instead of an `assert` blowing up
+or a handler silently acting on the wrong team.
+
+== Context
+
+`shvatka/tgbot/dialogs/team_view/handlers.py` used to open the "my team" dialog
+like this:
+
+[source,python]
+----
+team = await get_my_team(player=player, dao=dao.team_player)
+assert team
+manager.dialog_data["team_id"] = team.id
+----
+
+Weeks may pass between opening the main menu and pressing *🚩Моя команда* in it.
+If the captain removed the player meanwhile, `get_my_team` returns `None` and
+the bot answers with an `AssertionError` — the user sees a dead button and the
+log chat gets a traceback.
+
+The same shape appeared all over the team dialogs:
+
+* `team_manage/getters.py` — `assert team`, and `get_my_team_` returning
+  `team=None` into a Jinja template that dereferences `team.name`;
+* `team_manage/handlers.py` — `assert team` in `start_merge`,
+  `gotten_chat_request`, `gotten_user_request`; a bare `done()` with no
+  explanation in the rename/role/emoji handlers;
+* `change_permission_handler` took the *selected player's own* membership
+  (`get_team_player_by_player`) rather than their membership in the captain's
+  team — if that player had joined another team in the meantime, the captain
+  would have flipped a permission in a team they have nothing to do with.
+
+Three constraints shaped the answer:
+
+* **Getters cannot close a dialog.** They run inside `manager.show()`; calling
+  `done()` from there re-enters the manager while it is rendering.
+* **The existing `SHError` handler is not enough.** `dp.errors` already answers
+  the callback with `notify_user`, but it leaves the dialog open on a window
+  that will fail again on the next click. And most of these errors are not
+  domain errors at all — nothing went wrong, the window is simply old.
+* **Error handlers cannot reach the dialog.** aiogram_dialog puts
+  `dialog_manager` into the data of `dialogs_router.errors`, but the catch-all
+  handler on `dp.errors` runs first and stops propagation, so a handler
+  registered deeper is never reached.
+
+== Decision
+
+=== `DialogOutdated` is the signal
+
+A dedicated exception in `shvatka/tgbot/dialogs/outdated.py`, deliberately *not*
+an `SHError`: it does not mean the domain refused something, it means the window
+the user is looking at describes a world that no longer exists. It carries
+`notify_user` (Russian, shown to the user) and `text` (English, logged).
+
+=== One middleware handles it
+
+`OutdatedDialogMiddleware` is an inner middleware of the dialogs router. It
+catches `DialogOutdated`, answers the callback query with an alert (or replies
+to the message, for `MessageInput` handlers), and calls `manager.done()`.
+
+Inner middlewares of a router wrap the handlers of its sub-routers too, so one
+registration covers every dialog — including window getters, which run inside
+the handler call. It must be registered **after** `setup_dialogs`, so that it
+sits inside aiogram_dialog's own `ManagerMiddleware` and has `dialog_manager` in
+the data; `tests/unit/test_outdated_dialog_middleware.py` pins that ordering.
+
+Closing the dialog — rather than switching back a window — is the deliberate
+choice: whatever the dialog kept in `dialog_data` was captured against the old
+state, so the honest thing is to drop it and let the user re-enter from a window
+built out of current data. The parent dialog re-renders on the way out, so a
+button that should no longer be there disappears in the same round trip.
+
+=== Guards instead of asserts
+
+Three helpers next to the exception replace the hand-written checks, so a call
+site states which staleness it is guarding against:
+
+[cols="1,4",options="header"]
+|===
+| Helper | Answers
+
+| `get_actual_team(player, dao)`
+| the team the player is in *now*
+
+| `get_actual_team_player(player, team, dao)`
+| the acting player's own membership in that team
+
+| `get_actual_teammate(teammate, team, dao)`
+| another player's membership *in that team* — not wherever they are today
+|===
+
+=== The "my team" window resolves its team on every render
+
+`my_team_view` no longer captures a team id in `on_start`; `my_team_getter`
+resolves the current team on every render. Remembering an id and trusting it
+later is the bug this SHEP is about, so the dialog stopped doing it. The team
+card body is shared with the public team view through `team_card()`.
+
+=== Alternatives considered
+
+* **Handle it in `dp.errors`.** Rejected: the catch-all error handler already
+  registered there wins the propagation, and error handlers at that level have
+  no dialog manager.
+* **Move `setup_dialogs` onto the dispatcher** so error handlers get a manager.
+  Rejected: it puts the dialog middlewares on every handler in the bot, and
+  AGENTS.md is explicit that middleware changes break in ways no test catches.
+* **Let getters return `None` and hide widgets with `when=`.** Rejected: it
+  spreads a "maybe there is no team" branch through every template of a dialog
+  that only makes sense for a team member.
+* **Reuse `PlayerNotInTeam`** and close the dialog on it. Rejected: the same
+  exception is raised about *other* players in perfectly healthy flows, so it
+  cannot mean "this window is stale".
+
+== Consequences
+
+* Any dialog can now bail out from anywhere — getter, `on_click`, `MessageInput`
+  — with one `raise`, and the user gets told why.
+* One more middleware in the dialogs router. It only wraps a `try/except`, but
+  it is on the hot path of every dialog event.
+* Closing the dialog loses whatever the user had typed into it. That is the
+  point (the data was captured against stale state), but it is a real cost for
+  multi-step dialogs, and a future variant that switches to a safe window
+  instead is not precluded.
+* `DialogOutdated` is tgbot-only. If the API grows the same problem, it needs
+  its own answer — the exception must not migrate into `core`.
+
+== Phases and status
+
+[cols="1,4,2",options="header"]
+|===
+| Phase | Content | Status
+
+| 1
+| `DialogOutdated`, the middleware, the guards; team_view and team_manage
+  converted
+| ✅ done
+
+| 2
+| Sweep the remaining dialogs (game editing, orgs) for state that can change
+  under an open window
+| ⏳ not started
+|===
+
+== Deviations from the plan
+
+None yet.
+
+== Open questions
+
+* Should `DialogOutdated` be able to name a window to fall back to, instead of
+  always closing? The captain's bridge losing the whole dialog because one
+  selected player left is heavier than it needs to be.

--- a/docs/modules/shep/pages/shep-0005-outdated-dialogs.adoc
+++ b/docs/modules/shep/pages/shep-0005-outdated-dialogs.adoc
@@ -16,8 +16,9 @@
 A telegram window stays clickable forever, so the state a dialog was opened for
 can be gone by the time a button is pressed. Dialogs now say so explicitly: a
 getter or a handler raises `DialogOutdated`, and one middleware turns that into
-an alert for the user plus a closed dialog — instead of an `assert` blowing up
-or a handler silently acting on the wrong team.
+an alert for the user plus a fresh main menu — instead of an `assert` blowing
+up, a window rendering around a team that isn't there, or a handler silently
+acting on the wrong team.
 
 == Context
 
@@ -38,8 +39,11 @@ log chat gets a traceback.
 
 The same shape appeared all over the team dialogs:
 
-* `team_manage/getters.py` — `assert team`, and `get_my_team_` returning
-  `team=None` into a Jinja template that dereferences `team.name`;
+* `team_manage/getters.py` — `assert team` in `get_team_with_players`, and
+  `get_my_team_` returning `team=None`. That one does not raise: jinja2's
+  default `Undefined` renders `{{team.name}}` as an empty string, so the
+  captain's bridge came up as `🚩Команда: <b></b>` with every permission-gated
+  button hidden — a dead window with no hint of why;
 * `team_manage/handlers.py` — `assert team` in `start_merge`,
   `gotten_chat_request`, `gotten_user_request`; a bare `done()` with no
   explanation in the rename/role/emoji handlers;
@@ -50,8 +54,8 @@ The same shape appeared all over the team dialogs:
 
 Three constraints shaped the answer:
 
-* **Getters cannot close a dialog.** They run inside `manager.show()`; calling
-  `done()` from there re-enters the manager while it is rendering.
+* **Getters cannot end a dialog.** They run inside `manager.show()`; calling
+  `done()` or `start()` from there re-enters the manager while it is rendering.
 * **The existing `SHError` handler is not enough.** `dp.errors` already answers
   the callback with `notify_user`, but it leaves the dialog open on a window
   that will fail again on the next click. And most of these errors are not
@@ -74,7 +78,8 @@ the user is looking at describes a world that no longer exists. It carries
 
 `OutdatedDialogMiddleware` is an inner middleware of the dialogs router. It
 catches `DialogOutdated`, answers the callback query with an alert (or replies
-to the message, for `MessageInput` handlers), and calls `manager.done()`.
+to the message, for `MessageInput` handlers), and restarts the main menu with
+`StartMode.RESET_STACK`.
 
 Inner middlewares of a router wrap the handlers of its sub-routers too, so one
 registration covers every dialog — including window getters, which run inside
@@ -82,30 +87,37 @@ the handler call. It must be registered **after** `setup_dialogs`, so that it
 sits inside aiogram_dialog's own `ManagerMiddleware` and has `dialog_manager` in
 the data; `tests/unit/test_outdated_dialog_middleware.py` pins that ordering.
 
-Closing the dialog — rather than switching back a window — is the deliberate
-choice: whatever the dialog kept in `dialog_data` was captured against the old
-state, so the honest thing is to drop it and let the user re-enter from a window
-built out of current data. The parent dialog re-renders on the way out, so a
-button that should no longer be there disappears in the same round trip.
+Resetting the whole stack — rather than `done()`-ing just the broken dialog — is
+the deliberate choice. The dialogs underneath captured *their* `dialog_data`
+against the same state that has just turned out to be gone, so returning into
+one of them only moves the problem one window down. The main menu is the one
+window with no remembered state at all: it is built from the identity provider
+on every render, so whatever the player is now, it is right.
 
 === Guards instead of asserts
 
-Three helpers next to the exception replace the hand-written checks, so a call
+Two helpers next to the exception replace the hand-written checks, so a call
 site states which staleness it is guarding against:
 
 [cols="1,4",options="header"]
 |===
 | Helper | Answers
 
-| `get_actual_team(player, dao)`
-| the team the player is in *now*
-
-| `get_actual_team_player(player, team, dao)`
-| the acting player's own membership in that team
+| `get_actual_team_player(identity)`
+| the acting player's membership right now, `.team` included — a thin
+  translation of `IdentityProvider.get_required_full_team_player`, turning
+  `PlayerNotInTeam` into `DialogOutdated`
 
 | `get_actual_teammate(teammate, team, dao)`
-| another player's membership *in that team* — not wherever they are today
+| another player's membership *in that team* — not wherever they are today.
+  `IdentityProvider` only knows the acting player, so this one takes a dao
 |===
+
+The acting player's side goes through `IdentityProvider` rather than a fresh
+`get_my_team(player, dao)`: it is the same source the windows render from, it
+caches within the request, and `AGENTS.md` already asks for it everywhere but
+the dao layer. One helper covers both "is there a team" and "am I in it",
+because `dto.FullTeamPlayer` carries `.team`.
 
 === The "my team" window resolves its team on every render
 
@@ -125,9 +137,11 @@ card body is shared with the public team view through `team_card()`.
 * **Let getters return `None` and hide widgets with `when=`.** Rejected: it
   spreads a "maybe there is no team" branch through every template of a dialog
   that only makes sense for a team member.
-* **Reuse `PlayerNotInTeam`** and close the dialog on it. Rejected: the same
-  exception is raised about *other* players in perfectly healthy flows, so it
-  cannot mean "this window is stale".
+* **Treat `PlayerNotInTeam` itself as "outdated"** in the middleware, with no
+  new exception. Rejected: the same exception is raised about *other* players in
+  perfectly healthy flows, so by itself it cannot mean "this window is stale".
+  It is translated at the point where it does mean that, in
+  `get_actual_team_player`.
 
 == Consequences
 
@@ -135,10 +149,10 @@ card body is shared with the public team view through `team_card()`.
   — with one `raise`, and the user gets told why.
 * One more middleware in the dialogs router. It only wraps a `try/except`, but
   it is on the hot path of every dialog event.
-* Closing the dialog loses whatever the user had typed into it. That is the
-  point (the data was captured against stale state), but it is a real cost for
-  multi-step dialogs, and a future variant that switches to a safe window
-  instead is not precluded.
+* Resetting the stack loses whatever the user had typed into the dialogs below
+  as well. That is the point (their data was captured against the same stale
+  state), but it is a real cost for a deep stack, and a future variant that
+  falls back to a named safe window instead is not precluded.
 * `DialogOutdated` is tgbot-only. If the API grows the same problem, it needs
   its own answer — the exception must not migrate into `core`.
 
@@ -166,5 +180,6 @@ None yet.
 == Open questions
 
 * Should `DialogOutdated` be able to name a window to fall back to, instead of
-  always closing? The captain's bridge losing the whole dialog because one
-  selected player left is heavier than it needs to be.
+  always landing in the main menu? The captain's bridge being reset because one
+  selected player left is heavier than it needs to be — going back to the player
+  list would do.

--- a/shvatka/tgbot/dialogs/__init__.py
+++ b/shvatka/tgbot/dialogs/__init__.py
@@ -82,7 +82,7 @@ def setup(router: Router, message_manager: MessageManagerProtocol) -> BgManagerF
 
 
 def setup_outdated_dialogs(dialogs_router: Router) -> None:
-    """Let any dialog handler or getter close itself by raising `DialogOutdated`.
+    """Let any dialog handler or getter bail out by raising `DialogOutdated`.
 
     Must run after `setup_dialogs`: inner middlewares are applied in
     registration order, and this one needs `dialog_manager` in the data, which

--- a/shvatka/tgbot/dialogs/__init__.py
+++ b/shvatka/tgbot/dialogs/__init__.py
@@ -27,6 +27,7 @@ from shvatka.tgbot.dialogs import (
     effects,
     profile,
 )
+from shvatka.tgbot.dialogs.outdated import OutdatedDialogMiddleware
 from shvatka.tgbot.dialogs.preview import render_dialogs_preview
 from shvatka.tgbot.filters import GameStatusFilter
 
@@ -75,8 +76,21 @@ def setup(router: Router, message_manager: MessageManagerProtocol) -> BgManagerF
     dialogs_router.include_router(setup_active_game_dialogs())
 
     bg_manager = setup_dialogs(dialogs_router, message_manager=message_manager)
+    setup_outdated_dialogs(dialogs_router)
     router.include_router(dialogs_router)
     return bg_manager
+
+
+def setup_outdated_dialogs(dialogs_router: Router) -> None:
+    """Let any dialog handler or getter close itself by raising `DialogOutdated`.
+
+    Must run after `setup_dialogs`: inner middlewares are applied in
+    registration order, and this one needs `dialog_manager` in the data, which
+    aiogram_dialog's own middleware puts there.
+    """
+    middleware = OutdatedDialogMiddleware()
+    dialogs_router.callback_query.middleware(middleware)
+    dialogs_router.message.middleware(middleware)
 
 
 def setup_all_dialogs() -> Router:

--- a/shvatka/tgbot/dialogs/outdated.py
+++ b/shvatka/tgbot/dialogs/outdated.py
@@ -1,0 +1,114 @@
+"""Guarding dialogs against state which changed while the window was waiting.
+
+Telegram keeps an inline keyboard clickable forever, so a window rendered today
+may get its button pressed in a month - by which time the captain has removed
+the player from the team the window was built for. Nothing tells the dialog
+that: `dialog_data` still holds the team id captured on start, and the getter
+still believes the player is a member. Re-checking on every event is the only
+option.
+
+`DialogOutdated`, raised from a getter or a handler, is how a dialog says "what
+I was opened for is gone". `OutdatedDialogMiddleware` catches it, tells the user
+what happened and closes the dialog, so they land back in a window built from
+current data instead of seeing an `assert` blow up.
+"""
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery, Message, TelegramObject
+from aiogram_dialog import DialogManager
+from aiogram_dialog.manager.manager_middleware import MANAGER_KEY
+
+from shvatka.core.interfaces.dal.player import PlayerTeamChecker, TeamPlayerGetter
+from shvatka.core.models import dto
+from shvatka.core.players.player import get_full_team_player_or_none, get_my_team
+
+logger = logging.getLogger(__name__)
+
+NOT_IN_TEAM = "Ты больше не состоишь в команде. Окно устарело, открой меню заново"
+NO_MORE_TEAMMATE = "Этот игрок больше не состоит в твоей команде. Окно устарело"
+
+
+class DialogOutdated(Exception):
+    """The dialog was opened for state which no longer holds.
+
+    Not an `SHError`: nothing went wrong in the domain, the user simply pressed
+    a button of a window which reality has moved on from.
+    """
+
+    def __init__(self, notify_user: str, text: str = "") -> None:
+        super().__init__(text or notify_user)
+        self.notify_user = notify_user
+        self.text = text or notify_user
+
+
+async def get_actual_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.Team:
+    """The team the player belongs to right now, whatever the window shows."""
+    team = await get_my_team(player=player, dao=dao)
+    if team is None:
+        raise DialogOutdated(NOT_IN_TEAM, f"player {player.id} is not in a team anymore")
+    return team
+
+
+async def get_actual_team_player(
+    player: dto.Player, team: dto.Team, dao: TeamPlayerGetter
+) -> dto.FullTeamPlayer:
+    """The acting player's own membership in `team`, as it is right now."""
+    team_player = await get_full_team_player_or_none(player=player, team=team, dao=dao)
+    if team_player is None:
+        raise DialogOutdated(NOT_IN_TEAM, f"player {player.id} is not in team {team.id} anymore")
+    return team_player
+
+
+async def get_actual_teammate(
+    teammate: dto.Player, team: dto.Team, dao: TeamPlayerGetter
+) -> dto.FullTeamPlayer:
+    """Membership of another player in `team`, as it is right now.
+
+    Guards the "selected player" of the captain's bridge: by the time the
+    captain presses a button the player may have left, or even joined another
+    team - and acting on their current membership would touch the wrong team.
+    """
+    team_player = await get_full_team_player_or_none(player=teammate, team=team, dao=dao)
+    if team_player is None:
+        raise DialogOutdated(
+            NO_MORE_TEAMMATE, f"player {teammate.id} is not in team {team.id} anymore"
+        )
+    return team_player
+
+
+class OutdatedDialogMiddleware(BaseMiddleware):
+    """Turns `DialogOutdated` into a notification and a closed dialog.
+
+    Installed as an inner middleware of the dialogs router, so it wraps every
+    dialog handler - including the window getters, which run inside `show()`
+    and therefore cannot close the dialog themselves.
+    """
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        try:
+            return await handler(event, data)
+        except DialogOutdated as e:
+            logger.info("dialog is outdated: %s", e.text, exc_info=e)
+            await self._notify(event, e)
+            await self._close(data.get(MANAGER_KEY))
+            return None
+
+    async def _notify(self, event: TelegramObject, e: DialogOutdated) -> None:
+        if isinstance(event, CallbackQuery):
+            await event.answer(e.notify_user, show_alert=True)
+        elif isinstance(event, Message):
+            await event.answer(e.notify_user)
+
+    async def _close(self, manager: DialogManager | None) -> None:
+        if manager is None or not manager.has_context():
+            return
+        await manager.done()

--- a/shvatka/tgbot/dialogs/outdated.py
+++ b/shvatka/tgbot/dialogs/outdated.py
@@ -9,8 +9,9 @@ option.
 
 `DialogOutdated`, raised from a getter or a handler, is how a dialog says "what
 I was opened for is gone". `OutdatedDialogMiddleware` catches it, tells the user
-what happened and closes the dialog, so they land back in a window built from
-current data instead of seeing an `assert` blow up.
+what happened and drops them back into the main menu, which is built out of
+current data - instead of an `assert` blowing up or a window rendering around a
+team that isn't there.
 """
 
 import logging
@@ -19,12 +20,15 @@ from typing import Any
 
 from aiogram import BaseMiddleware
 from aiogram.types import CallbackQuery, Message, TelegramObject
-from aiogram_dialog import DialogManager
+from aiogram_dialog import DialogManager, StartMode
 from aiogram_dialog.manager.manager_middleware import MANAGER_KEY
 
-from shvatka.core.interfaces.dal.player import PlayerTeamChecker, TeamPlayerGetter
+from shvatka.core.interfaces.dal.player import TeamPlayerGetter
+from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
-from shvatka.core.players.player import get_full_team_player_or_none, get_my_team
+from shvatka.core.players.player import get_full_team_player_or_none
+from shvatka.core.utils.exceptions import PlayerNotInTeam
+from shvatka.tgbot import states
 
 logger = logging.getLogger(__name__)
 
@@ -45,22 +49,17 @@ class DialogOutdated(Exception):
         self.text = text or notify_user
 
 
-async def get_actual_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.Team:
-    """The team the player belongs to right now, whatever the window shows."""
-    team = await get_my_team(player=player, dao=dao)
-    if team is None:
-        raise DialogOutdated(NOT_IN_TEAM, f"player {player.id} is not in a team anymore")
-    return team
+async def get_actual_team_player(identity: IdentityProvider) -> dto.FullTeamPlayer:
+    """The acting player's membership as it is right now, `.team` included.
 
-
-async def get_actual_team_player(
-    player: dto.Player, team: dto.Team, dao: TeamPlayerGetter
-) -> dto.FullTeamPlayer:
-    """The acting player's own membership in `team`, as it is right now."""
-    team_player = await get_full_team_player_or_none(player=player, team=team, dao=dao)
-    if team_player is None:
-        raise DialogOutdated(NOT_IN_TEAM, f"player {player.id} is not in team {team.id} anymore")
-    return team_player
+    The window was rendered against whatever `IdentityProvider` answered back
+    then; this asks it again, and turns "not in a team" from a domain error
+    into "this window is stale".
+    """
+    try:
+        return await identity.get_required_full_team_player()
+    except PlayerNotInTeam as e:
+        raise DialogOutdated(NOT_IN_TEAM, f"player {e.player_id} is not in a team anymore") from e
 
 
 async def get_actual_teammate(
@@ -71,6 +70,7 @@ async def get_actual_teammate(
     Guards the "selected player" of the captain's bridge: by the time the
     captain presses a button the player may have left, or even joined another
     team - and acting on their current membership would touch the wrong team.
+    `IdentityProvider` only knows the acting player, so this one takes the dao.
     """
     team_player = await get_full_team_player_or_none(player=teammate, team=team, dao=dao)
     if team_player is None:
@@ -81,11 +81,11 @@ async def get_actual_teammate(
 
 
 class OutdatedDialogMiddleware(BaseMiddleware):
-    """Turns `DialogOutdated` into a notification and a closed dialog.
+    """Turns `DialogOutdated` into a notification and a fresh main menu.
 
     Installed as an inner middleware of the dialogs router, so it wraps every
     dialog handler - including the window getters, which run inside `show()`
-    and therefore cannot close the dialog themselves.
+    and therefore cannot end the dialog themselves.
     """
 
     async def __call__(
@@ -99,7 +99,7 @@ class OutdatedDialogMiddleware(BaseMiddleware):
         except DialogOutdated as e:
             logger.info("dialog is outdated: %s", e.text, exc_info=e)
             await self._notify(event, e)
-            await self._close(data.get(MANAGER_KEY))
+            await self._restart(data.get(MANAGER_KEY))
             return None
 
     async def _notify(self, event: TelegramObject, e: DialogOutdated) -> None:
@@ -108,7 +108,13 @@ class OutdatedDialogMiddleware(BaseMiddleware):
         elif isinstance(event, Message):
             await event.answer(e.notify_user)
 
-    async def _close(self, manager: DialogManager | None) -> None:
-        if manager is None or not manager.has_context():
+    async def _restart(self, manager: DialogManager | None) -> None:
+        """Drop the whole stack, not just the broken dialog.
+
+        Whatever the dialogs below kept in their `dialog_data` was captured
+        against the same state that just turned out to be gone, so returning
+        into one of them only moves the problem one window down.
+        """
+        if manager is None:
             return
-        await manager.done()
+        await manager.start(states.MainMenuSG.main, mode=StartMode.RESET_STACK)

--- a/shvatka/tgbot/dialogs/team_manage/getters.py
+++ b/shvatka/tgbot/dialogs/team_manage/getters.py
@@ -8,34 +8,23 @@ from dishka.integrations.aiogram_dialog import inject
 from shvatka.core.players.player import get_team_players
 from shvatka.core.views.texts import PERMISSION_EMOJI
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.tgbot.dialogs.outdated import (
-    get_actual_team,
-    get_actual_team_player,
-    get_actual_teammate,
-)
+from shvatka.tgbot.dialogs.outdated import get_actual_team_player, get_actual_teammate
 
 
 @inject
-async def get_my_team_(
-    dao: HolderDao, identity: FromDishka[IdentityProvider], **_
-) -> dict[str, Any]:
-    player = await identity.get_required_player()
-    team = await get_actual_team(player, dao.team_player)
-    return {
-        "team": team,
-        "team_player": await get_actual_team_player(player, team, dao.team_player),
-    }
+async def get_my_team_(identity: FromDishka[IdentityProvider], **_) -> dict[str, Any]:
+    team_player = await get_actual_team_player(identity)
+    return {"team": team_player.team, "team_player": team_player}
 
 
 @inject
 async def get_team_with_players(
     dao: HolderDao, identity: FromDishka[IdentityProvider], **_
 ) -> dict[str, Any]:
-    player = await identity.get_required_player()
-    team = await get_actual_team(player, dao.team_player)
-    team_player = await get_actual_team_player(player, team, dao.team_player)
+    team_player = await get_actual_team_player(identity)
+    team = team_player.team
     players = await get_team_players(team=team, dao=dao.team_player)
-    excluded = [player.id]
+    excluded = [team_player.player.id]
     if team.captain:
         excluded.append(team.captain.id)
     return {
@@ -52,9 +41,8 @@ async def get_selected_player(
     identity: FromDishka[IdentityProvider],
     **_,
 ):
-    player = await identity.get_required_player()
-    team = await get_actual_team(player, dao.team_player)
-    team_player = await get_actual_team_player(player, team, dao.team_player)
+    team_player = await get_actual_team_player(identity)
+    team = team_player.team
     selected_player = await dao.player.get_by_id(dialog_manager.dialog_data["selected_player_id"])
     selected_team_player = await get_actual_teammate(selected_player, team, dao.team_player)
     return {

--- a/shvatka/tgbot/dialogs/team_manage/getters.py
+++ b/shvatka/tgbot/dialogs/team_manage/getters.py
@@ -5,10 +5,14 @@ from aiogram_dialog import DialogManager
 from shvatka.core.interfaces.identity import IdentityProvider
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
-from shvatka.core.players.player import get_full_team_player, get_my_team, get_team_players
-from shvatka.core.utils.exceptions import PlayerNotInTeam
+from shvatka.core.players.player import get_team_players
 from shvatka.core.views.texts import PERMISSION_EMOJI
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.tgbot.dialogs.outdated import (
+    get_actual_team,
+    get_actual_team_player,
+    get_actual_teammate,
+)
 
 
 @inject
@@ -16,13 +20,11 @@ async def get_my_team_(
     dao: HolderDao, identity: FromDishka[IdentityProvider], **_
 ) -> dict[str, Any]:
     player = await identity.get_required_player()
-    try:
-        team = await get_my_team(player=player, dao=dao.team_player)
-        team_player = await get_full_team_player(player=player, team=team, dao=dao.team_player)
-    except PlayerNotInTeam:
-        team = None
-        team_player = None
-    return {"team": team, "team_player": team_player}
+    team = await get_actual_team(player, dao.team_player)
+    return {
+        "team": team,
+        "team_player": await get_actual_team_player(player, team, dao.team_player),
+    }
 
 
 @inject
@@ -30,9 +32,8 @@ async def get_team_with_players(
     dao: HolderDao, identity: FromDishka[IdentityProvider], **_
 ) -> dict[str, Any]:
     player = await identity.get_required_player()
-    team = await get_my_team(player=player, dao=dao.team_player)
-    assert team
-    team_player = await get_full_team_player(player=player, team=team, dao=dao.team_player)
+    team = await get_actual_team(player, dao.team_player)
+    team_player = await get_actual_team_player(player, team, dao.team_player)
     players = await get_team_players(team=team, dao=dao.team_player)
     excluded = [player.id]
     if team.captain:
@@ -52,10 +53,10 @@ async def get_selected_player(
     **_,
 ):
     player = await identity.get_required_player()
-    team = await get_my_team(player=player, dao=dao.team_player)
-    team_player = await get_full_team_player(player=player, team=team, dao=dao.team_player)
+    team = await get_actual_team(player, dao.team_player)
+    team_player = await get_actual_team_player(player, team, dao.team_player)
     selected_player = await dao.player.get_by_id(dialog_manager.dialog_data["selected_player_id"])
-    selected_team_player = await get_full_team_player(selected_player, team, dao.team_player)
+    selected_team_player = await get_actual_teammate(selected_player, team, dao.team_player)
     return {
         "selected_player": selected_player,
         "selected_team_player": selected_team_player,

--- a/shvatka/tgbot/dialogs/team_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/team_manage/handlers.py
@@ -1,4 +1,3 @@
-import logging
 import typing
 from typing import Any
 
@@ -13,10 +12,7 @@ from dishka.integrations.aiogram_dialog import inject
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import enums
 from shvatka.core.players.player import (
-    get_my_team,
-    get_full_team_player,
     flip_permission,
-    get_team_player_by_player,
     get_player_by_id,
     leave,
     change_role,
@@ -34,11 +30,14 @@ from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot import keyboards as kb
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.outdated import (
+    get_actual_team,
+    get_actual_team_player,
+    get_actual_teammate,
+)
 from shvatka.tgbot.utils.data import SHMiddlewareData
 from shvatka.tgbot.views.errors import player_already_in_team
 from shvatka.tgbot.views.utils import total_remove_msg
-
-logger = logging.getLogger(__name__)
 
 
 @inject
@@ -51,12 +50,8 @@ async def rename_team_handler(
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
     player = await identity.get_required_player()
-    team = await get_my_team(player=player, dao=dao.team_player)
-    if not team:
-        logger.warning("player %s has no team", player.id)
-        await dialog_manager.done()
-        return
-    team_player = await get_full_team_player(player=player, team=team, dao=dao.team_player)
+    team = await get_actual_team(player, dao.team_player)
+    team_player = await get_actual_team_player(player, team, dao.team_player)
     await rename_team(team=team, captain=team_player, new_name=new_name, dao=dao.team)
 
 
@@ -70,12 +65,8 @@ async def change_desc_team_handler(
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
     player = await identity.get_required_player()
-    team = await get_my_team(player=player, dao=dao.team_player)
-    if team is None:
-        logger.warning("player %s has no team", player.id)
-        await dialog_manager.done()
-        return
-    team_player = await get_full_team_player(player=player, team=team, dao=dao.team_player)
+    team = await get_actual_team(player, dao.team_player)
+    team_player = await get_actual_team_player(player, team, dao.team_player)
     await change_team_desc(team=team, captain=team_player, new_desc=new_desc, dao=dao.team)
 
 
@@ -95,11 +86,13 @@ async def change_permission_handler(
     await c.answer()
     dao: HolderDao = manager.middleware_data["dao"]
     captain = await identity.get_required_player()
-    team = await get_my_team(captain, dao.team_player)
-    captain_team_player = await get_full_team_player(captain, team, dao.team_player)
+    team = await get_actual_team(captain, dao.team_player)
+    captain_team_player = await get_actual_team_player(captain, team, dao.team_player)
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    team_player = await get_team_player_by_player(player, dao.team_player)
+    # by their own membership the player may already be in another team -
+    # take the one in the captain's team, or say the window is outdated
+    team_player = await get_actual_teammate(player, team, dao.team_player)
     assert button.widget_id
     permission = enums.TeamPlayerPermission[button.widget_id]
     await flip_permission(captain_team_player, team_player, permission, dao.team_player)
@@ -115,8 +108,7 @@ async def start_merge(
     data = typing.cast(SHMiddlewareData, manager.middleware_data)
     dao = data["dao"]
     captain = await identity.get_required_player()
-    team = await get_my_team(captain, dao.team_player)
-    assert team
+    team = await get_actual_team(captain, dao.team_player)
     await manager.start(states.MergeTeamsSG.main, data={"team_id": team.id})
 
 
@@ -131,8 +123,10 @@ async def remove_player_handler(
     await c.answer()
     dao: HolderDao = manager.middleware_data["dao"]
     captain = await identity.get_required_player()
+    team = await get_actual_team(captain, dao.team_player)
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
+    await get_actual_teammate(player, team, dao.team_player)
     await leave(player=player, remover=captain, dao=dao.team_leaver, notifier=team_notifier)
     await manager.switch_to(state=states.CaptainsBridgeSG.players)
 
@@ -149,11 +143,8 @@ async def change_role_handler(
     captain = await identity.get_required_player()
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    team = await get_my_team(captain, dao.team_player)
-    if team is None:
-        logger.warning("player %s has no team", captain.id)
-        await manager.done()
-        return
+    team = await get_actual_team(captain, dao.team_player)
+    await get_actual_teammate(player, team, dao.team_player)
     await change_role(player, team, captain, role, dao.team_player)
     await manager.switch_to(states.CaptainsBridgeSG.player)
 
@@ -170,11 +161,8 @@ async def change_emoji_handler(
     captain = await identity.get_required_player()
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    team = await get_my_team(captain, dao.team_player)
-    if team is None:
-        logger.warning("player %s has no team", captain.id)
-        await manager.done()
-        return
+    team = await get_actual_team(captain, dao.team_player)
+    await get_actual_teammate(player, team, dao.team_player)
     await change_emoji(player, team, captain, emoji, dao.team_player)
     await manager.switch_to(states.CaptainsBridgeSG.player)
 
@@ -205,10 +193,8 @@ async def gotten_chat_request(
     target_id = m.chat_shared.chat_id
     dao: HolderDao = manager.middleware_data["dao"]
     captain = await identity.get_required_player()
-    team = await get_my_team(captain, dao.team_player)
-    assert team
+    team = await get_actual_team(captain, dao.team_player)
     old_chat_id = team.get_chat_id()
-    assert team
     try:
         chat = await dao.chat.get_by_tg_id(tg_id=target_id)
     except exceptions.ChatNotFound:
@@ -224,7 +210,7 @@ async def gotten_chat_request(
             disable_web_page_preview=True,
         )
         return
-    team_player = await get_full_team_player(player=captain, team=team, dao=dao.team_player)
+    team_player = await get_actual_team_player(captain, team, dao.team_player)
     bot: Bot = manager.middleware_data["bot"]
     try:
         await change_chat(team, team_player, chat, dao.chat)
@@ -269,8 +255,7 @@ async def gotten_user_request(
         raise RuntimeError("only user shared and contact are allowed")
     dao: HolderDao = manager.middleware_data["dao"]
     captain = await identity.get_required_player()
-    team = await get_my_team(captain, dao.team_player)
-    assert team
+    team = await get_actual_team(captain, dao.team_player)
     player = await get_player_by_user_id(target_id, dao.player)
     bot: Bot = manager.middleware_data["bot"]
     chat = await identity.get_required_chat()

--- a/shvatka/tgbot/dialogs/team_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/team_manage/handlers.py
@@ -1,4 +1,3 @@
-import typing
 from typing import Any
 
 from aiogram import Bot
@@ -30,12 +29,7 @@ from shvatka.core.utils import exceptions
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot import keyboards as kb
 from shvatka.tgbot import states
-from shvatka.tgbot.dialogs.outdated import (
-    get_actual_team,
-    get_actual_team_player,
-    get_actual_teammate,
-)
-from shvatka.tgbot.utils.data import SHMiddlewareData
+from shvatka.tgbot.dialogs.outdated import get_actual_team_player, get_actual_teammate
 from shvatka.tgbot.views.errors import player_already_in_team
 from shvatka.tgbot.views.utils import total_remove_msg
 
@@ -49,10 +43,8 @@ async def rename_team_handler(
     identity: FromDishka[IdentityProvider],
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
-    player = await identity.get_required_player()
-    team = await get_actual_team(player, dao.team_player)
-    team_player = await get_actual_team_player(player, team, dao.team_player)
-    await rename_team(team=team, captain=team_player, new_name=new_name, dao=dao.team)
+    team_player = await get_actual_team_player(identity)
+    await rename_team(team=team_player.team, captain=team_player, new_name=new_name, dao=dao.team)
 
 
 @inject
@@ -64,10 +56,10 @@ async def change_desc_team_handler(
     identity: FromDishka[IdentityProvider],
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
-    player = await identity.get_required_player()
-    team = await get_actual_team(player, dao.team_player)
-    team_player = await get_actual_team_player(player, team, dao.team_player)
-    await change_team_desc(team=team, captain=team_player, new_desc=new_desc, dao=dao.team)
+    team_player = await get_actual_team_player(identity)
+    await change_team_desc(
+        team=team_player.team, captain=team_player, new_desc=new_desc, dao=dao.team
+    )
 
 
 async def select_player(c: CallbackQuery, widget: Any, manager: DialogManager, player_id: str):
@@ -85,9 +77,8 @@ async def change_permission_handler(
 ):
     await c.answer()
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
-    team = await get_actual_team(captain, dao.team_player)
-    captain_team_player = await get_actual_team_player(captain, team, dao.team_player)
+    captain_team_player = await get_actual_team_player(identity)
+    team = captain_team_player.team
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
     # by their own membership the player may already be in another team -
@@ -105,10 +96,7 @@ async def start_merge(
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
 ):
-    data = typing.cast(SHMiddlewareData, manager.middleware_data)
-    dao = data["dao"]
-    captain = await identity.get_required_player()
-    team = await get_actual_team(captain, dao.team_player)
+    team = (await get_actual_team_player(identity)).team
     await manager.start(states.MergeTeamsSG.main, data={"team_id": team.id})
 
 
@@ -122,12 +110,16 @@ async def remove_player_handler(
 ):
     await c.answer()
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
-    team = await get_actual_team(captain, dao.team_player)
+    captain_team_player = await get_actual_team_player(identity)
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    await get_actual_teammate(player, team, dao.team_player)
-    await leave(player=player, remover=captain, dao=dao.team_leaver, notifier=team_notifier)
+    await get_actual_teammate(player, captain_team_player.team, dao.team_player)
+    await leave(
+        player=player,
+        remover=captain_team_player.player,
+        dao=dao.team_leaver,
+        notifier=team_notifier,
+    )
     await manager.switch_to(state=states.CaptainsBridgeSG.players)
 
 
@@ -140,12 +132,12 @@ async def change_role_handler(
     identity: FromDishka[IdentityProvider],
 ):
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
+    captain_team_player = await get_actual_team_player(identity)
+    team = captain_team_player.team
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    team = await get_actual_team(captain, dao.team_player)
     await get_actual_teammate(player, team, dao.team_player)
-    await change_role(player, team, captain, role, dao.team_player)
+    await change_role(player, team, captain_team_player.player, role, dao.team_player)
     await manager.switch_to(states.CaptainsBridgeSG.player)
 
 
@@ -158,12 +150,12 @@ async def change_emoji_handler(
     identity: FromDishka[IdentityProvider],
 ):
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
+    captain_team_player = await get_actual_team_player(identity)
+    team = captain_team_player.team
     player_id = manager.dialog_data["selected_player_id"]
     player = await get_player_by_id(player_id, dao.player)
-    team = await get_actual_team(captain, dao.team_player)
     await get_actual_teammate(player, team, dao.team_player)
-    await change_emoji(player, team, captain, emoji, dao.team_player)
+    await change_emoji(player, team, captain_team_player.player, emoji, dao.team_player)
     await manager.switch_to(states.CaptainsBridgeSG.player)
 
 
@@ -192,8 +184,9 @@ async def gotten_chat_request(
     assert m.chat_shared
     target_id = m.chat_shared.chat_id
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
-    team = await get_actual_team(captain, dao.team_player)
+    team_player = await get_actual_team_player(identity)
+    captain = team_player.player
+    team = team_player.team
     old_chat_id = team.get_chat_id()
     try:
         chat = await dao.chat.get_by_tg_id(tg_id=target_id)
@@ -210,7 +203,6 @@ async def gotten_chat_request(
             disable_web_page_preview=True,
         )
         return
-    team_player = await get_actual_team_player(captain, team, dao.team_player)
     bot: Bot = manager.middleware_data["bot"]
     try:
         await change_chat(team, team_player, chat, dao.chat)
@@ -254,8 +246,9 @@ async def gotten_user_request(
     else:
         raise RuntimeError("only user shared and contact are allowed")
     dao: HolderDao = manager.middleware_data["dao"]
-    captain = await identity.get_required_player()
-    team = await get_actual_team(captain, dao.team_player)
+    captain_team_player = await get_actual_team_player(identity)
+    captain = captain_team_player.player
+    team = captain_team_player.team
     player = await get_player_by_user_id(target_id, dao.player)
     bot: Bot = manager.middleware_data["bot"]
     chat = await identity.get_required_chat()

--- a/shvatka/tgbot/dialogs/team_view/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_view/dialogs.py
@@ -3,13 +3,12 @@ from aiogram_dialog.widgets.kbd import ScrollingGroup, Select, Cancel, SwitchTo,
 from aiogram_dialog.widgets.text import Const, Format, Jinja, Case
 
 from shvatka.tgbot import states
-from .getters import teams_getter, team_getter, filter_getter
+from .getters import teams_getter, team_getter, my_team_getter, filter_getter
 from .handlers import (
     select_team,
     select_player,
     change_active_filter,
     change_archive_filter,
-    on_start_my_team,
     on_leave_team,
 )
 from shvatka.tgbot.dialogs.common import BOOL_VIEW
@@ -100,9 +99,8 @@ my_team_view = Dialog(
         ),
         Button(Const("☄️Выйти из команды"), id="leave_team", on_click=on_leave_team),
         Cancel(Const("🔙Назад")),
-        getter=team_getter,
+        getter=my_team_getter,
         state=states.MyTeamSg.team,
         preview_data=PREVIEW_TEAM_CARD,
     ),
-    on_start=on_start_my_team,
 )

--- a/shvatka/tgbot/dialogs/team_view/getters.py
+++ b/shvatka/tgbot/dialogs/team_view/getters.py
@@ -1,9 +1,15 @@
-from aiogram_dialog import DialogManager
+from typing import Any
 
+from aiogram_dialog import DialogManager
+from dishka import FromDishka
+from dishka.integrations.aiogram_dialog import inject
+
+from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.players.player import get_team_players
 from shvatka.core.services.team import get_teams, get_team_by_id, get_played_games
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.tgbot.dialogs.outdated import get_actual_team
 from .common import get_active_filter, get_archive_filter
 
 
@@ -23,7 +29,22 @@ async def teams_getter(
 
 async def team_getter(dao: HolderDao, dialog_manager: DialogManager, **_):
     team_id: int = dialog_manager.dialog_data["team_id"]
-    team = await get_team_by_id(team_id, dao.team)
+    return await team_card(await get_team_by_id(team_id, dao.team), dao)
+
+
+@inject
+async def my_team_getter(dao: HolderDao, identity: FromDishka[IdentityProvider], **_):
+    """The card of the team the player is in *at this moment*.
+
+    Deliberately resolved on every render instead of remembering a team id when
+    the dialog started: between the two the player may have been removed from
+    the team, and then there is no card to show at all.
+    """
+    player = await identity.get_required_player()
+    return await team_card(await get_actual_team(player, dao.team_player), dao)
+
+
+async def team_card(team: dto.Team, dao: HolderDao) -> dict[str, Any]:
     players = await get_team_players(team=team, dao=dao.team_player)
     games = await get_played_games(team=team, dao=dao.team)
     games_numbers = [str(game.number) for game in games]

--- a/shvatka/tgbot/dialogs/team_view/getters.py
+++ b/shvatka/tgbot/dialogs/team_view/getters.py
@@ -9,7 +9,7 @@ from shvatka.core.models import dto
 from shvatka.core.players.player import get_team_players
 from shvatka.core.services.team import get_teams, get_team_by_id, get_played_games
 from shvatka.infrastructure.db.dao.holder import HolderDao
-from shvatka.tgbot.dialogs.outdated import get_actual_team
+from shvatka.tgbot.dialogs.outdated import get_actual_team_player
 from .common import get_active_filter, get_archive_filter
 
 
@@ -40,8 +40,7 @@ async def my_team_getter(dao: HolderDao, identity: FromDishka[IdentityProvider],
     the dialog started: between the two the player may have been removed from
     the team, and then there is no card to show at all.
     """
-    player = await identity.get_required_player()
-    return await team_card(await get_actual_team(player, dao.team_player), dao)
+    return await team_card((await get_actual_team_player(identity)).team, dao)
 
 
 async def team_card(team: dto.Team, dao: HolderDao) -> dict[str, Any]:

--- a/shvatka/tgbot/dialogs/team_view/handlers.py
+++ b/shvatka/tgbot/dialogs/team_view/handlers.py
@@ -7,10 +7,11 @@ from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
 from shvatka.core.interfaces.identity import IdentityProvider
-from shvatka.core.players.player import get_my_team, leave
+from shvatka.core.players.player import leave
 from shvatka.core.views.team import TeamNotifier
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.outdated import get_actual_team
 from shvatka.tgbot.dialogs.team_view.common import get_active_filter, get_archive_filter
 
 
@@ -41,16 +42,6 @@ async def on_leave_team(
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
     player = await identity.get_required_player()
+    await get_actual_team(player, dao.team_player)
     await leave(player, player, dao.team_leaver, notifier=team_notifier)
     await dialog_manager.done()
-
-
-@inject
-async def on_start_my_team(
-    start_data: dict, manager: DialogManager, identity: FromDishka[IdentityProvider]
-) -> None:
-    dao: HolderDao = manager.middleware_data["dao"]
-    player = await identity.get_required_player()
-    team = await get_my_team(player=player, dao=dao.team_player)
-    assert team
-    manager.dialog_data["team_id"] = team.id

--- a/shvatka/tgbot/dialogs/team_view/handlers.py
+++ b/shvatka/tgbot/dialogs/team_view/handlers.py
@@ -11,7 +11,7 @@ from shvatka.core.players.player import leave
 from shvatka.core.views.team import TeamNotifier
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot import states
-from shvatka.tgbot.dialogs.outdated import get_actual_team
+from shvatka.tgbot.dialogs.outdated import get_actual_team_player
 from shvatka.tgbot.dialogs.team_view.common import get_active_filter, get_archive_filter
 
 
@@ -41,7 +41,6 @@ async def on_leave_team(
     team_notifier: FromDishka[TeamNotifier],
 ):
     dao: HolderDao = dialog_manager.middleware_data["dao"]
-    player = await identity.get_required_player()
-    await get_actual_team(player, dao.team_player)
+    player = (await get_actual_team_player(identity)).player
     await leave(player, player, dao.team_leaver, notifier=team_notifier)
     await dialog_manager.done()

--- a/tests/integration/bot_full/test_outdated_dialog.py
+++ b/tests/integration/bot_full/test_outdated_dialog.py
@@ -1,0 +1,124 @@
+"""A dialog opened before the player left the team must not crash on a click.
+
+Between opening a window and pressing a button in it any amount of time may
+pass - the captain can remove the player meanwhile. See issue #339.
+"""
+
+import typing
+from unittest.mock import MagicMock
+
+import pytest
+from aiogram import Bot, Dispatcher
+from aiogram.client.session.base import BaseSession
+from aiogram.methods import AnswerCallbackQuery
+from aiogram_dialog.test_tools import BotClient, MockMessageManager
+from aiogram_dialog.test_tools.keyboard import InlineButtonTextLocator
+
+from shvatka.core.models import dto
+from shvatka.core.models import enums
+from shvatka.core.players.player import (
+    flip_permission,
+    get_full_team_player,
+    join_team,
+    leave,
+)
+from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.tgbot.dialogs.outdated import NOT_IN_TEAM
+from shvatka.tgbot.views.commands import START_COMMAND
+from tests.fixtures.chat_constants import create_tg_chat
+from tests.fixtures.user_constants import create_tg_from_dto
+from tests.mocks.team_notifier import TeamNotifierMock
+
+MY_TEAM_BUTTON = "🚩Моя команда"
+MANAGE_TEAM_BUTTON = "🚩Управление командой"
+PLAYERS_BUTTON = "👥Игроки"
+
+
+@pytest.fixture
+def hermione_client(hermione: dto.Player, dp: Dispatcher, bot: Bot) -> BotClient:
+    client = BotClient(dp, bot=bot)
+    client.user = create_tg_from_dto(hermione._user)
+    client.chat = create_tg_chat(
+        id_=client.user.id,
+        type_=enums.ChatType.private,
+        first_name=client.user.first_name,
+        last_name=client.user.last_name,
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_my_team_opened_after_removed_from_team(
+    harry: dto.Player,
+    hermione: dto.Player,
+    gryffindor: dto.Team,
+    hermione_client: BotClient,
+    message_manager: MockMessageManager,
+    bot_session: BaseSession,
+    dao: HolderDao,
+):
+    await join_team(hermione, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
+    main_menu = await open_main_menu(hermione_client, message_manager)
+
+    await leave(player=hermione, remover=harry, dao=dao.team_leaver, notifier=TeamNotifierMock())
+
+    message_manager.reset_history()
+    await hermione_client.click(main_menu, InlineButtonTextLocator(MY_TEAM_BUTTON))
+
+    assert_answered_with(bot_session, NOT_IN_TEAM)
+    # the dialog is closed, so the main menu is shown again - without the button
+    assert find_button(message_manager.last_message(), MY_TEAM_BUTTON) is None
+
+
+@pytest.mark.asyncio
+async def test_captains_bridge_opened_after_removed_from_team(
+    harry: dto.Player,
+    hermione: dto.Player,
+    gryffindor: dto.Team,
+    hermione_client: BotClient,
+    message_manager: MockMessageManager,
+    bot_session: BaseSession,
+    dao: HolderDao,
+):
+    await join_team(hermione, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
+    await flip_permission(
+        actor=await get_full_team_player(harry, gryffindor, dao.team_player),
+        team_player=await get_full_team_player(hermione, gryffindor, dao.team_player),
+        permission=enums.TeamPlayerPermission.can_manage_players,
+        dao=dao.team_player,
+    )
+    main_menu = await open_main_menu(hermione_client, message_manager)
+
+    message_manager.reset_history()
+    await hermione_client.click(main_menu, InlineButtonTextLocator(MANAGE_TEAM_BUTTON))
+    captains_bridge = message_manager.last_message()
+
+    await leave(player=hermione, remover=harry, dao=dao.team_leaver, notifier=TeamNotifierMock())
+
+    message_manager.reset_history()
+    await hermione_client.click(captains_bridge, InlineButtonTextLocator(PLAYERS_BUTTON))
+
+    assert_answered_with(bot_session, NOT_IN_TEAM)
+    assert find_button(message_manager.last_message(), PLAYERS_BUTTON) is None
+
+
+async def open_main_menu(client: BotClient, message_manager: MockMessageManager):
+    message_manager.reset_history()
+    await client.send("/" + START_COMMAND.command)
+    return message_manager.last_message()
+
+
+def find_button(message, text: str):
+    return InlineButtonTextLocator(text).find_button(message)
+
+
+def assert_answered_with(bot_session: BaseSession, text: str) -> None:
+    session = typing.cast(MagicMock, bot_session)
+    answers = [
+        arg
+        for call in session.await_args_list
+        for arg in list(call.args) + list(call.kwargs.values())
+        if isinstance(arg, AnswerCallbackQuery)
+    ]
+    assert [answer.text for answer in answers] == [text]
+    assert answers[0].show_alert

--- a/tests/integration/bot_full/test_outdated_dialog.py
+++ b/tests/integration/bot_full/test_outdated_dialog.py
@@ -11,6 +11,7 @@ import pytest
 from aiogram import Bot, Dispatcher
 from aiogram.client.session.base import BaseSession
 from aiogram.methods import AnswerCallbackQuery
+from aiogram.types import Message
 from aiogram_dialog.test_tools import BotClient, MockMessageManager
 from aiogram_dialog.test_tools.keyboard import InlineButtonTextLocator
 
@@ -32,6 +33,8 @@ from tests.mocks.team_notifier import TeamNotifierMock
 MY_TEAM_BUTTON = "🚩Моя команда"
 MANAGE_TEAM_BUTTON = "🚩Управление командой"
 PLAYERS_BUTTON = "👥Игроки"
+# always in the main menu, whether the player has a team or not
+TEAMS_BUTTON = "👥Команды"
 
 
 @pytest.fixture
@@ -66,8 +69,7 @@ async def test_my_team_opened_after_removed_from_team(
     await hermione_client.click(main_menu, InlineButtonTextLocator(MY_TEAM_BUTTON))
 
     assert_answered_with(bot_session, NOT_IN_TEAM)
-    # the dialog is closed, so the main menu is shown again - without the button
-    assert find_button(message_manager.last_message(), MY_TEAM_BUTTON) is None
+    assert_main_menu_without(message_manager.last_message(), MY_TEAM_BUTTON)
 
 
 @pytest.mark.asyncio
@@ -99,7 +101,7 @@ async def test_captains_bridge_opened_after_removed_from_team(
     await hermione_client.click(captains_bridge, InlineButtonTextLocator(PLAYERS_BUTTON))
 
     assert_answered_with(bot_session, NOT_IN_TEAM)
-    assert find_button(message_manager.last_message(), PLAYERS_BUTTON) is None
+    assert_main_menu_without(message_manager.last_message(), PLAYERS_BUTTON)
 
 
 async def open_main_menu(client: BotClient, message_manager: MockMessageManager):
@@ -108,8 +110,10 @@ async def open_main_menu(client: BotClient, message_manager: MockMessageManager)
     return message_manager.last_message()
 
 
-def find_button(message, text: str):
-    return InlineButtonTextLocator(text).find_button(message)
+def assert_main_menu_without(message: Message, gone: str) -> None:
+    """The user is dropped into a menu built from current data."""
+    assert InlineButtonTextLocator(TEAMS_BUTTON).find_button(message) is not None
+    assert InlineButtonTextLocator(gone).find_button(message) is None
 
 
 def assert_answered_with(bot_session: BaseSession, text: str) -> None:

--- a/tests/unit/test_outdated_dialog_middleware.py
+++ b/tests/unit/test_outdated_dialog_middleware.py
@@ -1,7 +1,8 @@
 """What happens when a dialog says the state it was opened for is gone.
 
-The user must learn why the window stopped working, and the window itself must
-go away - otherwise every next click hits the same dead state. See issue #339.
+The user must learn why the window stopped working, and must land somewhere
+built out of current data - otherwise every next click hits the same dead
+state. See issue #339.
 """
 
 from datetime import datetime
@@ -11,10 +12,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from aiogram import Router
 from aiogram.types import CallbackQuery, Chat, Message
-from aiogram_dialog import DialogManager, setup_dialogs
+from aiogram_dialog import DialogManager, StartMode, setup_dialogs
 from aiogram_dialog.manager.manager_middleware import MANAGER_KEY, ManagerMiddleware
 
 from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.tgbot import states
 from shvatka.tgbot.dialogs import setup_outdated_dialogs
 from shvatka.tgbot.dialogs.outdated import DialogOutdated, OutdatedDialogMiddleware
 from tests.fixtures.user_constants import create_tg_user
@@ -41,10 +43,14 @@ def create_message() -> Message:
     )
 
 
-def create_manager(has_context: bool = True) -> DialogManager:
-    manager = AsyncMock(DialogManager)
-    manager.has_context = lambda: has_context
-    return manager
+def create_manager() -> DialogManager:
+    return AsyncMock(DialogManager)
+
+
+def assert_main_menu_restarted(manager: DialogManager) -> None:
+    manager.start.assert_awaited_once_with(  # type: ignore[attr-defined]
+        states.MainMenuSG.main, mode=StartMode.RESET_STACK
+    )
 
 
 async def run(event: Any, manager: DialogManager | None) -> None:
@@ -56,35 +62,37 @@ async def run(event: Any, manager: DialogManager | None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_button_click_is_answered_with_alert_and_dialog_closed():
+async def test_button_click_is_answered_with_alert_and_menu_restarted():
     manager = create_manager()
 
     with patch.object(CallbackQuery, "answer", new_callable=AsyncMock) as answer:
         await run(create_callback(), manager)
 
     answer.assert_awaited_once_with(NOTIFY, show_alert=True)
-    manager.done.assert_awaited_once()
+    assert_main_menu_restarted(manager)
 
 
 @pytest.mark.asyncio
-async def test_typed_answer_is_replied_and_dialog_closed():
+async def test_typed_answer_is_replied_and_menu_restarted():
     manager = create_manager()
 
     with patch.object(Message, "answer", new_callable=AsyncMock) as answer:
         await run(create_message(), manager)
 
     answer.assert_awaited_once_with(NOTIFY)
-    manager.done.assert_awaited_once()
+    assert_main_menu_restarted(manager)
 
 
 @pytest.mark.asyncio
-async def test_nothing_to_close_when_the_dialog_is_already_gone():
-    manager = create_manager(has_context=False)
+async def test_dialogs_under_the_broken_one_are_dropped_too():
+    """They kept their own data from the same state that turned out to be gone."""
+    manager = create_manager()
 
     with patch.object(CallbackQuery, "answer", new_callable=AsyncMock):
         await run(create_callback(), manager)
 
     manager.done.assert_not_awaited()
+    assert_main_menu_restarted(manager)
 
 
 @pytest.mark.asyncio
@@ -97,7 +105,7 @@ async def test_user_is_still_notified_without_a_dialog_manager():
 
 @pytest.mark.parametrize("observer", ["callback_query", "message"])
 def test_installed_inside_the_aiogram_dialog_manager(observer: str):
-    """Without `dialog_manager` in the data there is nothing to close."""
+    """Without `dialog_manager` in the data there is no dialog to restart."""
     router = Router()
     setup_dialogs(router)
     setup_outdated_dialogs(router)

--- a/tests/unit/test_outdated_dialog_middleware.py
+++ b/tests/unit/test_outdated_dialog_middleware.py
@@ -1,0 +1,116 @@
+"""What happens when a dialog says the state it was opened for is gone.
+
+The user must learn why the window stopped working, and the window itself must
+go away - otherwise every next click hits the same dead state. See issue #339.
+"""
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiogram import Router
+from aiogram.types import CallbackQuery, Chat, Message
+from aiogram_dialog import DialogManager, setup_dialogs
+from aiogram_dialog.manager.manager_middleware import MANAGER_KEY, ManagerMiddleware
+
+from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.tgbot.dialogs import setup_outdated_dialogs
+from shvatka.tgbot.dialogs.outdated import DialogOutdated, OutdatedDialogMiddleware
+from tests.fixtures.user_constants import create_tg_user
+
+NOTIFY = "Ты больше не состоишь в команде"
+
+
+def create_callback() -> CallbackQuery:
+    return CallbackQuery(
+        id="1",
+        data="whatever",
+        chat_instance="--",
+        from_user=create_tg_user(),
+    )
+
+
+def create_message() -> Message:
+    return Message(
+        message_id=1,
+        date=datetime.fromtimestamp(1234567890, tz=tz_utc),
+        chat=Chat(id=1, type="private"),
+        from_user=create_tg_user(),
+        text="whatever",
+    )
+
+
+def create_manager(has_context: bool = True) -> DialogManager:
+    manager = AsyncMock(DialogManager)
+    manager.has_context = lambda: has_context
+    return manager
+
+
+async def run(event: Any, manager: DialogManager | None) -> None:
+    async def handler(_event: Any, _data: dict[str, Any]) -> None:
+        raise DialogOutdated(NOTIFY, "player 1 is not in a team anymore")
+
+    data: dict[str, Any] = {} if manager is None else {MANAGER_KEY: manager}
+    await OutdatedDialogMiddleware()(handler, event, data)
+
+
+@pytest.mark.asyncio
+async def test_button_click_is_answered_with_alert_and_dialog_closed():
+    manager = create_manager()
+
+    with patch.object(CallbackQuery, "answer", new_callable=AsyncMock) as answer:
+        await run(create_callback(), manager)
+
+    answer.assert_awaited_once_with(NOTIFY, show_alert=True)
+    manager.done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_typed_answer_is_replied_and_dialog_closed():
+    manager = create_manager()
+
+    with patch.object(Message, "answer", new_callable=AsyncMock) as answer:
+        await run(create_message(), manager)
+
+    answer.assert_awaited_once_with(NOTIFY)
+    manager.done.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_close_when_the_dialog_is_already_gone():
+    manager = create_manager(has_context=False)
+
+    with patch.object(CallbackQuery, "answer", new_callable=AsyncMock):
+        await run(create_callback(), manager)
+
+    manager.done.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_user_is_still_notified_without_a_dialog_manager():
+    with patch.object(CallbackQuery, "answer", new_callable=AsyncMock) as answer:
+        await run(create_callback(), None)
+
+    answer.assert_awaited_once_with(NOTIFY, show_alert=True)
+
+
+@pytest.mark.parametrize("observer", ["callback_query", "message"])
+def test_installed_inside_the_aiogram_dialog_manager(observer: str):
+    """Without `dialog_manager` in the data there is nothing to close."""
+    router = Router()
+    setup_dialogs(router)
+    setup_outdated_dialogs(router)
+
+    middlewares = list(router.observers[observer].middleware)
+    assert isinstance(middlewares[-1], OutdatedDialogMiddleware)
+    assert any(isinstance(m, ManagerMiddleware) for m in middlewares[:-1])
+
+
+@pytest.mark.asyncio
+async def test_other_errors_are_not_swallowed():
+    async def handler(_event: Any, _data: dict[str, Any]) -> None:
+        raise ValueError("something else")
+
+    with pytest.raises(ValueError, match="something else"):
+        await OutdatedDialogMiddleware()(handler, create_callback(), {})


### PR DESCRIPTION
Closes #339.

## The bug

A telegram window stays clickable forever, so the state a dialog was opened for can be gone by the time a button is pressed. Opening *🚩Моя команда* and pressing a button in it weeks later — after the captain removed the player — answered with an `AssertionError` on `assert team`, a dead button for the user and a traceback in the log chat.

The same shape was all over the team dialogs: `assert team` in `start_merge` / `gotten_chat_request` / `gotten_user_request`, `get_my_team_` returning `team=None` into a Jinja template that dereferences `team.name`, and a bare `done()` with no explanation in the rename / role / emoji handlers.

## The mechanism

`shvatka/tgbot/dialogs/outdated.py`:

- **`DialogOutdated`** — raised by a getter or a handler to say "what I was opened for is gone". Deliberately not an `SHError`: nothing went wrong in the domain, the window is simply old.
- **`OutdatedDialogMiddleware`** — an inner middleware of the dialogs router. Answers the callback query with an alert (or replies to the message, for `MessageInput`), then `manager.done()`.
- **`get_actual_team` / `get_actual_team_player` / `get_actual_teammate`** — guards that replace the hand-written checks, so each call site states which staleness it protects against.

Why a middleware and not an error handler: getters run inside `manager.show()` and cannot close a dialog themselves, and the catch-all handler on `dp.errors` wins propagation before any handler that would have a `dialog_manager` in its data. An inner middleware of a router wraps its sub-routers' handlers too, so one registration covers every dialog including getters. It has to be registered *after* `setup_dialogs` to sit inside aiogram_dialog's `ManagerMiddleware` — a unit test pins that ordering.

## Converted call sites

- `my_team_view` no longer captures a team id in `on_start`; `my_team_getter` resolves the current team on every render. Remembering an id and trusting it later is the bug this PR is about, so the dialog stopped doing it. The card body is shared with the public team view through `team_card()`.
- `captains_bridge` getters and handlers guard the acting player, their membership, and the selected player.

Also fixes a real mix-up found on the way: `change_permission_handler` took the selected player's *own* membership (`get_team_player_by_player`), so a player who had joined another team meanwhile would have had a permission flipped in that other team. It now resolves their membership in the captain's team.

## Tests

- `tests/unit/test_outdated_dialog_middleware.py` — notification and close for both callback and message events, no-context and no-manager cases, other exceptions pass through, and the middleware ordering invariant.
- `tests/integration/bot_full/test_outdated_dialog.py` — drives the real dispatcher with `BotClient`: opens the menu, removes the player from the team behind the dialog's back, clicks, and asserts the alert plus a re-rendered parent window without the stale button. Covers both the `on_start`-style path (my team) and the getter path (captain's bridge).

Docs: SHEP-0005 records the decision and the alternatives; `AGENTS.md` gets the rule that came out of it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GVMF9P95Jb6fq662kRgC4c)_