### PR TITLE
Keep the auth cookie to the host that set it

### DIFF
--- a/config_dist/config.yml
+++ b/config_dist/config.yml
@@ -46,7 +46,17 @@ api:
     bot-token: ""
     bot-username: ""
     auth-url: "https://example.org/sh/login/data"
-    domain: "example.org"
+    # Domain of the auth cookie. Leave it empty (or drop the key) to get a
+    # host-only cookie — the browser then sends it back only to the host that
+    # set it. A parent domain (example.org) hands the same cookie to every
+    # deployment under it, and because a cookie is keyed by (name, domain,
+    # path), logging into one of them overwrites the token of the others.
+    domain: ""
+    # Name of the auth cookie. Only worth changing when several deployments
+    # must share one `domain` — give each of them its own name so they stop
+    # overwriting each other.
+    cookie-name: "Authorization"
+    # "none" is only accepted by browsers together with secure: true
     samesite: "none"
     secure: false
     httponly: false

--- a/shvatka/api/app/config/models/auth.py
+++ b/shvatka/api/app/config/models/auth.py
@@ -8,11 +8,23 @@ class AuthConfig:
     secret_key: str
     token_expire: timedelta
     bot_username: str
-    domain: str
     samesite: Literal["lax", "strict", "none"] | None
     httponly: bool
     secure: bool
     auth_url: str
     bot_token: str
+    # Empty (the default) means a host-only cookie: the browser sends it back
+    # only to the host that set it. Naming a parent domain here shares the
+    # cookie with every deployment under it — and since the cookie is keyed by
+    # (name, domain, path), the next deployment to log a user in overwrites the
+    # previous one's token. Set it only for a deployment that really spans
+    # subdomains, and then give that deployment its own `cookie_name`.
+    domain: str | None = None
+    cookie_name: str = "Authorization"
     disable_cors: bool = False
     enable_basic: bool = False
+
+    @property
+    def cookie_domain(self) -> str | None:
+        """The Domain attribute to write, treating an empty value as host-only."""
+        return self.domain or None

--- a/shvatka/api/app/dependencies/auth.py
+++ b/shvatka/api/app/dependencies/auth.py
@@ -275,7 +275,9 @@ class AuthProvider(Provider):
         return AuthProperties(config, hasher)
 
     @provide
-    def get_cookie_auth(self) -> OAuth2PasswordBearerWithCookie:
-        return OAuth2PasswordBearerWithCookie(token_url="auth/token")
+    def get_cookie_auth(self, config: AuthConfig) -> OAuth2PasswordBearerWithCookie:
+        return OAuth2PasswordBearerWithCookie(
+            token_url="auth/token", cookie_name=config.cookie_name
+        )
 
     idp = provide(ApiIdentityProvider, scope=Scope.REQUEST)

--- a/shvatka/api/app/utils/cookie_auth.py
+++ b/shvatka/api/app/utils/cookie_auth.py
@@ -14,14 +14,16 @@ class OAuth2PasswordBearerWithCookie(OAuth2):
     def __init__(
         self,
         token_url: str,
+        cookie_name: str = "Authorization",
         scheme_name: str | None = None,
         auto_error: bool = True,
     ):
         flows = OAuthFlowsModel(password=OAuthFlowPassword(tokenUrl=token_url))
         super().__init__(flows=flows, scheme_name=scheme_name, auto_error=auto_error)
+        self.cookie_name = cookie_name
 
     def get_token(self, request: Request) -> Token:
-        authorization = request.cookies.get("Authorization", "")
+        authorization = request.cookies.get(self.cookie_name, "")
 
         scheme, param = get_authorization_scheme_param(authorization)
         if not authorization or scheme.lower() != "bearer":
@@ -35,11 +37,23 @@ class OAuth2PasswordBearerWithCookie(OAuth2):
 
 def set_auth_response(config: AuthConfig, response: Response, token: Token) -> None:
     response.set_cookie(
-        "Authorization",
+        config.cookie_name,
         value=f"{token.token_type} {token.access_token}",
         samesite=config.samesite,
-        domain=config.domain,
+        domain=config.cookie_domain,
         httponly=config.httponly,
         secure=config.secure,
         max_age=int(config.token_expire.total_seconds()),
+    )
+
+
+def delete_auth_response(config: AuthConfig, response: Response) -> None:
+    # the attributes have to repeat the ones the cookie was set with,
+    # otherwise the browser keeps the cookie and deletes nothing
+    response.delete_cookie(
+        config.cookie_name,
+        samesite=config.samesite,
+        domain=config.cookie_domain,
+        httponly=config.httponly,
+        secure=config.secure,
     )

