### PR TITLE
feat(email): let a player move to another email address

### DIFF
--- a/shvatka/api/auth/routes.py
+++ b/shvatka/api/auth/routes.py
@@ -201,6 +201,8 @@ async def email_confirm(
         await interactor(email=body.email, code=body.code)
     except exceptions.EmailConfirmationCodeInvalid as e:
         raise HTTPException(status_code=400, detail="invalid or expired code") from e
+    except exceptions.EmailAlreadyExist as e:
+        raise HTTPException(status_code=409, detail="email already exists") from e
     return {"ok": True}
 
 

--- a/shvatka/api/players/responses.py
+++ b/shvatka/api/players/responses.py
@@ -24,6 +24,8 @@ class PlayerWithIdentities:
     email: EmailAccount | None
     is_admin: bool = False
     """whether this player may use the admin panel (tg id in configured superusers)"""
+    pending_email: str | None = None
+    """an address waiting for its confirmation code, when it is not `email` itself"""
 
     @classmethod
     def from_core(
@@ -31,6 +33,7 @@ class PlayerWithIdentities:
         player: dto.Player,
         email: dto.EmailAccount | None,
         superusers: "Sequence[int]" = (),
+        pending_email: str | None = None,
     ) -> "PlayerWithIdentities":
         tg = player._user  # noqa: SLF001
         return cls(
@@ -42,6 +45,11 @@ class PlayerWithIdentities:
             forum=ForumUser.from_core(player._forum_user),  # noqa: SLF001
             email=EmailAccount.from_core(email),
             is_admin=tg is not None and tg.tg_id in superusers,
+            # The address already linked (verified or not) is described by `email`;
+            # `pending_email` is only about a move to some *other* address.
+            pending_email=None
+            if email is not None and pending_email == email.email
+            else pending_email,
         )
 
 

--- a/shvatka/api/players/routes.py
+++ b/shvatka/api/players/routes.py
@@ -32,7 +32,10 @@ async def read_users_me(
     if player_ is None:
         raise HTTPException(status_code=401, detail="User not found")
     email = await dao.email.get_by_player_id(player_.id)
-    return responses.PlayerWithIdentities.from_core(player_, email, config.superusers)
+    pending_email = await dao.email_confirm.get_pending_email(player_.id)
+    return responses.PlayerWithIdentities.from_core(
+        player_, email, config.superusers, pending_email
+    )
 
 
 @inject

--- a/shvatka/core/interfaces/dal/email.py
+++ b/shvatka/core/interfaces/dal/email.py
@@ -8,6 +8,9 @@ class EmailAccountDao(typing.Protocol):
     async def get_by_email(self, email: str) -> dto.EmailAccount | None:
         raise NotImplementedError
 
+    async def get_by_player_id(self, player_id: int) -> dto.EmailAccount | None:
+        raise NotImplementedError
+
     async def is_email_occupied(self, email: str) -> bool:
         raise NotImplementedError
 
@@ -17,6 +20,11 @@ class EmailAccountDao(typing.Protocol):
         raise NotImplementedError
 
     async def add_email_to_player(self, player: dto.Player, email: str) -> dto.EmailAccount:
+        raise NotImplementedError
+
+    async def set_player_email(
+        self, player_id: int, email: str, is_verified: bool
+    ) -> dto.EmailAccount:
         raise NotImplementedError
 
     async def set_verified(self, email: str) -> None:
@@ -39,6 +47,10 @@ class EmailConfirmationStore(typing.Protocol):
         raise NotImplementedError
 
     async def remove_code(self, email: str) -> None:
+        raise NotImplementedError
+
+    async def get_pending_email(self, player_id: int) -> str | None:
+        """The email a player is currently asked to confirm, if any."""
         raise NotImplementedError
 
 

--- a/shvatka/core/services/email.py
+++ b/shvatka/core/services/email.py
@@ -59,12 +59,32 @@ class EmailLinkInteractor:
     sender: EmailSender
 
     async def __call__(self, player: dto.Player, email: str) -> None:
-        """Attach an email to an already existing player (e.g. a telegram user)."""
+        """
+        Attach an email to an already existing player (e.g. a telegram user),
+        or move the player to another email.
+
+        A pending (unconfirmed) email is replaced right away — nothing usable is
+        at stake. A *verified* one keeps working until the new address is
+        confirmed, so a typo can never lock its owner out of their account.
+        """
         email = normalize_email_or_raise(email)
-        if await self.dao.is_email_occupied(email):
+        occupant = await self.dao.get_by_email(email)
+        if occupant is not None and occupant.player_id != player.id:
             raise exceptions.EmailAlreadyExist(text=f"email {email} already occupied")
-        await self.dao.add_email_to_player(player, email)
-        await self.dao.commit()
+        if occupant is not None and occupant.is_verified:
+            raise exceptions.EmailAlreadyExist(text=f"email {email} already linked to this player")
+
+        current = await self.dao.get_by_player_id(player.id)
+        if current is None:
+            await self.dao.add_email_to_player(player, email)
+            await self.dao.commit()
+        elif not current.is_verified and current.email != email:
+            await self.dao.set_player_email(player.id, email, is_verified=False)
+            await self.dao.commit()
+            await self.store.remove_code(current.email)
+        # A verified email is left untouched: the new one is only remembered as a
+        # pending confirmation and replaces the old one in EmailConfirmInteractor.
+
         await send_new_code(email, player.id, self.store, self.sender)
 
 
@@ -78,7 +98,16 @@ class EmailConfirmInteractor:
         saved = await self.store.get_code(email)
         if saved is None or not secrets.compare_digest(saved.code, code.strip()):
             raise exceptions.EmailConfirmationCodeInvalid(text=f"wrong code for {email}")
-        await self.dao.set_verified(email)
+        account = await self.dao.get_by_email(email)
+        if account is None:
+            # A change requested from an already verified address: only now, with
+            # the new one proven, does the player stop using the old email.
+            await self.dao.set_player_email(saved.player_id, email, is_verified=True)
+        elif account.player_id != saved.player_id:
+            # Someone else took the address between the request and the confirmation.
+            raise exceptions.EmailAlreadyExist(text=f"email {email} already occupied")
+        else:
+            await self.dao.set_verified(email)
         await self.dao.commit()
         await self.store.remove_code(email)
 

--- a/shvatka/infrastructure/db/dao/redis/email_confirm.py
+++ b/shvatka/infrastructure/db/dao/redis/email_confirm.py
@@ -24,12 +24,18 @@ class EmailConfirmationStore:
     def _create_key(self, email: str) -> str:
         return f"{self.prefix}:{email}"
 
+    def _player_key(self, player_id: int) -> str:
+        """Reverse index: which email this player is currently asked to confirm."""
+        return f"{self.prefix}:player:{player_id}"
+
     async def save_code(self, email: str, code: str, player_id: int) -> None:
+        expire = timedelta(minutes=EXPIRE_MINUTES)
         await self.redis.set(
             self._create_key(email),
             json.dumps({"code": code, "player_id": player_id}),
-            ex=timedelta(minutes=EXPIRE_MINUTES),
+            ex=expire,
         )
+        await self.redis.set(self._player_key(player_id), email, ex=expire)
 
     async def get_code(self, email: str) -> dto.EmailConfirmation | None:
         value = await self.redis.get(self._create_key(email))
@@ -43,4 +49,18 @@ class EmailConfirmationStore:
         )
 
     async def remove_code(self, email: str) -> None:
+        confirmation = await self.get_code(email)
         await self.redis.delete(self._create_key(email))
+        if confirmation is None:
+            return
+        # Drop the reverse index only while it still points at this very email:
+        # a newer request for another email must survive this cleanup.
+        pending = await self.get_pending_email(confirmation.player_id)
+        if pending == email:
+            await self.redis.delete(self._player_key(confirmation.player_id))
+
+    async def get_pending_email(self, player_id: int) -> str | None:
+        value = await self.redis.get(self._player_key(player_id))
+        if value is None:
+            return None
+        return value.decode() if isinstance(value, bytes) else str(value)

--- a/shvatka/tgbot/dialogs/profile/dialogs.py
+++ b/shvatka/tgbot/dialogs/profile/dialogs.py
@@ -88,6 +88,8 @@ profile_dialog = Dialog(
             on_success=on_email_code_entered,
         ),
         state=states.ProfileSG.email_code,
+        # back to the address input when someone else took the email meanwhile
+        preview_add_transitions=[PreviewSwitchTo(states.ProfileSG.email)],
     ),
     Window(
         Jinja("Введи своё новое имя пользователя. Сейчас сохранено {{player.username}}"),

--- a/shvatka/tgbot/dialogs/profile/handlers.py
+++ b/shvatka/tgbot/dialogs/profile/handlers.py
@@ -105,5 +105,9 @@ async def on_email_code_entered(
     except exceptions.EmailConfirmationCodeInvalid:
         await message.reply("Неверный или устаревший код, попробуй ещё раз")
         return
+    except exceptions.EmailAlreadyExist:
+        await message.reply("Эту почту успел занять кто-то другой, попробуй другую")
+        await manager.switch_to(state=states.ProfileSG.email)
+        return
     await message.reply("Электронная почта успешно подтверждена ✅")
     await manager.switch_to(state=states.ProfileSG.main)

--- a/tests/unit/mapper/test_me_response.py
+++ b/tests/unit/mapper/test_me_response.py
@@ -42,3 +42,27 @@ def test_me_from_core_forum_and_unverified_email():
     assert me.forum.name == "forum_harry"
     assert me.email is not None
     assert me.email.is_verified is False
+
+
+def test_me_pending_email_is_the_address_being_moved_to():
+    player = dto.Player(id=4, can_be_author=False, is_dummy=False, username="harry")
+    email = dto.EmailAccount(email="old@example.com", player_id=4, is_verified=True, db_id=1)
+
+    me = responses.PlayerWithIdentities.from_core(
+        player, email=email, pending_email="new@example.com"
+    )
+
+    assert me.email is not None
+    assert me.email.email == "old@example.com"
+    assert me.pending_email == "new@example.com"
+
+
+def test_me_pending_email_ignores_the_linked_address_itself():
+    player = dto.Player(id=5, can_be_author=False, is_dummy=False, username="harry")
+    email = dto.EmailAccount(email="h@example.com", player_id=5, is_verified=False, db_id=2)
+
+    me = responses.PlayerWithIdentities.from_core(
+        player, email=email, pending_email="h@example.com"
+    )
+
+    assert me.pending_email is None

--- a/tests/unit/services/email_service_test.py
+++ b/tests/unit/services/email_service_test.py
@@ -55,11 +55,29 @@ class FakeEmailDao:
         self.accounts[email] = account
         return account
 
+    async def set_player_email(
+        self, player_id: int, email: str, is_verified: bool
+    ) -> dto.EmailAccount:
+        for existing in list(self.accounts.values()):
+            if existing.player_id == player_id:
+                del self.accounts[existing.email]
+        account = dto.EmailAccount(
+            email=email, player_id=player_id, is_verified=is_verified, db_id=999
+        )
+        self.accounts[email] = account
+        return account
+
     async def set_verified(self, email: str) -> None:
         self.accounts[email].is_verified = True
 
     async def get_by_email(self, email: str) -> dto.EmailAccount | None:
         return self.accounts.get(email)
+
+    async def get_by_player_id(self, player_id: int) -> dto.EmailAccount | None:
+        for account in self.accounts.values():
+            if account.player_id == player_id:
+                return account
+        return None
 
     async def find_verified_player_by_email(self, email: str) -> dto.Player:
         account = self.accounts.get(email)
@@ -88,6 +106,12 @@ class FakeStore:
 
     async def remove_code(self, email: str) -> None:
         self.codes.pop(email, None)
+
+    async def get_pending_email(self, player_id: int) -> str | None:
+        for confirmation in self.codes.values():
+            if confirmation.player_id == player_id:
+                return confirmation.email
+        return None
 
 
 class FakeSender:
@@ -248,6 +272,87 @@ async def test_link_email_to_existing_player(link, dao, sender):
     assert "new@mail.com" in dao.accounts
     assert dao.accounts["new@mail.com"].player_id == 42
     assert sender.sent[0][0] == "new@mail.com"
+
+
+@pytest.mark.asyncio
+async def test_link_replaces_a_pending_email_in_place(link, dao, store, sender):
+    player = dto.Player(id=42, can_be_author=False, is_dummy=False, username="tg_user")
+    await link(player=player, email="typo@mail.com")
+
+    await link(player=player, email="right@mail.com")
+
+    assert "typo@mail.com" not in dao.accounts
+    assert dao.accounts["right@mail.com"].player_id == 42
+    assert store.codes.get("typo@mail.com") is None
+    assert sender.sent[-1][0] == "right@mail.com"
+
+
+@pytest.mark.asyncio
+async def test_link_resends_the_code_for_the_same_pending_email(link, dao, sender):
+    player = dto.Player(id=42, can_be_author=False, is_dummy=False, username="tg_user")
+    await link(player=player, email="pending@mail.com")
+
+    await link(player=player, email="Pending@Mail.com")
+
+    assert list(dao.accounts) == ["pending@mail.com"]
+    assert len(sender.sent) == 2
+
+
+@pytest.mark.asyncio
+async def test_link_keeps_the_verified_email_until_the_new_one_is_confirmed(
+    link, confirm, dao, store, sender
+):
+    player = dto.Player(id=42, can_be_author=False, is_dummy=False, username="tg_user")
+    await link(player=player, email="old@mail.com")
+    await confirm(email="old@mail.com", code=sender.sent[0][1])
+
+    await link(player=player, email="new@mail.com")
+
+    # nothing has moved yet: the old address still logs its owner in
+    assert dao.accounts["old@mail.com"].is_verified
+    assert "new@mail.com" not in dao.accounts
+    assert store.codes["new@mail.com"].player_id == 42
+
+    await confirm(email="new@mail.com", code=sender.sent[-1][1])
+
+    assert "old@mail.com" not in dao.accounts
+    assert dao.accounts["new@mail.com"].is_verified
+    assert dao.accounts["new@mail.com"].player_id == 42
+    assert store.codes.get("new@mail.com") is None
+
+
+@pytest.mark.asyncio
+async def test_link_rejects_an_email_of_another_player(link, dao, sender):
+    harry = dto.Player(id=1, can_be_author=False, is_dummy=False, username="harry")
+    ron = dto.Player(id=2, can_be_author=False, is_dummy=False, username="ron")
+    await link(player=harry, email="taken@mail.com")
+
+    with pytest.raises(exceptions.EmailAlreadyExist):
+        await link(player=ron, email="taken@mail.com")
+
+
+@pytest.mark.asyncio
+async def test_link_rejects_the_already_verified_own_email(link, confirm, sender):
+    player = dto.Player(id=42, can_be_author=False, is_dummy=False, username="tg_user")
+    await link(player=player, email="mine@mail.com")
+    await confirm(email="mine@mail.com", code=sender.sent[0][1])
+
+    with pytest.raises(exceptions.EmailAlreadyExist):
+        await link(player=player, email="mine@mail.com")
+
+
+@pytest.mark.asyncio
+async def test_confirm_never_verifies_an_email_owned_by_another_player(confirm, dao, store):
+    ron = dto.Player(id=2, can_be_author=False, is_dummy=False, username="ron")
+    await dao.add_email_to_player(ron, "contested@mail.com")
+    # a code harry asked for the same address, before ron took it
+    await store.save_code("contested@mail.com", "123456", player_id=1)
+
+    with pytest.raises(exceptions.EmailAlreadyExist):
+        await confirm(email="contested@mail.com", code="123456")
+
+    assert dao.accounts["contested@mail.com"].player_id == 2
+    assert not dao.accounts["contested@mail.com"].is_verified
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

A linked email could not be replaced. `POST /auth/email/link` always inserted a new `emails` row, which the unique `player_id` rejects — so the UI's «указать другой email» blew up for a pending address, and a verified one had no way out at all.

Linking now understands what it is looking at:

- **no email yet** — unchanged: the address is attached, unverified, and a code goes out;
- **a pending (unconfirmed) address** — swapped in place and its dead code dropped; nothing usable was at stake;
- **the same pending address again** — just a new code, nothing rewritten;
- **a verified address** — left alone. The move lives only in the confirmation store, and `EmailConfirmInteractor` is what finally attaches the new address, so a typo can never lock its owner out of the account they still log into.

`/users/me` reports such a move as `pending_email`, taken from a reverse index (`email_confirm:player:{id}`) the confirmation store now keeps beside the code, with the same TTL. That lets the UI show the confirm form after a reload instead of asking for the address again. The field is `null` while the pending address is the linked one — that case is already described by `email.is_verified`.

## Guards

- an address owned by another player is refused at link time (409, as before);
- confirming never verifies a row belonging to somebody else — if the address was taken between the request and the code, it raises `EmailAlreadyExist`, mapped to 409 on `/auth/email/confirm` and handled in the bot dialog.

## Tests

`tests/unit/services/email_service_test.py` gains cases for replacing a pending address, re-sending for the same one, keeping a verified address until the new one is confirmed, both rejection paths, and the ownership guard on confirm. `tests/unit/mapper/test_me_response.py` covers `pending_email`.

`pytest tests/unit` — 378 passed. `ruff format --check`, `ruff check` and `mypy shvatka` all clean.

## Paired with

The UI side lives in bomzheg/shvatka-ui#182.

---
_Generated by [Claude Code](https://claude.ai/code/session_013GYor9572HgbSSSLa37FrX)_