### PR TITLE
test(admin): pin that a superuser cannot read a scenario before the game is complete

### DIFF
--- a/shvatka/core/rules/game.py
+++ b/shvatka/core/rules/game.py
@@ -16,6 +16,14 @@ def check_can_read(game: dto.Game, player: dto.Player):
 
 
 async def check_can_view_scenario(game: dto.Game, identity: IdentityProvider) -> None:
+    """Who may read a game's scenario: everyone once it is complete, else the
+    author and the orgs given ``view_scenario``.
+
+    Admin rights are deliberately not on that list. An admin edits a game only
+    once it is complete (see :mod:`shvatka.core.games.admin_interactors`), and
+    a complete game is public anyway — so being a superuser never opens a
+    scenario still being written, however the game is addressed.
+    """
     player = await identity.get_required_player()
     if game.is_complete():
         return  # for completed - available for all

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -13,6 +13,7 @@ from shvatka.core.players.player import upsert_player
 from shvatka.core.services.user import upsert_user
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.infrastructure.db.dao.holder import HolderDao
+from tests.fixtures.scn_fixtures import GUID
 from tests.fixtures.user_constants import (
     create_dto_hermione,
     create_dto_ron,
@@ -793,6 +794,96 @@ async def test_admin_upload_file_non_completed_game_hidden(
     )
     assert resp.status_code == 404, resp.text
     assert resp.json()["type"] == "GameNotFound"
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_read_non_completed_game_scenario(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+):
+    """Being a superuser grants no sight of a game still being written.
+
+    The scenario of a game that is not complete belongs to its author and to
+    the orgs the author gave ``view_scenario`` — admin rights are not a way in,
+    not even knowing the game's id (the games list shows completed games only).
+    """
+    resp = await client.get(
+        f"/games/{game.id}",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["type"] == "NotAuthorizedForEdit"
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_read_non_completed_game_as_own(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+):
+    # the author-facing route is no way in either: the admin did not write it
+    resp = await client.get(
+        f"/games/my/{game.id}",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["type"] == "NotAuthorizedForEdit"
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_print_keys_of_non_completed_game(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+):
+    # the keys sheet is the scenario's secret half — same rule as the card
+    resp = await client.get(
+        f"/games/my/{game.id}/keys/print",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["type"] == "NotAuthorizedForEdit"
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_read_file_of_non_completed_game(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+):
+    # nor its media: a hint's picture is as much the scenario as its text
+    resp = await client.get(
+        f"/cdn/games/{game.id}/files/{GUID}",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_reads_the_scenario_once_the_game_is_complete(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+    dao: HolderDao,
+):
+    """The other side of the rule — and what makes the admin editor work.
+
+    A complete game is public: the admin reads its scenario like everybody
+    else, which is what the admin scenario editor loads before saving.
+    """
+    await complete_game(game, dao)
+    resp = await client.get(
+        f"/games/{game.id}",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success, resp.text
+    assert len(resp.json()["levels"]) == len(game.levels)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #355 (after the check it describes).

## What was checked

Whether an admin (superuser) can get the scenario of a game that is **not** in the `complete` status, by addressing it by id. I walked every path that can return scenario content:

| Surface | Guard | Admin on a non-complete game |
| --- | --- | --- |
| `GET /games/{id}` (card, full scenario) | `check_can_view_scenario` | 403 |
| `GET /games/my/{id}` | same | 403 |
| `GET /games/my/{id}/keys/print` (keys sheet) | same | 403 |
| `GET /cdn/games/{id}/files/{guid}` (hint media) | `GameFileReaderInteractor` | 403 |
| `GET /games/{id}/keys`, `/stat` | `get_typed_keys` / `get_game_stat` | org permission only |
| `GET /search` | completed games only | — |
| `PUT /admin/games/{id}/scenario`, `POST /admin/games/{id}/files` | `identity.get_superuser()` + `is_complete()` | 404 `GameNotFound` |

`check_can_view_scenario` never consults `is_superuser()`/`get_superuser()`, and neither does any DAO or identity provider on the way (`ApiIdentityProvider.get_org` returns a real organizer row or the author, nothing synthetic). So the answer to #355 is **no** — there is nothing to close off.

## What this PR changes

Nothing in behaviour; it pins the rule so it cannot be lost silently:

- `tests/integration/api_full/test_admin.py` — an admin addressing a game under construction by id gets 403 on its card, on the author-facing route, on the keys sheet and on its media, and reads the scenario only once the game is complete (the last one is also what the admin scenario editor loads before saving).
- `shvatka/core/rules/game.py` — a docstring on `check_can_view_scenario` saying the omission of admin rights is a decision, not an oversight.

## Adjacent findings (not touched here)

Two things I ran into that are outside what this PR is about — say the word and I'll take either:

1. `check_can_edit_release` returns early for a superuser at **any** status, so an admin can write/delete the release of someone else's draft game, and through `check_can_add_file` upload files into it. Its docstring reads as if that is intended ("an admin may rewrite any release"), so I left it — but it is wider than "admin operates on completed games only".
2. `GET /games/{id}/keys` and `/games/{id}/stat` on a non-complete game answer **500**, not 403, for anyone who is not an org: `services/organizers.get_by_player` lets SQLAlchemy's `NoResultFound` escape instead of raising an SHError.

## Testing

- `pytest tests/unit` — 370 passed.
- `ruff check` / `ruff format --check` — clean.
- The new tests are integration tests; the sandbox here cannot pull the Postgres image for testcontainers, so they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3ch1dNb9dretnhmxKdnUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3ch1dNb9dretnhmxKdnUr)_