--- a/shvatka/api/auth/routes.py
+++ b/shvatka/api/auth/routes.py
@@ -21,7 +21,7 @@ from shvatka.api.auth.requests import (
     ForgotPassword,
 )
 from shvatka.api.app.config.models.auth import AuthConfig
-from shvatka.api.app.utils.cookie_auth import set_auth_response
+from shvatka.api.app.utils.cookie_auth import delete_auth_response, set_auth_response
 from shvatka.core.interfaces.bus import Bus, OneTimeTokenUsed
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
@@ -75,13 +75,7 @@ async def logout(
     response: Response,
     config: FromDishka[AuthConfig],
 ):
-    response.delete_cookie(
-        "Authorization",
-        samesite=config.samesite,
-        domain=config.domain,
-        httponly=config.httponly,
-        secure=config.secure,
-    )
+    delete_auth_response(config, response)
     return {"ok": True}
 
 

--- a/tests/config/config.yml
+++ b/tests/config/config.yml
@@ -40,7 +40,7 @@ api:
     bot-token: "123:ABC"
     bot-username: "shvatkatestbot"
     auth-url: "https://example.org/sh/login/data"
-    domain: "test"
+    # no domain: the auth cookie is host-only, like every real deployment
     samesite: "none"
     secure: false
     httponly: false

--- a/tests/integration/api_full/test_user.py
+++ b/tests/integration/api_full/test_user.py
@@ -33,6 +33,8 @@ async def test_auth(client: AsyncClient, harry: dto.Player, auth: AuthProperties
     )
     assert resp.is_success
     resp.read()
+    # host-only, so a deployment on a neighbouring subdomain can't overwrite it
+    assert "Domain=" not in resp.headers["set-cookie"]
     access_token = resp.cookies.get("Authorization").removeprefix('"').removesuffix('"')
     actual_user = await auth.get_current_user(
         Token(access_token=access_token.removeprefix("bearer "), token_type="bearer"),

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -40,6 +40,10 @@ def test_load_api_config(paths: Paths):
     assert not config.api.enable_logging
     assert timedelta(minutes=30) == config.api.auth.token_expire
     assert "shvatkatestbot" == config.api.auth.bot_username
+    # the file names no cookie domain, so the cookie is host-only
+    assert config.api.auth.domain is None
+    assert config.api.auth.cookie_domain is None
+    assert "Authorization" == config.api.auth.cookie_name
     assert "none" == config.api.auth.samesite
     assert not config.api.auth.secure
     assert not config.api.auth.httponly

--- a/tests/unit/test_cookie_auth.py
+++ b/tests/unit/test_cookie_auth.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+from typing import Literal
+
+import pytest
+from fastapi import HTTPException, Request
+from starlette.responses import Response
+
+from shvatka.api.app.config.models.auth import AuthConfig
+from shvatka.api.app.utils.cookie_auth import (
+    OAuth2PasswordBearerWithCookie,
+    delete_auth_response,
+    set_auth_response,
+)
+from shvatka.api.auth.responses import Token
+
+
+def make_config(
+    domain: str | None = None,
+    cookie_name: str = "Authorization",
+    samesite: Literal["lax", "strict", "none"] | None = "lax",
+) -> AuthConfig:
+    return AuthConfig(
+        secret_key="secret",
+        token_expire=timedelta(minutes=30),
+        bot_username="shvatkatestbot",
+        samesite=samesite,
+        httponly=True,
+        secure=True,
+        auth_url="https://example.org/sh/login/data",
+        bot_token="123:ABC",
+        domain=domain,
+        cookie_name=cookie_name,
+    )
+
+
+def set_cookie_header(config: AuthConfig) -> str:
+    response = Response()
+    set_auth_response(config, response, Token(access_token="token", token_type="bearer"))
+    return response.headers["set-cookie"]
+
+
+def make_request(cookie: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "headers": [(b"cookie", cookie.encode())],
+        }
+    )
+
+
+@pytest.mark.parametrize("domain", [None, ""], ids=["absent", "empty"])
+def test_no_domain_means_host_only_cookie(domain: str | None):
+    # a cookie without a Domain attribute goes back only to the host that set
+    # it, so a sibling deployment can't overwrite it (issue #349)
+    assert "Domain=" not in set_cookie_header(make_config(domain=domain))
+
+
+def test_configured_domain_is_written():
+    assert "Domain=bomzheg.dev" in set_cookie_header(make_config(domain="bomzheg.dev"))
+
+
+def test_cookie_name_is_configurable():
+    header = set_cookie_header(make_config(cookie_name="AuthorizationTest"))
+    assert header.startswith("AuthorizationTest=")
+
+
+def test_deleted_cookie_repeats_the_attributes_it_was_set_with():
+    config = make_config(domain="bomzheg.dev", cookie_name="AuthorizationTest")
+    response = Response()
+    delete_auth_response(config, response)
+    header = response.headers["set-cookie"]
+
+    assert header.startswith('AuthorizationTest=""')
+    assert "Domain=bomzheg.dev" in header
+    assert "Max-Age=0" in header
+
+
+def test_token_is_read_from_the_configured_cookie():
+    cookie_auth = OAuth2PasswordBearerWithCookie(
+        token_url="auth/token", cookie_name="AuthorizationTest"
+    )
+
+    token = cookie_auth.get_token(make_request("AuthorizationTest=bearer some-token"))
+
+    assert Token(access_token="some-token", token_type="bearer") == token
+
+
+def test_another_deployments_cookie_is_not_accepted():
+    cookie_auth = OAuth2PasswordBearerWithCookie(
+        token_url="auth/token", cookie_name="AuthorizationTest"
+    )
+
+    with pytest.raises(HTTPException):
+        cookie_auth.get_token(make_request("Authorization=bearer some-token"))


