### PR TITLE
Resend a running level's messages from the admin panel, blind

### DIFF
--- a/shvatka/api/admin/requests.py
+++ b/shvatka/api/admin/requests.py
@@ -20,6 +20,12 @@ class AdminGameStatusChange:
 
 
 @dataclass
+class AdminResendLevel:
+    team_id: int | None = None
+    """the single team to resend to; ``null`` means every team of the game"""
+
+
+@dataclass
 class AdminChangeEmail:
     email: str
     verified: bool = False

--- a/shvatka/api/admin/routes.py
+++ b/shvatka/api/admin/routes.py
@@ -21,6 +21,7 @@ from shvatka.core.files.interactors import CollectFileGarbageInteractor
 from shvatka.core.games.admin_interactors import (
     AdminChangeGameStatusInteractor,
     AdminGamesListInteractor,
+    AdminResendCurrentLevelInteractor,
     AdminUpdateGameScenarioInteractor,
     AdminUploadGameFileInteractor,
 )
@@ -314,6 +315,29 @@ async def change_game_scenario(
 
 
 @inject
+async def resend_current_level(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[AdminResendCurrentLevelInteractor],
+    body: Annotated[requests.AdminResendLevel, Body()],
+) -> shared.Items[shared.Team]:
+    """Send the running level's messages to a team again — telegram lost them.
+
+    With ``team_id`` it goes to that one team, without it to every team of the
+    game. The puzzle and the hints the team has already earned go from the
+    engine straight to it; the answer names the teams the request covered and
+    nothing else — not the level any of them is on, not how many hints it has
+    had, not whether it has finished.
+    """
+    teams = await interactor(identity=identity, team_id=body.team_id)
+    rendered = []
+    for team in teams:
+        one = shared.Team.from_core(team)
+        assert one is not None
+        rendered.append(one)
+    return shared.Items(rendered)
+
+
+@inject
 async def upload_game_file(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[AdminUploadGameFileInteractor],
@@ -375,5 +399,6 @@ def setup() -> APIRouter:
     router.add_api_route("/games/{id}/status", change_game_status, methods=["PUT"])
     router.add_api_route("/games/{id}/scenario", change_game_scenario, methods=["PUT"])
     router.add_api_route("/games/{id}/files", upload_game_file, methods=["POST"])
+    router.add_api_route("/games/running/resend", resend_current_level, methods=["POST"])
     router.add_api_route("/files/gc", collect_file_garbage, methods=["POST"])
     return router

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -1,4 +1,4 @@
-from collections.abc import Collection
+from collections.abc import Collection, Iterable
 from typing import Protocol
 
 from shvatka.core.games.dto import BonusEvent, CurrentHintsOnly, Event, PassedLevels
@@ -17,6 +17,7 @@ from shvatka.core.interfaces.dal.game import (
     GameReleaseSaver,
     GameStartPlanner,
 )
+from shvatka.core.interfaces.dal.level_times import LevelByTeamGetter
 from shvatka.core.interfaces.dal.player import PlayerByUserGetter
 from shvatka.core.interfaces.dal.waiver import WaiverChecker
 from shvatka.core.interfaces.identity import IdentityProvider
@@ -62,6 +63,20 @@ class AdminGameStatusChanger(GameByIdGetter, GameCompleter, GameStartPlanner, Pr
         raise NotImplementedError
 
     async def get_by_statuses(self, statuses: Collection[GameStatus]) -> list[dto.Game]:
+        raise NotImplementedError
+
+
+class AdminLevelResender(LevelByTeamGetter, Protocol):
+    """Resend a running level's messages to a team on behalf of an admin.
+
+    As narrow as the job: who is playing the game, and since when each of them
+    is on the level it is on. It reads no key, writes nothing, and the level
+    itself comes from the game the caller already holds — so the panel gains
+    no way to ask where a team is, only a way to send it what it should
+    already have.
+    """
+
+    async def get_played_teams(self, game: dto.Game) -> Iterable[dto.Team]:
         raise NotImplementedError
 
 

--- a/shvatka/core/games/admin_interactors.py
+++ b/shvatka/core/games/admin_interactors.py
@@ -15,16 +15,28 @@ A game's *status* is a different matter: the panel may walk a game that
 collects waivers, runs, is finished or is complete to another status (see
 :class:`AdminChangeGameStatusInteractor`), without ever reading a level, a
 hint or a file of it. Games still being written stay invisible even to that.
+
+The same line runs through the one thing the panel may do to a game that is
+being *played* — resending a level's messages to a team that lost them (see
+:class:`AdminResendCurrentLevelInteractor`). The admin presses the button;
+the puzzle and the hints go from the engine straight to the team, and neither
+they nor the team's position in the game ever pass through the panel.
 """
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import BinaryIO
 
 from adaptix import Retort
 
-from shvatka.core.games.adapters import AdminGameScenarioEditor, AdminGameStatusChanger
+from shvatka.core.games.adapters import (
+    AdminGameScenarioEditor,
+    AdminGameStatusChanger,
+    AdminLevelResender,
+)
 from shvatka.core.interfaces.clients.file_storage import FileStorage
+from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.game import GameFileUploader
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.scheduler import Scheduler
@@ -36,7 +48,22 @@ from shvatka.core.rules.game import check_admin_can_manage_game
 from shvatka.core.services.game import check_no_other_game_active, complete_game
 from shvatka.core.services.scenario.files import save_file, sync_files_for_level
 from shvatka.core.services.scenario.game_ops import parse_uploaded_game
-from shvatka.core.utils.exceptions import CantEditGame, GameNotFound, SHDataBreach
+from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.core.utils.exceptions import (
+    CantEditGame,
+    GameNotFound,
+    GameStatusError,
+    SHDataBreach,
+    TeamCurrentLevelNotFound,
+    TeamError,
+)
+from shvatka.core.views.game import (
+    AnyViewTask,
+    SendHint,
+    SendPuzzle,
+    ShowTasks,
+    ViewSender,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -207,3 +234,95 @@ class AdminChangeGameStatusInteractor:
         await self.dao.cancel_start(game)
         game.start_at = None
         await self.scheduler.cancel_scheduled_game(game)
+
+
+@dataclass
+class AdminResendCurrentLevelInteractor:
+    """Send a running level's messages to a team again, without reading them.
+
+    Telegram drops a message now and then, and a team is left staring at a
+    chat with no puzzle in it. Putting that right used to need an org; the
+    panel can do it now, for one team or for every team of the running game at
+    once.
+
+    What goes out is exactly what the team is entitled to have at this moment:
+    the puzzle of the level it is on, and every hint whose time has already
+    come — the same list its own screen shows, built here from the level and
+    the team's level time. It goes from the engine to the views directly, so
+    the admin sends the hints without ever seeing one.
+
+    The answer is the teams the request covered, in the order the panel asked
+    for them, and nothing else. Not the level any of them is on, not how many
+    hints it has had, not even whether it is still playing: a team that is
+    through the last level is answered for like all the others and simply has
+    nothing to resend. So the button says what it did, and the game keeps its
+    secrets — the panel cannot ask the same question twice and read the team's
+    progress off the difference.
+    """
+
+    dao: AdminLevelResender
+    sender: ViewSender
+    current_game: CurrentGameProvider
+
+    async def __call__(
+        self, identity: IdentityProvider, team_id: int | None = None
+    ) -> list[dto.Team]:
+        admin = await identity.get_superuser()
+        game = await self.current_game.get_required_full_game()
+        if not game.is_started():
+            # there is nothing to resend before the first puzzle went out
+            raise GameStatusError(
+                game_status=game.status.name,
+                game=game,
+                text="cant resend level messages of a game that is not started",
+                notify_user="Переотправить сообщения уровня можно только в идущей игре",
+            )
+        teams = await self._resolve_teams(game, team_id)
+        tasks = ShowTasks()
+        for team in teams:
+            tasks.view.extend(await self._level_messages(team, game))
+        await self.sender.show_later(tasks)
+        logger.warning(
+            "admin %s resent level messages of game %s to %s team(s)",
+            admin.id,
+            game.id,
+            len(teams),
+        )
+        return teams
+
+    async def _resolve_teams(self, game: dto.FullGame, team_id: int | None) -> list[dto.Team]:
+        """The teams to resend to — always taken from the ones playing.
+
+        A team that did not sign up for this game has no level to be sent, so
+        naming one is a mistake rather than a way to find out anything: the
+        answer is the same refusal whether the team exists or not.
+        """
+        played = list(await self.dao.get_played_teams(game))
+        if team_id is None:
+            return played
+        for team in played:
+            if team.id == team_id:
+                return [team]
+        raise TeamError(
+            team_id=team_id,
+            game=game,
+            text=f"team {team_id} does not play the current game",
+            notify_user="Эта команда не играет в текущей игре",
+        )
+
+    async def _level_messages(self, team: dto.Team, game: dto.FullGame) -> list[AnyViewTask]:
+        try:
+            level_time = await self.dao.get_current_level_time(team, game)
+        except TeamCurrentLevelNotFound:
+            # played teams normally have one; a team without it has nothing to lose
+            return []
+        if level_time.has_finished(game):
+            return []
+        level = game.levels[level_time.level_number]
+        shown = level.get_hints_for_timedelta(datetime.now(tz=tz_utc) - level_time.start_at)
+        # hint #0 is the puzzle itself, the rest are the hints already released
+        tasks: list[AnyViewTask] = [SendPuzzle(team=team, level=level)]
+        tasks.extend(
+            SendHint(team=team, hint_number=number, level=level) for number in range(1, len(shown))
+        )
+        return tasks

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -31,12 +31,14 @@ from shvatka.core.files.interactors import CollectFileGarbageInteractor
 from shvatka.core.games.admin_interactors import (
     AdminChangeGameStatusInteractor,
     AdminGamesListInteractor,
+    AdminResendCurrentLevelInteractor,
     AdminUpdateGameScenarioInteractor,
     AdminUploadGameFileInteractor,
 )
 from shvatka.core.games.adapters import (
     AdminGameScenarioEditor,
     AdminGameStatusChanger,
+    AdminLevelResender,
     GameReleaseEditor,
     GameReleaseReader,
 )
@@ -634,8 +636,14 @@ class AdminProvider(Provider):
     def admin_game_status_changer(self, dao: HolderDao) -> AdminGameStatusChanger:
         return AdminGameStatusChangerImpl(dao=dao)
 
+    @provide
+    def admin_level_resender(self, dao: GamePlayerDao) -> AdminLevelResender:
+        # the play dao already answers both questions; the admin sees only these two
+        return dao
+
     admin_games_list = provide(AdminGamesListInteractor)
     admin_change_game_status = provide(AdminChangeGameStatusInteractor)
+    admin_resend_current_level = provide(AdminResendCurrentLevelInteractor)
 
     @provide
     def admin_otl(

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -1342,3 +1342,104 @@ async def test_admin_remove_player_forbidden_for_non_superuser(
     )
     assert resp.status_code == 403
     assert await check_dao.team_player.get_team(draco) is not None
+
+
+# ---------------------------------------------------------------------------
+# Resending the running level's messages (issue shvatka-ui#185). The one thing
+# the panel may do to a game being played — and it does it blind: the answer
+# names the teams the request covered and nothing about where any of them is.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_resends_the_running_level_to_one_team(
+    client: AsyncClient,
+    admin_token: Token,
+    started_game: dto.FullGame,
+    gryffindor: dto.Team,
+):
+    resp = await client.post(
+        "/admin/games/running/resend",
+        json={"team_id": gryffindor.id},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200, resp.text
+    assert [team["id"] for team in resp.json()["items"]] == [gryffindor.id]
+    # the answer carries the team, never a level, a hint or a position in the game
+    assert "level" not in resp.text
+    assert "hint" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_resends_the_running_level_to_every_team(
+    client: AsyncClient,
+    admin_token: Token,
+    started_game: dto.FullGame,
+    gryffindor: dto.Team,
+    slytherin: dto.Team,
+):
+    resp = await client.post(
+        "/admin/games/running/resend",
+        json={},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200, resp.text
+    assert {team["id"] for team in resp.json()["items"]} == {gryffindor.id, slytherin.id}
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_resend_to_a_team_that_does_not_play(
+    client: AsyncClient,
+    admin_token: Token,
+    started_game: dto.FullGame,
+    gryffindor: dto.Team,
+):
+    """Naming a team that is not in the game answers the same either way.
+
+    A refusal that told a stranger's id from a player's would be a way to read
+    the game's roster out of the panel one guess at a time.
+    """
+    resp = await client.post(
+        "/admin/games/running/resend",
+        json={"team_id": gryffindor.id + 1000},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "TeamError"
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_resend_before_the_game_runs(
+    client: AsyncClient,
+    admin_token: Token,
+    game: dto.FullGame,
+    dao: HolderDao,
+):
+    await set_status(game, GameStatus.getting_waivers, dao)
+    resp = await client.post(
+        "/admin/games/running/resend",
+        json={},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "GameStatusError"
+
+
+@pytest.mark.asyncio
+async def test_admin_resend_forbidden_for_non_superuser(
+    client: AsyncClient,
+    hermione_token: Token,
+    started_game: dto.FullGame,
+    gryffindor: dto.Team,
+):
+    resp = await client.post(
+        "/admin/games/running/resend",
+        json={"team_id": gryffindor.id},
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -1166,7 +1166,9 @@ async def test_admin_change_game_status_forbidden_for_non_superuser(
         ("/games/my/{id}", 403, "NotAuthorizedForEdit"),
         ("/games/my/{id}/keys/print", 403, "NotAuthorizedForEdit"),
         ("/games/{id}/keys", 403, "NotAuthorizedForEdit"),
+        # where every team stands right now, and the same table as a file
         ("/games/{id}/stat", 403, "NotAuthorizedForEdit"),
+        ("/games/{id}/stat/export", 403, "NotAuthorizedForEdit"),
         # the media of a running game is offered by what the *team* has been
         # shown, so an admin in no team is turned away one step earlier
         (f"/cdn/games/{{id}}/files/{GUID}", 422, "PlayerNotInTeam"),

--- a/tests/unit/services/admin_resend_level_test.py
+++ b/tests/unit/services/admin_resend_level_test.py
@@ -1,0 +1,273 @@
+"""Resending a running level's messages from the admin panel (shvatka-ui#185).
+
+Telegram loses a message and a team is left without its puzzle. The panel can
+put that right — and these pin down that it does so blind: what the admin gets
+back says which teams were covered and nothing about where any of them is.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+import pytest
+
+from shvatka.core.games.admin_interactors import AdminResendCurrentLevelInteractor
+from shvatka.core.models import dto
+from shvatka.core.models.dto import GameResults, action, hints, scn
+from shvatka.core.models.enums import GameStatus
+from shvatka.core.utils import exceptions
+from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.core.views.game import SendHint, SendPuzzle, ShowTasks
+from tests.fixtures.identity import MockIdentityProvider
+
+AUTHOR = dto.Player(id=1, can_be_author=True, is_dummy=False, username="author")
+
+
+def make_team(id_: int) -> dto.Team:
+    return dto.Team(
+        id=id_,
+        name=f"team{id_}",
+        captain=None,
+        is_dummy=False,
+        description=None,
+    )
+
+
+def make_level(number: int, hint_times: list[int]) -> dto.GamedLevel:
+    scenario = scn.LevelScenario(
+        id=f"level{number}",
+        time_hints=scn.HintsList(
+            [
+                hints.TimeHint(time=time, hint=[hints.TextHint(text=f"hint {time}")])
+                for time in hint_times
+            ]
+        ),
+        conditions=scn.Conditions([action.KeyWinCondition({f"SH{number}"})]),
+        __model_version__=1,
+    )
+    level = dto.Level(
+        db_id=100 + number,
+        name_id=f"level{number}",
+        author=AUTHOR,
+        scenario=scenario,
+        game_id=10,
+        number_in_game=number,
+    )
+    return level  # type: ignore[return-value]
+
+
+def make_game(status: GameStatus = GameStatus.started) -> dto.FullGame:
+    return dto.FullGame(
+        id=10,
+        author=AUTHOR,
+        name="my game",
+        status=status,
+        manage_token="token",
+        start_at=datetime.now(tz=tz_utc) - timedelta(hours=1),
+        number=None,
+        results=GameResults(published_chanel_id=None, results_picture_file_id=None, keys_url=None),
+        levels=[make_level(0, [0, 10, 20]), make_level(1, [0, 5])],
+    )
+
+
+@dataclass
+class FakeResenderDao:
+    """In-memory stand-in for ``AdminLevelResender``."""
+
+    teams: list[dto.Team]
+    level_times: dict[int, dto.LevelTime] = field(default_factory=dict)
+
+    async def get_played_teams(self, game: dto.Game) -> list[dto.Team]:
+        return self.teams
+
+    async def get_current_level_time(self, team: dto.Team, game: dto.Game) -> dto.LevelTime:
+        try:
+            return self.level_times[team.id]
+        except KeyError as e:
+            raise exceptions.TeamCurrentLevelNotFound(team=team, game=game) from e
+
+
+@dataclass
+class FakeSender:
+    shown: list[ShowTasks] = field(default_factory=list)
+
+    async def show_later(self, tasks: ShowTasks) -> None:
+        self.shown.append(tasks)
+
+
+@dataclass
+class FakeCurrentGame:
+    game: dto.FullGame | None
+
+    async def get_full_game(self) -> dto.FullGame | None:
+        return self.game
+
+    async def get_required_full_game(self) -> dto.FullGame:
+        if self.game is None:
+            raise exceptions.HaveNotActiveGame
+        return self.game
+
+
+def level_time(id_: int, team: dto.Team, game: dto.Game, number: int, minutes_ago: int):
+    return dto.LevelTime(
+        id=id_,
+        game=game,
+        team=team,
+        level_number=number,
+        start_at=datetime.now(tz=tz_utc) - timedelta(minutes=minutes_ago),
+    )
+
+
+def admin_identity() -> MockIdentityProvider:
+    admin = dto.Player(id=99, can_be_author=True, is_dummy=False, username="admin")
+    return MockIdentityProvider(player=admin, superuser=admin)
+
+
+def build(game: dto.FullGame, dao: FakeResenderDao) -> tuple:
+    sender = FakeSender()
+    interactor = AdminResendCurrentLevelInteractor(
+        dao=dao,
+        sender=sender,
+        current_game=FakeCurrentGame(game=game),
+    )
+    return interactor, sender
+
+
+@pytest.mark.asyncio
+async def test_resends_the_puzzle_and_the_hints_already_released():
+    """Exactly what the team should have on screen right now, no more."""
+    game = make_game()
+    team = make_team(1)
+    dao = FakeResenderDao(
+        teams=[team],
+        level_times={team.id: level_time(5, team, game, number=0, minutes_ago=12)},
+    )
+    interactor, sender = build(game, dao)
+
+    result = await interactor(identity=admin_identity(), team_id=team.id)
+
+    assert result == [team]
+    # 12 minutes in: the puzzle (0 min) and the 10-minute hint, not the 20-minute one
+    assert sender.shown[0].view == [
+        SendPuzzle(team=team, level=game.levels[0]),
+        SendHint(team=team, hint_number=1, level=game.levels[0]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_hint_whose_time_has_not_come_is_not_resent():
+    game = make_game()
+    team = make_team(1)
+    dao = FakeResenderDao(
+        teams=[team],
+        level_times={team.id: level_time(5, team, game, number=1, minutes_ago=2)},
+    )
+    interactor, sender = build(game, dao)
+
+    await interactor(identity=admin_identity(), team_id=team.id)
+
+    assert sender.shown[0].view == [SendPuzzle(team=team, level=game.levels[1])]
+
+
+@pytest.mark.asyncio
+async def test_without_a_team_every_playing_team_gets_its_own_level():
+    game = make_game()
+    first, second = make_team(1), make_team(2)
+    dao = FakeResenderDao(
+        teams=[first, second],
+        level_times={
+            first.id: level_time(5, first, game, number=0, minutes_ago=1),
+            second.id: level_time(6, second, game, number=1, minutes_ago=1),
+        },
+    )
+    interactor, sender = build(game, dao)
+
+    result = await interactor(identity=admin_identity())
+
+    assert result == [first, second]
+    assert sender.shown[0].view == [
+        SendPuzzle(team=first, level=game.levels[0]),
+        SendPuzzle(team=second, level=game.levels[1]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_team_that_has_finished_is_answered_for_like_the_others():
+    """The answer must not tell the admin who is through the last level."""
+    game = make_game()
+    playing, finished = make_team(1), make_team(2)
+    dao = FakeResenderDao(
+        teams=[playing, finished],
+        level_times={
+            playing.id: level_time(5, playing, game, number=0, minutes_ago=1),
+            # level_number past the last level is what "finished" looks like
+            finished.id: level_time(6, finished, game, number=2, minutes_ago=1),
+        },
+    )
+    interactor, sender = build(game, dao)
+
+    result = await interactor(identity=admin_identity())
+
+    assert result == [playing, finished]
+    assert sender.shown[0].view == [SendPuzzle(team=playing, level=game.levels[0])]
+
+
+@pytest.mark.asyncio
+async def test_a_team_without_a_level_time_costs_the_others_nothing():
+    game = make_game()
+    playing, stranger = make_team(1), make_team(2)
+    dao = FakeResenderDao(
+        teams=[playing, stranger],
+        level_times={playing.id: level_time(5, playing, game, number=0, minutes_ago=1)},
+    )
+    interactor, sender = build(game, dao)
+
+    result = await interactor(identity=admin_identity())
+
+    assert result == [playing, stranger]
+    assert sender.shown[0].view == [SendPuzzle(team=playing, level=game.levels[0])]
+
+
+@pytest.mark.asyncio
+async def test_a_team_that_does_not_play_is_refused():
+    game = make_game()
+    team = make_team(1)
+    dao = FakeResenderDao(
+        teams=[team],
+        level_times={team.id: level_time(5, team, game, number=0, minutes_ago=1)},
+    )
+    interactor, sender = build(game, dao)
+
+    with pytest.raises(exceptions.TeamError):
+        await interactor(identity=admin_identity(), team_id=2)
+    assert sender.shown == []
+
+
+@pytest.mark.parametrize(
+    "status", [GameStatus.getting_waivers, GameStatus.finished, GameStatus.complete]
+)
+@pytest.mark.asyncio
+async def test_nothing_to_resend_until_the_game_runs(status: GameStatus):
+    game = make_game(status)
+    team = make_team(1)
+    dao = FakeResenderDao(teams=[team])
+    interactor, sender = build(game, dao)
+
+    with pytest.raises(exceptions.GameStatusError):
+        await interactor(identity=admin_identity())
+    assert sender.shown == []
+
+
+@pytest.mark.asyncio
+async def test_a_player_who_is_not_an_admin_gets_nowhere():
+    game = make_game()
+    team = make_team(1)
+    dao = FakeResenderDao(
+        teams=[team],
+        level_times={team.id: level_time(5, team, game, number=0, minutes_ago=1)},
+    )
+    interactor, sender = build(game, dao)
+    player = dto.Player(id=2, can_be_author=False, is_dummy=False, username="player")
+
+    with pytest.raises(exceptions.NotAuthorizedForAdmin):
+        await interactor(identity=MockIdentityProvider(player=player))
+    assert sender.shown == []


### PR DESCRIPTION
Engine side of bomzheg/shvatka-ui#185 — the admin panel gets a button that resends a level's messages to a team, «без доступа админу к подсказкам».

## What it does

`POST /admin/games/running/resend` with `{"team_id": <id>}` — or `{}` for every team of the running game — sends the team the puzzle of the level it is on and every hint whose time has already come. That is the same list the team's own screen shows, built in `AdminResendCurrentLevelInteractor` from the level and the team's level time, and handed to `ViewSender.show_later` like every other in-game message. So the messages reach telegram and the web push, and the admin sends the hints without ever seeing one.

## Keeping the panel blind

The answer is `Items[Team]` — the teams the request covered, in the order the panel asked for them, and nothing else. Not the level any of them is on, not how many hints it has had, not whether it is still playing:

- a team through the last level is answered for like all the others and simply has nothing resent, so asking twice and diffing the answers tells the panel nothing about anyone's progress;
- a team that does not play the game is refused the same way whether it exists or not, so the roster cannot be read out one guess at a time;
- the dao the interactor gets is a new, narrow `AdminLevelResender` (who plays, and since when each is on its level) rather than the full `GamePlayerDao`, so the panel gains no way to *ask* where a team is — only a way to send it what it should already have.

The game must be `started`; anything else is a `GameStatusError`, and `identity.get_superuser()` guards the whole thing.

## Also

`/games/{id}/stat/export` is `/games/{id}/stat` as a file — the same table of where every team stands right now. It was already guarded (the interactor asks for a spying org exactly like the json one) but not covered, so it joins the regression list that pins an admin reading nothing of a running game.

## Tests

- `tests/unit/services/admin_resend_level_test.py` — what goes out at a given point on the level, the finished team answered for like the rest, the stranger refused, the statuses that have nothing to resend, and a non-admin getting nowhere.
- `tests/integration/api_full/test_admin.py` — the endpoint for one team and for all, the refusals, and an assertion that the response body contains neither `level` nor `hint`.

`ruff format --check .`, `ruff check .`, `mypy` and `pytest tests/unit` are green locally; the integration suite needs docker, which this environment has none of, so it runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gYUwJyS6RQNqEdszBqnfR

---
_Generated by [Claude Code](https://claude.ai/code/session_015gYUwJyS6RQNqEdszBqnfR)_