### PR TITLE
feat(game): hints of the passed levels

### DIFF
--- a/shvatka/api/games/responses.py
+++ b/shvatka/api/games/responses.py
@@ -15,6 +15,8 @@ from shvatka.core.games.dto import (
     Event,
     GameStatWithBonuses,
     MyRole,
+    PassedLevelHints,
+    PassedLevels,
 )
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import action, hints
@@ -329,6 +331,38 @@ class CurrentHintResponse:
             started_at=core.started_at,
             level_time_id=core.level_time_id,
             is_finished=core.is_finished,
+        )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class PassedLevel:
+    level_number: int
+    level_time_id: int
+    started_at: datetime
+    finished_at: datetime
+    hints: list[hints.TimeHint]
+
+    @classmethod
+    def from_core(cls, core: PassedLevelHints) -> "PassedLevel":
+        return cls(
+            level_number=core.level_number,
+            level_time_id=core.level_time_id,
+            started_at=core.started_at,
+            finished_at=core.finished_at,
+            hints=core.hints,
+        )
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class PassedLevelsResponse:
+    game_id: int
+    levels: list[PassedLevel]
+
+    @classmethod
+    def from_core(cls, core: PassedLevels) -> "PassedLevelsResponse":
+        return cls(
+            game_id=core.game_id,
+            levels=[PassedLevel.from_core(level) for level in core.levels],
         )
 
 