### PR DESCRIPTION
Closes #349.

## Why the test session disappeared

Auth state on the site is only the cookie — the UI keeps nothing in `localStorage`, it just sends `withCredentials`. That cookie was written with:

- a hard-coded name, `"Authorization"`,
- the default path, `/`,
- and `Domain` taken from `api.auth.domain`, which both deployments pointed at the shared parent `bomzheg.dev`.

A browser keys a cookie by **(name, domain, path)** — the host that set it is not part of the key, and neither is the port or the scheme. So prod and test were writing into the same slot: logging into `shvatka.bomzheg.dev` sent `Set-Cookie: Authorization=…; Domain=bomzheg.dev; Path=/`, which *overwrote* the test token. The next request to test carried the prod JWT, it failed validation, and you looked logged out. Nothing had expired — which is why a single environment kept working for the whole token lifetime.

`logout` had the mirror problem: signing out of test deleted the prod cookie too.

## What changed

- `AuthConfig.domain` is now `str | None`, defaulting to `None`, and an empty value means the same thing. Omitting it produces a **host-only** cookie — sent back only to the host that set it, never to a sibling subdomain. That is stricter than naming the host explicitly, since `Domain=shvatka.bomzheg.dev` would still match its own subdomains.
- `AuthConfig.cookie_name` is a new config value (default `Authorization`), threaded through `set_auth_response`, the deletion path, and `OAuth2PasswordBearerWithCookie`. It gives each deployment its own slot for the case where a shared `domain` is genuinely required.
- Logout no longer repeats the `set_cookie` attributes by hand — it calls `delete_auth_response`, which sits next to `set_auth_response` and reads the same fields. Deletion only works when name, domain, path, `samesite`, `secure` and `httponly` all match; keeping them in one file stops them drifting into a cookie nothing can remove.
- `config_dist/config.yml` ships `domain: ""` with a comment explaining the shared-slot trap, plus a note that `samesite: "none"` is only accepted by browsers together with `secure: true` (the dist file pairs `none` with `secure: false`, which browsers reject outright).

## Tests

- `tests/unit/test_cookie_auth.py` (new): no `Domain=` for an absent or empty domain, a configured domain still written, a custom cookie name honoured on set/delete, and the scheme refusing another deployment's cookie name.
- `tests/unit/test_config_parser.py`: the test config now names no domain, so it asserts the host-only default.
- `tests/integration/api_full/test_user.py`: the login response's `Set-Cookie` carries no `Domain`.

`pytest tests/unit` (468 passed), `ruff format --check`, `ruff check` and `mypy` are green locally. Integration tests need Docker, so they run in CI.

## Deploying it

The code change alone doesn't clear the existing cookie — each deployment's own `config.yml` has to drop `api.auth.domain` (or set it empty). Worth also giving the test deployment `cookie-name: "AuthorizationTest"`: browsers still hold the old `Domain=bomzheg.dev` cookie until it expires, and a distinct name makes test ignore it outright instead of relying on which duplicate the header parser keeps.

---
_Generated by [Claude Code](https://claude.ai/code/session_0175uRMYrVEbyFc5Lrf5QYjv)_