### PR TITLE
Stop counting one-shot scripts, put a floor under coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,21 @@ pytest tests            # everything (needs Docker for testcontainers)
 pytest tests/unit       # fast unit-only loop, no DB
 ```
 
+### Coverage
+
+`fail_under` in `[tool.coverage.report]` is the floor, and coverage itself
+enforces it — the CI `pytest --cov` step goes red below it. `branch = true`
+means the number counts branches next to statements, so one threshold guards
+both. Raise it as the number grows; don't lower it to turn a build green.
+Nothing enforces it locally unless you ask for coverage: the fast loop
+(`pytest tests/unit`) passes no `--cov`, so it never reports and never fails.
+
+`[tool.coverage.run] omit` in `pyproject.toml` drops what tests are never going
+to reach: the bot layer, alembic migrations, and **one-shot scripts** — the
+forum crawler (parsers, loader, uploader), the 0→1 scenario migration, and the
+maintenance scripts over prod data. New code of that kind belongs in the omit
+list with a comment saying why; everything else stays measured.
+
 ### What the suite can't see
 
 Changes to **middleware, DI wiring, filters, or how the acting user is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,36 @@ omit = [
     "shvatka/tgbot/*",
     "shvatka/infrastructure/db/migrations/*",
     "*/__main__.py",
+    # One-shot scripts: run by hand (or once, on a single deploy), talking to a
+    # foreign site or to prod data. They are not part of the product's
+    # behaviour and nobody is going to write tests for them, so measuring them
+    # only skews the numbers.
+    #
+    # the forum crawler: logs into the old engine, parses its HTML and uploads
+    # scenarios back. Its models/ stay measured — the DAO layer uses them.
+    "shvatka/infrastructure/crawler/auth.py",
+    "shvatka/infrastructure/crawler/constants.py",
+    "shvatka/infrastructure/crawler/factory.py",
+    "shvatka/infrastructure/crawler/retort.py",
+    "shvatka/infrastructure/crawler/game_scn/*",
+    "shvatka/infrastructure/crawler/teams/*",
+    # one-time migration of stored scenarios from format 0 to 1
+    "shvatka/core/migration_utils/*",
+    # maintenance scripts over prod data
+    "shvatka/infrastructure/empty_file_repairer.py",
+    "shvatka/infrastructure/file_id_updater.py",
+    "shvatka/infrastructure/stored_scn_checker.py",
 ]
 
 [tool.coverage.report]
+# The floor for the whole measured codebase. With branch = true this single
+# number covers both: coverage counts every branch as a measurable thing next
+# to the statements, so a PR that adds untested branches drags it down too.
+# The full suite gives ~80% today — raise this as the number grows, don't lower
+# it to make a red build green. It only applies where coverage runs at all, so
+# the fast local loop (pytest tests/unit, no --cov) is unaffected.
+fail_under = 78
+precision = 2
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",


### PR DESCRIPTION
## What

Two related changes to how coverage is measured and enforced.

**Ignore one-shot scripts** (`[tool.coverage.run] omit` in `pyproject.toml`).
They are run by hand — or once, on a single deploy — talk to a foreign site or
to prod data, and are never going to get tests:

- the forum crawler: `game_scn/*` (parser, loader, uploader), `teams/*`, plus
  `auth.py`, `constants.py`, `factory.py`, `retort.py`. Its `models/` stay
  measured, the DAO layer imports them.
- `core/migration_utils/*` — the one-time 0→1 scenario migration, imported from
  nowhere else.
- `infrastructure/empty_file_repairer.py`, `file_id_updater.py`,
  `stored_scn_checker.py` — maintenance scripts over prod data.

`player_username_updater.py` stays in, `tests/integration/test_player_username.py`
covers it.

**Enforce a minimum** with coverage's own `fail_under = 78` in
`[tool.coverage.report]`. No workflow changes: the CI `pytest --cov` step goes
red on its own below the floor, after `coverage.xml` is written, so the summary
/ comment / badge steps still publish.

`branch = true` makes one threshold guard both — coverage counts every branch
next to the statements, so a PR adding untested branches drags the total down
too.

## Numbers

Master reports 77% lines (11728/15270) and 46% branches (850/1844), 73.5%
total. Dropping the scripts removes 1244 statements and 248 branches,
essentially none of which were covered; the previous CI run on this branch
measured **83.36% lines (11692/14026)** and **53.26% branches (850/1596)** from
the same tests, i.e. 80.28% total — a couple of points of headroom over the
floor.

## Notes

- Nothing changes for the fast local loop: `pytest tests/unit` passes no
  `--cov`, so coverage never reports and never fails. `pytest --cov=shvatka
  tests/unit` on its own *will* fail the floor, by design — it's a partial run.
- `precision = 2` so the reported total isn't rounded up into passing.
- `AGENTS.md` gained a short *Coverage* section: where the floor lives, raise it
  rather than lower it, and what belongs in the omit list.