--- a/shvatka/api/games/routes.py
+++ b/shvatka/api/games/routes.py
@@ -20,6 +20,7 @@ from shvatka.core.games.interactors import (
     GameResultsFileInteractor,
     CheckKeyInteractor,
     GamePlayRoleReader,
+    PassedLevelsReaderInteractor,
 )
 from shvatka.core.games.editor_interactors import (
     MyGamesInteractor,
@@ -266,6 +267,19 @@ async def get_current_level(
 
 
 @inject
+async def get_passed_levels(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[PassedLevelsReaderInteractor],
+) -> responses.PassedLevelsResponse:
+    """Hints of the levels the team has already left.
+
+    Separate from the current level on purpose — the client polls the current
+    one constantly, and asks for the passed ones only when a player opens them.
+    """
+    return responses.PassedLevelsResponse.from_core(await interactor(identity))
+
+
+@inject
 async def insert_key(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[CheckKeyInteractor],
@@ -364,6 +378,7 @@ def setup() -> APIRouter:
     games_router.add_api_route("/active", get_active_game, methods=["GET"])
     games_router.add_api_route("/active/me", get_my_role, methods=["GET"])
     games_router.add_api_route("/running/level/current", get_current_level, methods=["GET"])
+    games_router.add_api_route("/running/level/passed", get_passed_levels, methods=["GET"])
     games_router.add_api_route("/running/key", insert_key, methods=["POST"])
     games_router.add_api_route("/{id}", get_game_card, methods=["GET"])
     games_router.add_api_route("/{id}/release", get_game_release, methods=["GET"])

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from shvatka.core.games.dto import BonusEvent, CurrentHintsOnly, Event
+from shvatka.core.games.dto import BonusEvent, CurrentHintsOnly, Event, PassedLevels
 from shvatka.core.interfaces.dal.complex import GameScenarioEditor, TypedKeyGetter, GameStatDao
 from shvatka.core.interfaces.dal.file_info import FileInfoGetter
 from shvatka.core.interfaces.dal.file_link import FileIdsByGuidsGetter, GameFilesAdder
@@ -92,6 +92,12 @@ class GamePlayDao(Protocol):
         identity: IdentityProvider,
     ) -> CurrentHintsOnly:
         pass
+
+    async def get_passed_levels(
+        self,
+        identity: IdentityProvider,
+    ) -> PassedLevels:
+        """Levels the team has already left, with the hints it saw on each."""
 
     async def get_effects(
         self,

--- a/shvatka/core/games/dto.py
+++ b/shvatka/core/games/dto.py
@@ -104,6 +104,41 @@ class CurrentHintsOnly:
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
+class PassedLevelHints:
+    """Hints a team had on a level it has already left.
+
+    Only the hints that were actually published to the team are listed: the
+    ones whose time had come between ``started_at`` and ``finished_at``. A team
+    that solved a level fast never saw its later hints, and doesn't see them
+    here either.
+    """
+
+    level_number: int
+    level_time_id: int
+    started_at: datetime
+    finished_at: datetime
+    hints: list[hints.TimeHint]
+
+    @property
+    def duration(self) -> timedelta:
+        return self.finished_at - self.started_at
+
+    def get_guids(self) -> list[str]:
+        return [g for h in self.hints for g in h.get_guids()]
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class PassedLevels:
+    """Every level the team has left behind, oldest first."""
+
+    game_id: int
+    levels: list[PassedLevelHints]
+
+    def get_guids(self) -> list[str]:
+        return [g for level in self.levels for g in level.get_guids()]
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
 class FoundBonusHints:
     bonus_hints: dict[UUID, list[hints.AnyHint]]
     """{effect_id: []}"""

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -3,7 +3,12 @@ import typing
 from dataclasses import dataclass
 from datetime import datetime
 
-from shvatka.core.games.dto import CurrentHintsAndKeys, GameStatWithBonuses, MyRole
+from shvatka.core.games.dto import (
+    CurrentHintsAndKeys,
+    GameStatWithBonuses,
+    MyRole,
+    PassedLevels,
+)
 from shvatka.core.games.game_play import schedule_first_hint
 from shvatka.core.games.results import build_results_table, resolve_bonus_levels
 from shvatka.core.interfaces.clients.file_storage import FileGateway
@@ -127,16 +132,15 @@ class GameFileReaderInteractor:
                     player=player,
                 )
         elif game.is_started():
-            if not await self.is_guid_in_current_hint(identity, guid):
-                if not await self.is_guid_in_applied_effects(identity, guid):
-                    raise exceptions.NotAuthorizedForEdit(
-                        permission_name="game_file_read",
-                        text=f"There is no file with uuid {guid} associated "
-                        f"with game id {game_id} and available now",
-                        game=game,
-                        user=await identity.get_user(),
-                        player=player,
-                    )
+            if not await self.is_guid_available_to_team(identity, guid):
+                raise exceptions.NotAuthorizedForEdit(
+                    permission_name="game_file_read",
+                    text=f"There is no file with uuid {guid} associated "
+                    f"with game id {game_id} and available now",
+                    game=game,
+                    user=await identity.get_user(),
+                    player=player,
+                )
         else:
             raise exceptions.NotAuthorizedForEdit(
                 permission_name="game_file_read",
@@ -158,9 +162,26 @@ class GameFileReaderInteractor:
             return False
         return guid in release.get_guids()
 
+    async def is_guid_available_to_team(self, identity: IdentityProvider, guid: str) -> bool:
+        """Whether the team has already been shown the file.
+
+        A hint the team saw stays readable after it left the level — that's
+        what makes the passed levels browsable — but a hint it never reached
+        does not become readable by passing the level.
+        """
+        return (
+            await self.is_guid_in_current_hint(identity, guid)
+            or await self.is_guid_in_applied_effects(identity, guid)
+            or await self.is_guid_in_passed_levels(identity, guid)
+        )
+
     async def is_guid_in_current_hint(self, identity: IdentityProvider, guid: str) -> bool:
         hints_ = await self.game_play_dao.get_current_hints(identity)
         return guid in hints_.get_guids()
+
+    async def is_guid_in_passed_levels(self, identity: IdentityProvider, guid: str) -> bool:
+        passed = await self.game_play_dao.get_passed_levels(identity)
+        return guid in passed.get_guids()
 
     async def is_guid_in_applied_effects(self, identity: IdentityProvider, guid: str) -> bool:
         effects = await self.game_play_dao.get_effects(identity)
@@ -216,6 +237,21 @@ class GamePlayReaderInteractor:
             is_finished=hints_.is_finished,
             level_numbers_by_name_id=level_numbers_by_name_id,
         )
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class PassedLevelsReaderInteractor:
+    """Hints of the levels the team has already passed.
+
+    Kept apart from :class:`GamePlayReaderInteractor` on purpose: the current
+    level is polled every few seconds, while the passed ones only grow when a
+    level is left, so the client asks for them separately and only on demand.
+    """
+
+    game_play_dao: GamePlayDao
+
+    async def __call__(self, identity: IdentityProvider) -> PassedLevels:
+        return await self.game_play_dao.get_passed_levels(identity)
 
 
 @dataclass(kw_only=True)

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -4,7 +4,7 @@ import typing
 from dataclasses import dataclass
 from typing import Iterable
 
-from shvatka.core.games.dto import CurrentHintsOnly, Event
+from shvatka.core.games.dto import CurrentHintsOnly, Event, PassedLevelHints, PassedLevels
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 
 from shvatka.core.interfaces.dal.complex import GamePackager
@@ -375,6 +375,30 @@ class GamePlayDaoImpl(GamePlayDao):
             level_time_id=level_time.id,
             is_finished=is_finished,
         )
+
+    async def get_passed_levels(self, identity: IdentityProvider) -> PassedLevels:
+        game = await self.current_game.get_required_full_game()
+        team = await identity.get_required_team()
+        # resolving the current level time also checks the waiver
+        current = await self.get_level_time(identity)
+        level_times = await self.dao.level_time.get_team_level_times(team, game)
+        passed: list[PassedLevelHints] = []
+        for level_time, next_level_time in zip(level_times, level_times[1:]):
+            if level_time.id == current.id or level_time.has_finished(game):
+                continue
+            level = game.levels[level_time.level_number]
+            passed.append(
+                PassedLevelHints(
+                    level_number=level_time.level_number,
+                    level_time_id=level_time.id,
+                    started_at=level_time.start_at,
+                    finished_at=next_level_time.start_at,
+                    hints=level.get_hints_for_timedelta(
+                        next_level_time.start_at - level_time.start_at
+                    ),
+                )
+            )
+        return PassedLevels(game_id=game.id, levels=passed)
 
     async def get_team_typed_keys(self, identity: IdentityProvider) -> list[dto.InsertedKey]:
         level_time = await self.get_level_time(identity)

--- a/shvatka/infrastructure/db/dao/rdb/level_times.py
+++ b/shvatka/infrastructure/db/dao/rdb/level_times.py
@@ -59,6 +59,18 @@ class LevelTimeDao(BaseDAO[models.LevelTime]):
         )
         return result.scalar_one_or_none()
 
+    async def get_team_level_times(self, team: dto.Team, game: dto.Game) -> list[dto.LevelTime]:
+        """Every level the team has been on in the game, oldest first."""
+        result = await self.session.scalars(
+            select(models.LevelTime)
+            .where(
+                models.LevelTime.game_id == game.id,
+                models.LevelTime.team_id == team.id,
+            )
+            .order_by(models.LevelTime.start_at)
+        )
+        return [lt.to_dto(game=game, team=team) for lt in result.all()]
+
     async def get_game_level_times(self, game: dto.Game) -> list[dto.LevelTime]:
         result = await self.session.scalars(
             select(models.LevelTime)

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -7,6 +7,7 @@ from shvatka.common.url_factory import UrlFactory
 from shvatka.core.games.interactors import (
     GameFileReaderInteractor,
     GamePlayReaderInteractor,
+    PassedLevelsReaderInteractor,
     GameKeysReaderInteractor,
     GameStatReaderInteractor,
     GameResultsFileInteractor,
@@ -271,6 +272,7 @@ class GamePlayProvider(Provider):
 
     file_reader = provide(GameFileReaderInteractor)
     game_play_reader_interactor = provide(GamePlayReaderInteractor)
+    passed_levels_reader_interactor = provide(PassedLevelsReaderInteractor)
 
     @provide
     def game_play_dao(self, dao: HolderDao, current_game: CurrentGameProvider) -> GamePlayDao:

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -266,6 +266,89 @@ async def test_game_hints(
 
 
 @pytest.mark.asyncio
+async def test_game_passed_levels(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+    started_game: dto.FullGame,
+    dao: HolderDao,
+):
+    await dao.level_time.delete_all()
+    now = datetime.now(tz=tz_utc)
+    first = models.LevelTime(
+        game_id=started_game.id,
+        team_id=gryffindor.id,
+        level_number=0,
+        start_at=now - timedelta(minutes=5),
+    )
+    second = models.LevelTime(
+        game_id=started_game.id,
+        team_id=gryffindor.id,
+        level_number=1,
+        start_at=now - timedelta(minutes=2),
+    )
+    dao.level_time._save(first)
+    dao.level_time._save(second)
+    await dao.commit()
+    token = auth.create_user_token(harry)
+
+    resp = await client.get(
+        "/games/running/level/passed",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["game_id"] == started_game.id
+    assert len(resp_json["levels"]) == 1
+    passed = resp_json["levels"][0]
+    assert passed["level_number"] == 0
+    assert passed["level_time_id"] == first.id
+    # three minutes on the level: only the hints of 0 and 2 minutes were shown
+    assert [hint["time"] for hint in passed["hints"]] == [0, 2]
+
+
+@pytest.mark.asyncio
+async def test_game_file_from_passed_level(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+    started_game: dto.FullGame,
+    dao: HolderDao,
+):
+    """A photo the team saw stays readable after it left the level."""
+    await dao.level_time.delete_all()
+    now = datetime.now(tz=tz_utc)
+    dao.level_time._save(
+        models.LevelTime(
+            game_id=started_game.id,
+            team_id=gryffindor.id,
+            level_number=0,
+            start_at=now - timedelta(minutes=5),
+        )
+    )
+    dao.level_time._save(
+        models.LevelTime(
+            game_id=started_game.id,
+            team_id=gryffindor.id,
+            level_number=1,
+            start_at=now - timedelta(minutes=2),
+        )
+    )
+    await dao.commit()
+    token = auth.create_user_token(harry)
+
+    resp = await client.get(
+        f"/cdn/games/{started_game.id}/files/{GUID}",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+
+    assert resp.is_success, resp.text
+
+
+@pytest.mark.asyncio
 async def test_post_wrong_key(
     client: AsyncClient,
     auth: AuthProperties,

--- a/tests/integration/test_game_play.py
+++ b/tests/integration/test_game_play.py
@@ -4,7 +4,11 @@ from datetime import datetime, timedelta
 import pytest
 from dishka import AsyncContainer
 
-from shvatka.core.games.interactors import GamePlayReaderInteractor, CheckKeyInteractor
+from shvatka.core.games.interactors import (
+    GamePlayReaderInteractor,
+    CheckKeyInteractor,
+    PassedLevelsReaderInteractor,
+)
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import hints
 from shvatka.core.models.enums import GameStatus
@@ -531,3 +535,66 @@ async def test_get_current_hints(
         await join_team(ron, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
     with pytest.raises(exceptions.WaiverError):
         await interactor(MockIdentityProvider(user=ron._user, player=ron, team=gryffindor))
+
+
+@pytest.mark.asyncio
+async def test_get_passed_levels(
+    game_with_waivers: dto.FullGame,
+    dishka_request: AsyncContainer,
+    dao: HolderDao,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+):
+    now = datetime.now(tz=tz_utc)
+    first_started_at = now - timedelta(minutes=9)
+    second_started_at = now - timedelta(minutes=2)
+    for level_number, start_at in ((0, first_started_at), (1, second_started_at)):
+        dao.level_time._save(
+            models.LevelTime(
+                game_id=game_with_waivers.id,
+                team_id=gryffindor.id,
+                level_number=level_number,
+                start_at=start_at,
+            )
+        )
+    await dao.commit()
+
+    interactor = await dishka_request.get(PassedLevelsReaderInteractor)
+    passed = await interactor(
+        MockIdentityProvider(user=harry._user, player=harry, team=gryffindor)
+    )
+
+    assert passed.game_id == game_with_waivers.id
+    # the current level is not among the passed ones
+    assert [level.level_number for level in passed.levels] == [0]
+    first = passed.levels[0]
+    assert first.started_at == first_started_at
+    assert first.finished_at == second_started_at
+    # seven minutes on a level with hints at 0, 2, 4 and 6 minutes
+    assert [hint.time for hint in first.hints] == [0, 2, 4, 6]
+
+
+@pytest.mark.asyncio
+async def test_get_passed_levels_on_first_level(
+    game_with_waivers: dto.FullGame,
+    dishka_request: AsyncContainer,
+    dao: HolderDao,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+):
+    dao.level_time._save(
+        models.LevelTime(
+            game_id=game_with_waivers.id,
+            team_id=gryffindor.id,
+            level_number=0,
+            start_at=datetime.now(tz=tz_utc) - timedelta(minutes=5),
+        )
+    )
+    await dao.commit()
+
+    interactor = await dishka_request.get(PassedLevelsReaderInteractor)
+    passed = await interactor(
+        MockIdentityProvider(user=harry._user, player=harry, team=gryffindor)
+    )
+
+    assert passed.levels == []

--- a/tests/integration/test_game_play.py
+++ b/tests/integration/test_game_play.py
@@ -598,3 +598,31 @@ async def test_get_passed_levels_on_first_level(
     )
 
     assert passed.levels == []
+
+
+@pytest.mark.asyncio
+async def test_get_passed_levels_requires_waiver(
+    game_with_waivers: dto.FullGame,
+    dishka_request: AsyncContainer,
+    dao: HolderDao,
+    ron: dto.Player,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+):
+    """Same guard as ``get_current_hints``: no waiver, no access — to any level."""
+    await leave(ron, ron, dao.team_leaver, notifier=TeamNotifierMock())
+    dao.level_time._save(
+        models.LevelTime(
+            game_id=game_with_waivers.id,
+            team_id=gryffindor.id,
+            level_number=0,
+            start_at=datetime.now(tz=tz_utc) - timedelta(minutes=5),
+        )
+    )
+    await dao.commit()
+    interactor = await dishka_request.get(PassedLevelsReaderInteractor)
+
+    with suppress(exceptions.PlayerRestoredInTeam):
+        await join_team(ron, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
+    with pytest.raises(exceptions.WaiverError):
+        await interactor(MockIdentityProvider(user=ron._user, player=ron, team=gryffindor))


### PR DESCRIPTION
## What

A playing team can now read back the hints it saw on the levels it has already left.

New endpoint: `GET /games/running/level/passed` →

```json
{
  "game_id": 7,
  "levels": [
    {
      "level_number": 0,
      "level_time_id": 11,
      "started_at": "...",
      "finished_at": "...",
      "hints": [ { "time": 0, "hint": [...] } ]
    }
  ]
}
```

It lists every level time of the team in the running game **except the current one**, each with the hints whose time had come between that level's start and the level up (`finished_at` is the start of the next level time).

## Why a separate endpoint

The client polls `/games/running/level/current` every few seconds, while the passed levels only change on a level up. Keeping them apart lets the UI fetch them once, on demand, when a player opens the spoiler.

## Hints the team never reached

Only hints that were actually published to the team are listed — a team that solved a level in three minutes doesn't get its 5-minute hint by passing it. The cdn file check follows the same rule: `GameFileReaderInteractor` now also accepts a guid that appears in the passed levels' hints, so the pictures keep loading after the level up, and nothing else becomes readable.

## Changes

- `core/games/dto.py` — `PassedLevelHints` / `PassedLevels`
- `core/games/adapters.py` — `GamePlayDao.get_passed_levels`
- `core/games/interactors.py` — `PassedLevelsReaderInteractor`; file access extended to the passed levels' guids
- `infrastructure/db/dao/rdb/level_times.py` — `get_team_level_times` (served by the existing `game_id, team_id, start_at` index)
- `infrastructure/db/dao/complex/game.py` — the implementation; resolving the current level time keeps the waiver check
- `infrastructure/di/interactors.py` — wiring
- `api/games/` — response + route

## Tests

- `tests/integration/test_game_play.py` — passed levels of a team on its second level, and the empty answer on the first one
- `tests/integration/api_full/test_game.py` — the endpoint's payload, and a photo from a passed level still served by the cdn endpoint

`ruff format --check`, `ruff check`, `mypy` and `pytest tests/unit` all pass locally; the integration suite needs docker, which isn't available in this environment, so it runs in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkmvRZBrRnhQoMxta1fW5E)_