### PR TITLE
perf(dao): stop joining forum_users on every player load

### DIFF
--- a/docs/modules/shep/nav.adoc
+++ b/docs/modules/shep/nav.adoc
@@ -9,4 +9,5 @@
 ** xref:shep-0008-rich-results.adoc[SHEP-0008 Results as a rich message]
 ** xref:shep-0009-key-submission-latency.adoc[SHEP-0009 Key submission latency]
 ** xref:shep-0010-message-outbox.adoc[SHEP-0010 Message outbox]
+** xref:shep-0011-player-identity-loading.adoc[SHEP-0011 Player identity loading]
 ** xref:template.adoc[SHEP template]

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -66,6 +66,10 @@ came out of it*.
 | xref:shep-0010-message-outbox.adoc[SHEP-0010]
 | Durable delivery of what the game shows
 | Draft
+
+| xref:shep-0011-player-identity-loading.adoc[SHEP-0011]
+| Loading a player without their forum account
+| Accepted, implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0011-player-identity-loading.adoc
+++ b/docs/modules/shep/pages/shep-0011-player-identity-loading.adoc
@@ -1,0 +1,132 @@
+= SHEP-0011 — Loading a player without their forum account
+:navtitle: SHEP-0011 Player identity loading
+
+[cols="1,4"]
+|===
+| SHEP | 0011
+| Title | Loading a player without their forum account
+| Status | `Accepted, implemented`
+| Created | 2026-08-27
+| Updated | 2026-08-27
+| Related | PR #379
+|===
+
+== Summary
+
+Every query that loaded a player also joined `forum_users`, even though only the
+profile, the admin panel, global search and the merge flow ever read the forum
+account. The forum identity moves out of `dto.Player` into a separate
+`dto.PlayerWithForum`, so the type says which queries paid for the join — and
+the ~30 bulk queries that never needed it stop joining the table.
+
+== Context
+
+`models.Player.to_dto_user_prefetched()` filled both `user` and `forum_user`,
+and 42 eager-load sites across 11 DAO modules asked for both. That was not
+defensive by accident: `dto.Player` had no way to express "this relation was
+not loaded", so `_forum_user is None` meant both "no forum account" and "we did
+not ask". Loading it everywhere made the two indistinguishable but always safe.
+
+What actually reads the forum identity is narrow:
+
+* `api/players/responses.py` `PlayerWithIdentities` — `/me` and the profile;
+* `api/admin/responses.py` `AdminPlayer` — the admin player list and card;
+* `core/players/player.py` `merge_players` — refuses a second forum account;
+* `core/search/interactors.py` `classify_player_hit` — the `forum_name` hit;
+* `tgbot/dialogs/main_menu` — offers linking a forum account to players without one;
+* `Player.name_mention` — a forum-imported dummy with no real username.
+
+Nothing else: the shared `api/shared/responses.py` `Player` (game authors, team
+captains, poll entries) reads only `id`, `can_be_author`, `name_mention` and
+`username`, and every bot view builds player cards from `username` and the
+telegram link.
+
+Two things made the join redundant rather than merely unused. Migration
+`d4ddc1efb2ff` backfilled `players.username` for every row
+(`coalesce(tg username, forum name, 'id'||id)`), and every creation path since
+sets it through `get_free_and_associated_username`. So `name_mention` returns
+the username without consulting either identity, and a forum-only player is
+already found by their username.
+
+The cost was worst on the hottest path: `PlayerDao.get_by_id`, called for every
+authenticated API request from `api/app/dependencies/auth.py`, used two
+`selectinload` options — three roundtrips to answer a question that almost
+every endpoint asks only for an id.
+
+== Decision
+
+=== The forum identity lives on its own dto
+
+`dto.Player` keeps `_user` and drops `forum_user`, `has_forum_user()` and
+`get_forum_name()`. `dto.PlayerWithForum(Player)` adds a public `forum_user`
+field and those two accessors back, plus the `name_mention` branch for a
+forum-imported dummy.
+
+A subclass, not a sentinel on `Player`: a caller that needs the forum account
+now says so in its signature, and mypy rejects a plain `Player` there. The
+alternative — a `NOT_LOADED` marker so `has_forum_user()` could raise on an
+unloaded player — keeps one type but moves the check to runtime, and every
+consumer would have to be trusted to trigger it.
+
+=== Two ways to load a player by id
+
+`PlayerDao.get_by_id` loads the telegram user only, with `joinedload` — one
+statement instead of three. `PlayerDao.get_identities_by_id` loads both and
+returns `PlayerWithForum`; `core/interfaces/dal/player.py` exposes it as
+`PlayerIdentitiesGetter`, and `PlayerMergeOperandsGetter` composes both for the
+interactors that need each.
+
+`IdentityProvider.get_player()` keeps returning a plain `Player`. `/me` is the
+one endpoint that renders the forum account, so it pays for a second lookup
+instead of every authenticated request carrying the join.
+
+=== The bot asks for the flag, not the account
+
+The main menu offers "Былые свершения" only to players without a forum account.
+`ForumUserDAO.exists_for_player` answers that with one indexed lookup and the
+getter passes `has_forum_user` to the window, rather than the dialog reaching
+into the player dto.
+
+=== Exports identify a player by username
+
+`export_stat.Player.from_dto` loses its `forum_name` fallback: the username
+branch already covers a forum-only player, since the backfill derived their
+username from the forum name. `PlayerIdentity.forum_name` stays — the crawler
+still produces it and the loader still resolves it, so old exports import
+unchanged.
+
+== Consequences
+
+* Every list of games, levels, waivers, key logs, organizers, team players and
+  files loses one `LEFT OUTER JOIN forum_users`, and each authenticated API
+  request loses two roundtrips.
+* `/me` and the admin player card cost one extra query. That is the trade: the
+  rare endpoint pays instead of the common one.
+* Adding a forum read to a bulk path is now a visible type change rather than a
+  silent `None`.
+* A forum-imported dummy whose username is still the `id{N}` placeholder is
+  mentioned as `dummy-{id}` on paths that load a plain `Player`.
+  `renew_id_usernames` exists to remove those placeholders.
+
+== Phases and status
+
+[cols="1,4,2",options="header"]
+|===
+| Phase | Content | Status
+
+| 1 | Split the dto, add `get_identities_by_id`, drop the join from the bulk queries | ✅ done in PR #379
+| 2 | Same treatment for `models.Player.user` where only `username` is read | ⏳ not started
+|===
+
+== Deviations from the plan
+
+`PlayerDao.search_players` keeps the forum join and returns `PlayerWithForum`
+for both its callers, including the public player search which discards it. The
+query is admin-shaped and already outer-joins `users` and `email_accounts`;
+splitting it in two to save one more join was not worth the duplication.
+
+== Open questions
+
+Whether `_user` deserves the same split. It is read far more widely — every bot
+player card links to the telegram account — but list endpoints that render only
+`username` do not need it either. Phase 2 above.

--- a/shvatka/api/admin/responses.py
+++ b/shvatka/api/admin/responses.py
@@ -16,14 +16,14 @@ class AdminPlayer:
     forum: ForumUser | None
 
     @classmethod
-    def from_core(cls, core: dto.Player) -> "AdminPlayer":
+    def from_core(cls, core: dto.PlayerWithForum) -> "AdminPlayer":
         return cls(
             id=core.id,
             can_be_author=core.can_be_author,
             name_mention=core.name_mention,
             username=core.username,
             tg=TgUser.from_core(core._user),  # noqa: SLF001
-            forum=ForumUser.from_core(core._forum_user),  # noqa: SLF001
+            forum=ForumUser.from_core(core.forum_user),
         )
 
 

--- a/shvatka/api/players/responses.py
+++ b/shvatka/api/players/responses.py
@@ -30,7 +30,7 @@ class PlayerWithIdentities:
     @classmethod
     def from_core(
         cls,
-        player: dto.Player,
+        player: dto.PlayerWithForum,
         email: dto.EmailAccount | None,
         superusers: "Sequence[int]" = (),
         pending_email: str | None = None,
@@ -42,7 +42,7 @@ class PlayerWithIdentities:
             name_mention=player.name_mention,
             username=player.username,
             tg=TgUser.from_core(tg),
-            forum=ForumUser.from_core(player._forum_user),  # noqa: SLF001
+            forum=ForumUser.from_core(player.forum_user),
             email=EmailAccount.from_core(email),
             is_admin=tg is not None and tg.tg_id in superusers,
             # The address already linked (verified or not) is described by `email`;

--- a/shvatka/api/players/routes.py
+++ b/shvatka/api/players/routes.py
@@ -30,10 +30,11 @@ async def read_users_me(
     player_ = await identity.get_player()
     if player_ is None:
         raise HTTPException(status_code=401, detail="User not found")
-    email = await dao.email.get_by_player_id(player_.id)
-    pending_email = await dao.email_confirm.get_pending_email(player_.id)
+    identities = await dao.player.get_identities_by_id(player_.id)
+    email = await dao.email.get_by_player_id(identities.id)
+    pending_email = await dao.email_confirm.get_pending_email(identities.id)
     return responses.PlayerWithIdentities.from_core(
-        player_, email, config.superusers, pending_email
+        identities, email, config.superusers, pending_email
     )
 
 

--- a/shvatka/core/interfaces/dal/player.py
+++ b/shvatka/core/interfaces/dal/player.py
@@ -17,6 +17,22 @@ class PlayerByIdGetter(Protocol):
         raise NotImplementedError
 
 
+class PlayerIdentitiesGetter(Protocol):
+    """Load a player together with their forum identity.
+
+    Separate from :class:`PlayerByIdGetter` because reading the forum account
+    costs a join that almost nothing needs — only ask for it where the forum
+    identity is actually shown or checked.
+    """
+
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        raise NotImplementedError
+
+
+class PlayerMergeOperandsGetter(PlayerByIdGetter, PlayerIdentitiesGetter, Protocol):
+    """Load players by id, plus the two sides of a merge with their forum identity."""
+
+
 class PlayerByUserIdGetter(Protocol):
     async def get_by_user_id(self, user_id: int) -> dto.Player:
         raise NotImplementedError

--- a/shvatka/core/models/dto/__init__.py
+++ b/shvatka/core/models/dto/__init__.py
@@ -24,7 +24,7 @@ from .level_testing import (
 )
 from .levels_times import GameStat, GameStatWithHints, LevelTime, LevelTimeOnGame, SpyHintInfo
 from .organizer import Organizer, PrimaryOrganizer, SecondaryOrganizer
-from .player import Player, PlayerWithCreds, PlayerWithStat
+from .player import Player, PlayerWithCreds, PlayerWithForum, PlayerWithStat
 from .poll import Vote, VotedPlayer
 from .team import Team
 from .team_player import FullTeamPlayer, TeamDataRange, TeamPlayer

--- a/shvatka/core/models/dto/export_stat.py
+++ b/shvatka/core/models/dto/export_stat.py
@@ -41,12 +41,8 @@ class Player:
             player_tg_id = player.get_chat_id()
             assert player_tg_id is not None
             return Player(tg_user_id=player_tg_id, identity=PlayerIdentity.tg_user_id)
-        elif player.has_forum_user():
-            player_name = player.get_forum_name()
-            assert player_name is not None
-            return Player(forum_name=player_name, identity=PlayerIdentity.forum_name)
         else:
-            raise RuntimeError("player without user, forum_user and username")
+            raise RuntimeError("player without user and username")
 
 
 @dataclass

--- a/shvatka/core/models/dto/player.py
+++ b/shvatka/core/models/dto/player.py
@@ -14,12 +14,9 @@ class Player:
     username: str | None = field(default=None)
     user: InitVar[User | None] = field(default=None)
     _user: User | None = field(init=False)
-    forum_user: InitVar[ForumUser | None] = field(default=None)
-    _forum_user: ForumUser | None = field(init=False)
 
-    def __post_init__(self, user: User | None, forum_user: ForumUser | None) -> None:
+    def __post_init__(self, user: User | None) -> None:
         self._user = user
-        self._forum_user = forum_user
 
     def username_is_dummy(self) -> bool:
         return self.username == f"id{self.id}"
@@ -29,19 +26,14 @@ class Player:
         if self.username is not None and not self.username_is_dummy():
             return self.username
         if self.is_dummy:
-            if self._forum_user:
-                return self._forum_user.name_mention
             return f"dummy-{self.id}"
         if self.has_user():
-            assert self._user, f"only tg users supported, got forum user, {self!r}"
+            assert self._user, f"has_user() lied about {self!r}"
             return self._user.name_mention
         return f"id{self.id}"
 
     def has_user(self) -> bool:
         return self._user is not None
-
-    def has_forum_user(self) -> bool:
-        return self._forum_user is not None
 
     def get_tech_chat_id(self, reserve_chat_id: int) -> int:
         return self.get_chat_id() or reserve_chat_id
@@ -62,12 +54,6 @@ class Player:
             return None
         return self._user.fullname or None
 
-    def get_forum_name(self) -> str | None:
-        if self._forum_user is None:
-            return None
-        assert self._forum_user, f"only forum users supported, got tg user, {self!r}"
-        return self._forum_user.name
-
     def with_stat(self, typed_keys_count: int, typed_correct_keys_count: int) -> PlayerWithStat:
         return PlayerWithStat(
             id=self.id,
@@ -75,7 +61,6 @@ class Player:
             can_be_author=self.can_be_author,
             is_dummy=self.is_dummy,
             user=self._user,
-            forum_user=self._forum_user,
             typed_keys_count=typed_keys_count,
             typed_correct_keys_count=typed_correct_keys_count,
         )
@@ -88,8 +73,41 @@ class Player:
             username=self.username,
             hashed_password=hashed_password,
             user=self._user,
-            forum_user=self._forum_user,
         )
+
+
+@dataclass
+class PlayerWithForum(Player):
+    """A player together with their forum identity.
+
+    Reading the forum account means joining ``forum_users``, and almost nothing
+    needs it: a player carries their own ``username``, and telegram links come
+    from ``_user``. So only the paths that actually render or check the forum
+    account ask for this type — the profile, the admin panel, global search,
+    the merge flow and forum-driven lookups — and everywhere else a plain
+    :class:`Player` is loaded without touching the forum table.
+    """
+
+    forum_user: ForumUser | None = None
+
+    @property
+    def name_mention(self) -> str:
+        # a forum-imported dummy saved before usernames existed has nothing else to show
+        if (
+            self.is_dummy
+            and self.forum_user is not None
+            and (self.username is None or self.username_is_dummy())
+        ):
+            return self.forum_user.name_mention
+        return super().name_mention
+
+    def has_forum_user(self) -> bool:
+        return self.forum_user is not None
+
+    def get_forum_name(self) -> str | None:
+        if self.forum_user is None:
+            return None
+        return self.forum_user.name
 
 
 @dataclass
@@ -103,7 +121,6 @@ class PlayerWithCreds(Player):
             is_dummy=self.is_dummy,
             username=self.username,
             user=self._user,
-            forum_user=self._forum_user,
         )
 
 

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -24,6 +24,7 @@ from shvatka.core.interfaces.dal.complex import TeamMerger
 from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
+    PlayerMergeOperandsGetter,
     PlayerPromoter,
     TeamJoiner,
     TeamPlayerGetter,
@@ -389,7 +390,7 @@ class AcceptRequestInteractor:
     team_joiner: TeamJoiner
     team_dao: TeamByIdGetter
     team_player_dao: TeamPlayerGetter
-    player_dao: PlayerByIdGetter
+    player_dao: PlayerMergeOperandsGetter
     org_adder: OrgAdder
     team_merger: TeamMerger
     player_merger: PlayerMerger
@@ -520,8 +521,10 @@ class AcceptRequestInteractor:
         timeline: list[TimelineItem] | None = None,
     ) -> ndto.ActionRequest:
         admin = await identity.get_superuser()
-        primary = await self.player_dao.get_by_id(request.payload["primary_player_id"])
-        secondary = await self.player_dao.get_by_id(request.payload["secondary_player_id"])
+        primary = await self.player_dao.get_identities_by_id(request.payload["primary_player_id"])
+        secondary = await self.player_dao.get_identities_by_id(
+            request.payload["secondary_player_id"]
+        )
         logger.warning(
             "admin %s accepted player merge request %s: merging player %s into %s%s",
             admin.id,

--- a/shvatka/core/players/admin_interactors.py
+++ b/shvatka/core/players/admin_interactors.py
@@ -41,7 +41,7 @@ class AdminSearchPlayersInteractor:
         active: bool = True,
         archive: bool = False,
         can_be_author: bool | None = None,
-    ) -> list[dto.Player]:
+    ) -> list[dto.PlayerWithForum]:
         admin = await identity.get_superuser()
         logger.warning(
             "admin %s searched players (username=%s, name=%s, can_be_author=%s)",
@@ -66,7 +66,7 @@ class AdminGetPlayerInteractor:
     async def __call__(self, identity: IdentityProvider, player_id: int) -> PlayerIdentitiesInfo:
         admin = await identity.get_superuser()
         logger.warning("admin %s viewed player %s", admin.id, player_id)
-        player = await self.dao.get_by_id(player_id)
+        player = await self.dao.get_identities_by_id(player_id)
         email = await self.dao.get_email_by_player_id(player.id)
         return PlayerIdentitiesInfo(player=player, email=email)
 
@@ -112,7 +112,7 @@ class AdminSetPlayerUsernameInteractor:
         if normalized is None:
             raise exceptions.PlayerInvalidUsername(text=f"invalid username {username}")
         await set_player_username(player, normalized, self.dao)
-        updated = await self.dao.get_by_id(player.id)
+        updated = await self.dao.get_identities_by_id(player.id)
         email = await self.dao.get_email_by_player_id(updated.id)
         return PlayerIdentitiesInfo(player=updated, email=email)
 
@@ -142,7 +142,7 @@ class AdminChangePlayerTgInteractor:
         await self.dao.unlink_user(player)
         await self.dao.link_user(player, saved)
         await self.dao.commit()
-        updated = await self.dao.get_by_id(player.id)
+        updated = await self.dao.get_identities_by_id(player.id)
         email = await self.dao.get_email_by_player_id(updated.id)
         return PlayerIdentitiesInfo(player=updated, email=email)
 
@@ -182,7 +182,7 @@ class AdminMergePlayersInteractor:
             raise exceptions.MergeError(
                 player_id=primary_id, notify_user="нельзя объединить игрока с самим собой"
             )
-        primary = await self.dao.get_by_id(primary_id)
-        secondary = await self.dao.get_by_id(secondary_id)
+        primary = await self.dao.get_identities_by_id(primary_id)
+        secondary = await self.dao.get_identities_by_id(secondary_id)
         await merge_players(primary, secondary, self.game_log, self.dao, timeline=timeline)
         return await self.dao.get_by_id(primary_id)

--- a/shvatka/core/players/dto.py
+++ b/shvatka/core/players/dto.py
@@ -21,7 +21,7 @@ class PlayerMainInfo:
 class PlayerIdentitiesInfo:
     """A player together with their email account (telegram/forum live on the player)."""
 
-    player: dto.Player
+    player: dto.PlayerWithForum
     email: dto.EmailAccount | None
 
 

--- a/shvatka/core/players/interactors.py
+++ b/shvatka/core/players/interactors.py
@@ -66,7 +66,7 @@ class SearchPlayersInteractor:
         active: bool = True,
         archive: bool = False,
         can_be_author: bool | None = None,
-    ) -> list[dto.Player]:
+    ) -> list[dto.PlayerWithForum]:
         return await self.dao.search_players(
             username=username,
             name=name,

--- a/shvatka/core/players/interfaces.py
+++ b/shvatka/core/players/interfaces.py
@@ -11,6 +11,7 @@ from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
     PlayerByUserIdGetter,
     PlayerDeleter,
+    PlayerIdentitiesGetter,
     PlayerWaiversGetter,
     TeamPlayerHistoryCleaner,
     TeamPlayerHistoryGetter,
@@ -43,7 +44,7 @@ class PlayerSearcher(Protocol):
         active: bool = True,
         archive: bool = False,
         can_be_author: bool | None = None,
-    ) -> list[dto.Player]:
+    ) -> list[dto.PlayerWithForum]:
         raise NotImplementedError
 
 
@@ -90,8 +91,8 @@ class PlayerMerger(
     pass
 
 
-class AdminPlayerReader(PlayerByIdGetter, EmailByPlayerIdReader, Protocol):
-    """Load a player by id together with their email account."""
+class AdminPlayerReader(PlayerIdentitiesGetter, EmailByPlayerIdReader, Protocol):
+    """Load a player by id together with their email and forum accounts."""
 
 
 class AdminEmailSetter(PlayerByIdGetter, Committer, Protocol):
@@ -105,13 +106,22 @@ class AdminEmailSetter(PlayerByIdGetter, Committer, Protocol):
 
 
 class AdminUsernameSetter(
-    PlayerUsernameChanger, PlayerByIdGetter, EmailByPlayerIdReader, Protocol
+    PlayerUsernameChanger,
+    PlayerByIdGetter,
+    PlayerIdentitiesGetter,
+    EmailByPlayerIdReader,
+    Protocol,
 ):
     """Set the username of an arbitrary player, plus reload them by id."""
 
 
 class AdminTgChanger(
-    UserUpserter, PlayerByIdGetter, PlayerByUserIdGetter, EmailByPlayerIdReader, Protocol
+    UserUpserter,
+    PlayerByIdGetter,
+    PlayerIdentitiesGetter,
+    PlayerByUserIdGetter,
+    EmailByPlayerIdReader,
+    Protocol,
 ):
     async def unlink_user(self, player: dto.Player) -> None:
         raise NotImplementedError
@@ -120,7 +130,7 @@ class AdminTgChanger(
         raise NotImplementedError
 
 
-class AdminPlayerMerger(PlayerMerger, PlayerByIdGetter, Protocol):
+class AdminPlayerMerger(PlayerMerger, PlayerByIdGetter, PlayerIdentitiesGetter, Protocol):
     """Merge one player into another, plus load both by id."""
 
 

--- a/shvatka/core/players/player.py
+++ b/shvatka/core/players/player.py
@@ -6,7 +6,6 @@ from itertools import pairwise
 from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
     PlayerByUserIdGetter,
-    PlayerIdentitiesGetter,
     PlayerPromoter,
     PlayerTeamChecker,
     PlayerUpserter,
@@ -72,12 +71,6 @@ async def get_my_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.Team | 
 
 async def get_player_by_id(id_: int, dao: PlayerByIdGetter) -> dto.Player:
     return await dao.get_by_id(id_)
-
-
-async def get_player_identities_by_id(
-    id_: int, dao: PlayerIdentitiesGetter
-) -> dto.PlayerWithForum:
-    return await dao.get_identities_by_id(id_)
 
 
 async def get_player_by_user_id(user_id: int, dao: PlayerByUserIdGetter) -> dto.Player:

--- a/shvatka/core/players/player.py
+++ b/shvatka/core/players/player.py
@@ -6,6 +6,7 @@ from itertools import pairwise
 from shvatka.core.interfaces.dal.player import (
     PlayerByIdGetter,
     PlayerByUserIdGetter,
+    PlayerIdentitiesGetter,
     PlayerPromoter,
     PlayerTeamChecker,
     PlayerUpserter,
@@ -71,6 +72,12 @@ async def get_my_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.Team | 
 
 async def get_player_by_id(id_: int, dao: PlayerByIdGetter) -> dto.Player:
     return await dao.get_by_id(id_)
+
+
+async def get_player_identities_by_id(
+    id_: int, dao: PlayerIdentitiesGetter
+) -> dto.PlayerWithForum:
+    return await dao.get_identities_by_id(id_)
 
 
 async def get_player_by_user_id(user_id: int, dao: PlayerByUserIdGetter) -> dto.Player:
@@ -373,8 +380,8 @@ async def dismiss_promotion(token: str, dao: InviteRemover):
 
 
 async def merge_players(
-    primary: dto.Player,
-    secondary: dto.Player,
+    primary: dto.PlayerWithForum,
+    secondary: dto.PlayerWithForum,
     game_log: GameLogWriter,
     dao: PlayerMerger,
     timeline: list[TimelineItem] | None = None,

--- a/shvatka/core/search/adapters.py
+++ b/shvatka/core/search/adapters.py
@@ -21,6 +21,6 @@ class GlobalSearchDao(Protocol):
         """Команды (включая архивные форумные), чьё название содержит text."""
         raise NotImplementedError
 
-    async def search_players(self, text: str) -> list[dto.Player]:
+    async def search_players(self, text: str) -> list[dto.PlayerWithForum]:
         """Игроки, у которых text встречается в username, имени в tg или имени на форуме."""
         raise NotImplementedError

--- a/shvatka/core/search/dto.py
+++ b/shvatka/core/search/dto.py
@@ -70,7 +70,7 @@ class TeamHit:
 
 @dataclass(frozen=True, kw_only=True)
 class PlayerHit:
-    player: dto.Player
+    player: dto.PlayerWithForum
     found_in: PlayerMatchField
     snippet: str
 

--- a/shvatka/core/search/interactors.py
+++ b/shvatka/core/search/interactors.py
@@ -122,7 +122,7 @@ def make_hint_part_snippet(
     return result
 
 
-def classify_player_hit(player: dto.Player, query: str) -> PlayerHit | None:
+def classify_player_hit(player: dto.PlayerWithForum, query: str) -> PlayerHit | None:
     if player.username and (snippet := make_snippet(player.username, query)):
         return PlayerHit(player=player, found_in=PlayerMatchField.username, snippet=snippet)
     tg_username = player.get_tg_username()

--- a/shvatka/infrastructure/db/dao/complex/player.py
+++ b/shvatka/infrastructure/db/dao/complex/player.py
@@ -95,6 +95,9 @@ class AdminPlayerMergerImpl(PlayerMergerImpl, AdminPlayerMerger):
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
 
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        return await self.dao.player.get_identities_by_id(id_)
+
 
 @dataclass
 class AdminPlayerWaiverPointsReaderImpl(AdminPlayerWaiverPointsReader):
@@ -111,8 +114,8 @@ class AdminPlayerWaiverPointsReaderImpl(AdminPlayerWaiverPointsReader):
 class AdminPlayerReaderImpl(AdminPlayerReader):
     dao: "HolderDao"
 
-    async def get_by_id(self, id_: int) -> dto.Player:
-        return await self.dao.player.get_by_id(id_)
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        return await self.dao.player.get_identities_by_id(id_)
 
     async def get_email_by_player_id(self, player_id: int) -> dto.EmailAccount | None:
         return await self.dao.email.get_by_player_id(player_id)
@@ -144,6 +147,9 @@ class AdminUsernameSetterImpl(AdminUsernameSetter):
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
 
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        return await self.dao.player.get_identities_by_id(id_)
+
     async def is_username_occupied(self, username: str) -> bool:
         return await self.dao.player.is_username_occupied(username)
 
@@ -166,6 +172,9 @@ class AdminTgChangerImpl(AdminTgChanger):
 
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
+
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        return await self.dao.player.get_identities_by_id(id_)
 
     async def get_by_user_id(self, user_id: int) -> dto.Player:
         return await self.dao.player.get_by_user_id(user_id)

--- a/shvatka/infrastructure/db/dao/complex/search.py
+++ b/shvatka/infrastructure/db/dao/complex/search.py
@@ -22,5 +22,5 @@ class GlobalSearchDaoImpl(GlobalSearchDao):
     async def search_teams(self, text: str) -> list[dto.Team]:
         return await self.dao.team.search_by_name(text)
 
-    async def search_players(self, text: str) -> list[dto.Player]:
+    async def search_players(self, text: str) -> list[dto.PlayerWithForum]:
         return await self.dao.player.search_by_any_name(text)

--- a/shvatka/infrastructure/db/dao/rdb/email.py
+++ b/shvatka/infrastructure/db/dao/rdb/email.py
@@ -93,7 +93,6 @@ class EmailAccountDao(BaseDAO[models.EmailAccount]):
             .join(models.Player.email)
             .options(
                 joinedload(models.Player.user),
-                joinedload(models.Player.forum_user),
                 contains_eager(models.Player.email),
             )
             .where(

--- a/shvatka/infrastructure/db/dao/rdb/file_info.py
+++ b/shvatka/infrastructure/db/dao/rdb/file_info.py
@@ -116,11 +116,7 @@ class FileInfoDao(BaseDAO[models.FileInfo]):
     async def get_all(self, limit: int, offset: int) -> Sequence[hints.SavedFileMeta]:
         result: ScalarResult[models.FileInfo] = await self.session.scalars(
             select(models.FileInfo)
-            .options(
-                joinedload(models.FileInfo.author).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                )
-            )
+            .options(joinedload(models.FileInfo.author).options(joinedload(models.Player.user)))
             .order_by(models.FileInfo.id)
             .limit(limit)
             .offset(offset)
@@ -192,11 +188,7 @@ class FileInfoDao(BaseDAO[models.FileInfo]):
         result: ScalarResult[models.FileInfo] = await self.session.scalars(
             select(models.FileInfo)
             .where(models.FileInfo.file_id.is_(None))
-            .options(
-                joinedload(models.FileInfo.author).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                )
-            )
+            .options(joinedload(models.FileInfo.author).options(joinedload(models.Player.user)))
             .limit(limit)
         )
         return [f.to_dto(f.author.to_dto_user_prefetched()) for f in result.all()]

--- a/shvatka/infrastructure/db/dao/rdb/forum_user.py
+++ b/shvatka/infrastructure/db/dao/rdb/forum_user.py
@@ -41,6 +41,13 @@ class ForumUserDAO(BaseDAO[models.ForumUser]):
         result = await self._get_by_id(id_)
         return result.to_dto()
 
+    async def exists_for_player(self, player_id: int) -> bool:
+        """Whether the player has a forum account, without loading it."""
+        result = await self.session.scalars(
+            select(models.ForumUser.id).where(models.ForumUser.player_id == player_id).limit(1)
+        )
+        return result.one_or_none() is not None
+
     async def get_by_forum_id(self, forum_id: int) -> dto.ForumUser:
         result = await self.session.scalars(
             select(models.ForumUser).where(models.ForumUser.forum_id == forum_id)

--- a/shvatka/infrastructure/db/dao/rdb/game.py
+++ b/shvatka/infrastructure/db/dao/rdb/game.py
@@ -59,7 +59,6 @@ class GameDao(BaseDAO[models.Game]):
                 joinedload(models.Game.levels),
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 ),
             ),
         )
@@ -83,7 +82,6 @@ class GameDao(BaseDAO[models.Game]):
             options = (
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 ),
             )
             game = await self._get_by_id(id_, options)
@@ -117,7 +115,6 @@ class GameDao(BaseDAO[models.Game]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 )
             )
             .where(
@@ -136,7 +133,6 @@ class GameDao(BaseDAO[models.Game]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 )
             )
             .where(models.Game.status.in_(statuses))
@@ -151,7 +147,6 @@ class GameDao(BaseDAO[models.Game]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 )
             )
             .where(
@@ -183,7 +178,6 @@ class GameDao(BaseDAO[models.Game]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 )
             )
         )
@@ -255,7 +249,6 @@ class GameDao(BaseDAO[models.Game]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 )
             )
         )

--- a/shvatka/infrastructure/db/dao/rdb/level.py
+++ b/shvatka/infrastructure/db/dao/rdb/level.py
@@ -92,10 +92,7 @@ class LevelDao(BaseDAO[models.Level]):
     async def get_by_id(self, id_: int) -> dto.Level:
         level = await self._get_by_id(
             id_,
-            (
-                joinedload(models.Level.author).joinedload(models.Player.user),
-                joinedload(models.Level.author).joinedload(models.Player.forum_user),
-            ),
+            (joinedload(models.Level.author).joinedload(models.Player.user),),
         )
         return level.to_dto(level.author.to_dto_user_prefetched())
 
@@ -114,11 +111,9 @@ class LevelDao(BaseDAO[models.Level]):
                 .joinedload(models.Game.author)
                 .options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 ),
                 joinedload(models.Level.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 ),
             )
             .where(
@@ -207,7 +202,6 @@ class LevelDao(BaseDAO[models.Level]):
             )
             .options(
                 joinedload(models.Level.author).joinedload(models.Player.user),
-                joinedload(models.Level.author).joinedload(models.Player.forum_user),
             )
         )
         level: models.Level = result.scalar_one()

--- a/shvatka/infrastructure/db/dao/rdb/level_times.py
+++ b/shvatka/infrastructure/db/dao/rdb/level_times.py
@@ -80,9 +80,6 @@ class LevelTimeDao(BaseDAO[models.LevelTime]):
                 joinedload(models.LevelTime.team)
                 .joinedload(models.Team.captain)
                 .joinedload(models.Player.user),
-                joinedload(models.LevelTime.team)
-                .joinedload(models.Team.captain)
-                .joinedload(models.Player.forum_user),
                 joinedload(models.LevelTime.team).joinedload(models.Team.chat),
                 joinedload(models.LevelTime.team).joinedload(models.Team.forum_team),
             )

--- a/shvatka/infrastructure/db/dao/rdb/log_keys.py
+++ b/shvatka/infrastructure/db/dao/rdb/log_keys.py
@@ -46,9 +46,7 @@ class KeyTimeDao(BaseDAO[models.KeyTime]):
         result: ScalarResult[models.KeyTime] = await self.session.scalars(
             select(models.KeyTime)
             .options(
-                joinedload(models.KeyTime.player).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                ),
+                joinedload(models.KeyTime.player).options(joinedload(models.Player.user)),
             )
             .where(
                 models.KeyTime.game_id == game.id,
@@ -70,9 +68,7 @@ class KeyTimeDao(BaseDAO[models.KeyTime]):
         result: ScalarResult[models.KeyTime] = await self.session.scalars(
             select(models.KeyTime)
             .options(
-                joinedload(models.KeyTime.player).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                ),
+                joinedload(models.KeyTime.player).options(joinedload(models.Player.user)),
                 joinedload(models.KeyTime.event),
             )
             .where(
@@ -145,13 +141,9 @@ class KeyTimeDao(BaseDAO[models.KeyTime]):
                 joinedload(models.KeyTime.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(
-                        joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                    ),
+                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
-                joinedload(models.KeyTime.player).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                ),
+                joinedload(models.KeyTime.player).options(joinedload(models.Player.user)),
             )
             .order_by(models.KeyTime.enter_time)
         )

--- a/shvatka/infrastructure/db/dao/rdb/organizer.py
+++ b/shvatka/infrastructure/db/dao/rdb/organizer.py
@@ -62,13 +62,9 @@ class OrganizerDao(BaseDAO[models.Organizer]):
     async def get_by_id(self, id_: int) -> dto.SecondaryOrganizer:
         options = [
             joinedload(models.Organizer.player).joinedload(models.Player.user),
-            joinedload(models.Organizer.player).joinedload(models.Player.forum_user),
             joinedload(models.Organizer.game)
             .joinedload(models.Game.author)
             .joinedload(models.Player.user),
-            joinedload(models.Organizer.game)
-            .joinedload(models.Game.author)
-            .joinedload(models.Player.forum_user),
         ]
         result = await self._get_by_id(id_, options)
         return result.to_dto(
@@ -110,7 +106,6 @@ class OrganizerDao(BaseDAO[models.Organizer]):
             )
             .options(
                 joinedload(models.Organizer.player).joinedload(models.Player.user),
-                joinedload(models.Organizer.player).joinedload(models.Player.forum_user),
             )
         )
         return result.all()

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -32,13 +32,26 @@ class PlayerDao(BaseDAO[models.Player]):
     async def get_by_id(self, id_: int) -> dto.Player:
         player = await self._get_by_id(
             id_,
-            (
-                selectinload(models.Player.forum_user),
-                selectinload(models.Player.user),
-            ),
+            (joinedload(models.Player.user),),
             populate_existing=True,
         )
         return player.to_dto_user_prefetched()
+
+    async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
+        """Like :meth:`get_by_id`, but also loads the forum identity.
+
+        For the few places that show or check it (profile, admin panel, merge);
+        every other caller must use the cheaper :meth:`get_by_id`.
+        """
+        player = await self._get_by_id(
+            id_,
+            (
+                joinedload(models.Player.forum_user),
+                joinedload(models.Player.user),
+            ),
+            populate_existing=True,
+        )
+        return player.to_dto_with_forum_prefetched()
 
     async def get_player_with_stat(self, id_: int) -> dto.PlayerWithStat:
         result: Result[tuple[models.Player, int, int]] = await self.session.execute(
@@ -61,10 +74,7 @@ class PlayerDao(BaseDAO[models.Player]):
                 ),
             )
             .outerjoin(models.Player.typed_keys)
-            .options(
-                selectinload(models.Player.forum_user),
-                selectinload(models.Player.user),
-            )
+            .options(selectinload(models.Player.user))
             .where(models.Player.id == id_)
             .group_by(models.Player.id)
         )
@@ -83,10 +93,7 @@ class PlayerDao(BaseDAO[models.Player]):
             select(models.Game)
             .distinct()
             .options(
-                joinedload(models.Game.author).options(
-                    joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
-                ),
+                joinedload(models.Game.author).options(joinedload(models.Player.user)),
             )
             .join(models.Game.waivers)
             .where(
@@ -124,18 +131,14 @@ class PlayerDao(BaseDAO[models.Player]):
         result: ScalarResult[models.Player] = await self.session.scalars(
             select(models.Player)
             .join(models.Player.user)
-            .options(
-                joinedload(models.Player.forum_user),
-                contains_eager(models.Player.user),
-            )
+            .options(contains_eager(models.Player.user))
             .where(models.User.tg_id == user_id)
         )
         try:
             player = result.one()
         except NoResultFound as e:
             raise exceptions.PlayerNotFoundError from e
-        forum_user = forum_user_db.to_dto() if (forum_user_db := player.forum_user) else None
-        return player.to_dto(user=player.user.to_dto(), forum_user=forum_user)
+        return player.to_dto(user=player.user.to_dto())
 
     async def create_for_user(self, user: dto.User) -> dto.Player:
         user_db = await self.session.get(models.User, user.db_id)
@@ -155,7 +158,7 @@ class PlayerDao(BaseDAO[models.Player]):
         active: bool = True,
         archive: bool = False,
         can_be_author: bool | None = None,
-    ) -> list[dto.Player]:
+    ) -> list[dto.PlayerWithForum]:
         if not active and not archive:
             return []
         query = (
@@ -201,9 +204,9 @@ class PlayerDao(BaseDAO[models.Player]):
             query = query.order_by(models.Player.id)
 
         result: ScalarResult[models.Player] = await self.session.scalars(query)
-        return [player.to_dto_user_prefetched() for player in result.unique().all()]
+        return [player.to_dto_with_forum_prefetched() for player in result.unique().all()]
 
-    async def search_by_any_name(self, text: str) -> list[dto.Player]:
+    async def search_by_any_name(self, text: str) -> list[dto.PlayerWithForum]:
         """Поиск по любому имени: username, tg-username, имени в tg и имени на форуме."""
         pattern = ilike_pattern(text)
         tg_name = func.concat_ws(" ", models.User.first_name, models.User.last_name)
@@ -225,9 +228,9 @@ class PlayerDao(BaseDAO[models.Player]):
             )
             .order_by(models.Player.id)
         )
-        return [player.to_dto_user_prefetched() for player in result.unique().all()]
+        return [player.to_dto_with_forum_prefetched() for player in result.unique().all()]
 
-    async def get_by_forum_player_name(self, name: str) -> dto.Player | None:
+    async def get_by_forum_player_name(self, name: str) -> dto.PlayerWithForum | None:
         result = await self.session.scalars(
             select(models.Player)
             .join(models.Player.forum_user)
@@ -238,20 +241,20 @@ class PlayerDao(BaseDAO[models.Player]):
             .where(models.ForumUser.name == name)
         )
         try:
-            return result.one().to_dto_user_prefetched()
+            return result.one().to_dto_with_forum_prefetched()
         except NoResultFound:
             return None
 
-    async def create_for_forum_user_name(self, forum_user_name: str) -> dto.Player:
+    async def create_for_forum_user_name(self, forum_user_name: str) -> dto.PlayerWithForum:
         forum_user_db = models.ForumUser(name=forum_user_name)
         player = await self._create_dummy()
         forum_user_db.player = player
         self.session.add(forum_user_db)
         await self._flush(forum_user_db)
         player.username = await self.get_free_and_associated_username(player)
-        return player.to_dto(forum_user=forum_user_db.to_dto())
+        return player.to_dto_with_forum(forum_user=forum_user_db.to_dto())
 
-    async def create_for_forum_user(self, user: dto.ForumUser) -> dto.Player:
+    async def create_for_forum_user(self, user: dto.ForumUser) -> dto.PlayerWithForum:
         forum_user_db = await self.session.get(models.ForumUser, user.db_id)
         assert forum_user_db
         assert isinstance(forum_user_db, models.ForumUser)
@@ -261,7 +264,7 @@ class PlayerDao(BaseDAO[models.Player]):
             player = await self._create_dummy()
             forum_user_db.player = player
             player.username = await self.get_free_and_associated_username(player)
-        return player.to_dto(forum_user=forum_user_db.to_dto())
+        return player.to_dto_with_forum(forum_user=forum_user_db.to_dto())
 
     async def link_forum_user(self, player: dto.Player, user: dto.ForumUser) -> None:
         forum_user_db = await self.session.get(models.ForumUser, user.db_id)
@@ -317,10 +320,7 @@ class PlayerDao(BaseDAO[models.Player]):
     async def get_by_ids_with_user_and_pit(self, ids: Iterable[int]) -> list[dto.VotedPlayer]:
         result = await self.session.execute(
             select(models.Player, models.TeamPlayer)
-            .options(
-                joinedload(models.Player.user),
-                joinedload(models.Player.forum_user),
-            )
+            .options(joinedload(models.Player.user))
             .join(models.Player.teams)
             .where(
                 models.Player.id.in_(ids),

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -208,7 +208,6 @@ class TeamDao(BaseDAO[models.Team]):
             .options(
                 joinedload(models.Game.author).options(
                     joinedload(models.Player.user),
-                    joinedload(models.Player.forum_user),
                 ),
             )
             .join(models.Game.waivers)
@@ -247,7 +246,6 @@ def get_team_options() -> Sequence[ORMOption]:
     return (
         joinedload(models.Team.captain).options(
             joinedload(models.Player.user),
-            joinedload(models.Player.forum_user),
         ),
         joinedload(models.Team.chat),
         joinedload(models.Team.forum_team),

--- a/shvatka/infrastructure/db/dao/rdb/team_player.py
+++ b/shvatka/infrastructure/db/dao/rdb/team_player.py
@@ -279,7 +279,6 @@ def not_leaved() -> Sequence[ColumnElement["bool"]]:
 def get_player_full_load_options() -> ORMOption:
     return joinedload(models.TeamPlayer.player).options(
         joinedload(models.Player.user),
-        joinedload(models.Player.forum_user),
     )
 
 
@@ -289,6 +288,5 @@ def get_team_load_options() -> ORMOption:
         joinedload(models.Team.forum_team),
         joinedload(models.Team.captain).options(
             joinedload(models.Player.user),
-            joinedload(models.Player.forum_user),
         ),
     )

--- a/shvatka/infrastructure/db/dao/rdb/waiver.py
+++ b/shvatka/infrastructure/db/dao/rdb/waiver.py
@@ -86,13 +86,9 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(
-                        joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                    ),
+                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
-                joinedload(models.Waiver.player).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                ),
+                joinedload(models.Waiver.player).options(joinedload(models.Player.user)),
             )
             .where(models.Waiver.game_id == game.id)
         )
@@ -108,14 +104,10 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(
-                        joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                    ),
+                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
                 joinedload(models.Waiver.game).options(
-                    joinedload(models.Game.author).options(
-                        joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                    ),
+                    joinedload(models.Game.author).options(joinedload(models.Player.user)),
                 ),
             )
             .where(models.Waiver.player_id == player.id)
@@ -133,9 +125,7 @@ class WaiverDao(BaseDAO[models.Waiver]):
         result: ScalarResult[models.Waiver] = await self.session.scalars(
             select(models.Waiver)
             .options(
-                joinedload(models.Waiver.player).options(
-                    joinedload(models.Player.user), joinedload(models.Player.forum_user)
-                ),
+                joinedload(models.Waiver.player).options(joinedload(models.Player.user)),
             )
             .where(
                 models.Waiver.game_id == game.id,
@@ -154,9 +144,7 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team)
                 .joinedload(models.Team.captain)
                 .joinedload(models.Player.user),
-                joinedload(models.Waiver.team)
-                .joinedload(models.Team.captain)
-                .joinedload(models.Player.forum_user),
+                joinedload(models.Waiver.team).joinedload(models.Team.captain),
             )
             .where(
                 models.Waiver.game_id == game.id,
@@ -171,7 +159,6 @@ class WaiverDao(BaseDAO[models.Waiver]):
             select(models.Waiver, models.TeamPlayer)
             .options(
                 joinedload(models.Waiver.player).joinedload(models.Player.user),
-                joinedload(models.Waiver.player).joinedload(models.Player.forum_user),
             )
             .join(models.TeamPlayer, models.Waiver.player_id == models.TeamPlayer.player_id)
             .where(

--- a/shvatka/infrastructure/db/dao/rdb/waiver.py
+++ b/shvatka/infrastructure/db/dao/rdb/waiver.py
@@ -144,7 +144,6 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team)
                 .joinedload(models.Team.captain)
                 .joinedload(models.Player.user),
-                joinedload(models.Waiver.team).joinedload(models.Team.captain),
             )
             .where(
                 models.Waiver.game_id == game.id,

--- a/shvatka/infrastructure/db/models/player.py
+++ b/shvatka/infrastructure/db/models/player.py
@@ -84,10 +84,23 @@ class Player(Base):
     def __repr__(self) -> str:
         return f"<Player id={self.id} >"
 
-    def to_dto(
-        self, user: dto.User | None = None, forum_user: dto.ForumUser | None = None
-    ) -> dto.Player:
+    def to_dto(self, user: dto.User | None = None) -> dto.Player:
         return dto.Player(
+            id=self.id,
+            username=self.username,
+            user=user,
+            can_be_author=self.can_be_author,
+            is_dummy=self.is_dummy,
+        )
+
+    def to_dto_user_prefetched(self) -> dto.Player:
+        """DTO of a player loaded with ``user``, but without the forum identity."""
+        return self.to_dto(user=self.user.to_dto() if self.user else None)
+
+    def to_dto_with_forum(
+        self, user: dto.User | None = None, forum_user: dto.ForumUser | None = None
+    ) -> dto.PlayerWithForum:
+        return dto.PlayerWithForum(
             id=self.id,
             username=self.username,
             user=user,
@@ -96,8 +109,13 @@ class Player(Base):
             is_dummy=self.is_dummy,
         )
 
-    def to_dto_user_prefetched(self) -> dto.Player:
-        return self.to_dto(
+    def to_dto_with_forum_prefetched(self) -> dto.PlayerWithForum:
+        """DTO of a player loaded with both ``user`` and ``forum_user``.
+
+        Only for queries that eagerly loaded the forum identity — everything
+        else must use :meth:`to_dto_user_prefetched` and leave it unjoined.
+        """
+        return self.to_dto_with_forum(
             user=self.user.to_dto() if self.user else None,
             forum_user=self.forum_user.to_dto() if self.forum_user else None,
         )

--- a/shvatka/tgbot/dialogs/main_menu/dialogs.py
+++ b/shvatka/tgbot/dialogs/main_menu/dialogs.py
@@ -112,7 +112,7 @@ main_menu = Dialog(
             Const("🔮Былые свершения"),
             id="to_merge_player",
             state=states.MergePlayersSG.main,
-            when=~F["player"].has_forum_user(),
+            when=~F["has_forum_user"],
         ),
         Cancel(Const("❌Закрыть")),
         # ачивки
@@ -120,6 +120,7 @@ main_menu = Dialog(
         getter=get_main,
         preview_data={
             "player": PREVIEW_AUTHOR,
+            "has_forum_user": False,
             "game": PREVIEW_SIMPLE_GAME,
             "org": PREVIEW_ORG,
             "team": PREVIEW_TEAM,

--- a/shvatka/tgbot/dialogs/main_menu/getters.py
+++ b/shvatka/tgbot/dialogs/main_menu/getters.py
@@ -16,6 +16,7 @@ async def get_main(
     current_game: FromDishka[CurrentGameProvider],
     identity: FromDishka[TgBotIdentityProvider],
     interactor: FromDishka[GamePlayRoleReader],
+    dao: FromDishka[HolderDao],
     **_,
 ):
     game = await current_game.get_game()
@@ -32,6 +33,7 @@ async def get_main(
 
     return {
         "player": player,
+        "has_forum_user": await dao.forum_user.exists_for_player(player.id),
         "game": game,
         "org": org,
         "team": team,

--- a/shvatka/tgbot/handlers/merge.py
+++ b/shvatka/tgbot/handlers/merge.py
@@ -6,7 +6,7 @@ from aiogram_dialog.api.protocols import BgManagerFactory
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
-from shvatka.core.players.player import get_player_by_id, merge_players
+from shvatka.core.players.player import get_player_identities_by_id, merge_players
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.views.game import GameLogWriter
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -49,8 +49,8 @@ async def confirm_merge_players(
     bg_manager_factory: FromDishka[BgManagerFactory],
     bot: Bot,
 ):
-    primary = await get_player_by_id(callback_data.primary_player_id, dao.player)
-    secondary = await get_player_by_id(callback_data.secondary_player_id, dao.player)
+    primary = await get_player_identities_by_id(callback_data.primary_player_id, dao.player)
+    secondary = await get_player_identities_by_id(callback_data.secondary_player_id, dao.player)
     await merge_players(primary, secondary, game_log, dao.player_merger)
     await callback_query.answer("Успешно объединено")
     assert isinstance(callback_query.message, Message)

--- a/shvatka/tgbot/handlers/merge.py
+++ b/shvatka/tgbot/handlers/merge.py
@@ -6,7 +6,7 @@ from aiogram_dialog.api.protocols import BgManagerFactory
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
-from shvatka.core.players.player import get_player_identities_by_id, merge_players
+from shvatka.core.players.player import merge_players
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.views.game import GameLogWriter
 from shvatka.infrastructure.db.dao.holder import HolderDao
@@ -49,8 +49,8 @@ async def confirm_merge_players(
     bg_manager_factory: FromDishka[BgManagerFactory],
     bot: Bot,
 ):
-    primary = await get_player_identities_by_id(callback_data.primary_player_id, dao.player)
-    secondary = await get_player_identities_by_id(callback_data.secondary_player_id, dao.player)
+    primary = await dao.player.get_identities_by_id(callback_data.primary_player_id)
+    secondary = await dao.player.get_identities_by_id(callback_data.secondary_player_id)
     await merge_players(primary, secondary, game_log, dao.player_merger)
     await callback_query.answer("Успешно объединено")
     assert isinstance(callback_query.message, Message)

--- a/tests/unit/domain/test_player_forum_identity.py
+++ b/tests/unit/domain/test_player_forum_identity.py
@@ -1,0 +1,58 @@
+import pytest
+
+from shvatka.core.models import dto
+
+
+def _forum_user(name: str = "forum_harry", player_id: int = 3) -> dto.ForumUser:
+    return dto.ForumUser(db_id=1, forum_id=7, name=name, registered=None, player_id=player_id)
+
+
+def test_plain_player_does_not_carry_the_forum_identity():
+    """The base dto must not grow the forum account back: it costs a join everywhere."""
+    player = dto.Player(id=1, can_be_author=False, is_dummy=False, username="harry")
+    assert not hasattr(player, "forum_user")
+    assert not hasattr(player, "has_forum_user")
+    assert not hasattr(player, "get_forum_name")
+
+
+def test_player_with_forum_exposes_the_account():
+    player = dto.PlayerWithForum(
+        id=3, can_be_author=False, is_dummy=False, username="harry", forum_user=_forum_user()
+    )
+    assert player.has_forum_user()
+    assert player.get_forum_name() == "forum_harry"
+
+
+def test_player_with_forum_without_account():
+    player = dto.PlayerWithForum(id=3, can_be_author=False, is_dummy=False, username="harry")
+    assert not player.has_forum_user()
+    assert player.get_forum_name() is None
+
+
+def test_username_wins_over_forum_name_in_mention():
+    player = dto.PlayerWithForum(
+        id=3, can_be_author=True, is_dummy=True, username="harry", forum_user=_forum_user()
+    )
+    assert player.name_mention == "harry"
+
+
+def test_forum_dummy_with_placeholder_username_is_mentioned_by_forum_name():
+    player = dto.PlayerWithForum(
+        id=3, can_be_author=False, is_dummy=True, username="id3", forum_user=_forum_user()
+    )
+    assert player.name_mention == "forum_harry"
+
+
+def test_dummy_without_forum_account_falls_back_to_its_id():
+    assert (
+        dto.Player(id=3, can_be_author=False, is_dummy=True, username=None).name_mention
+        == "dummy-3"
+    )
+
+
+@pytest.mark.parametrize("cls", [dto.Player, dto.PlayerWithForum])
+def test_tg_accessors_are_shared(cls):
+    user = dto.User(tg_id=100500, db_id=1, username="tg_harry", first_name="Harry")
+    player = cls(id=8, can_be_author=False, is_dummy=False, username="harry", user=user)
+    assert player.get_chat_id() == 100500
+    assert player.get_tg_username() == "tg_harry"

--- a/tests/unit/mapper/test_me_response.py
+++ b/tests/unit/mapper/test_me_response.py
@@ -4,7 +4,9 @@ from shvatka.core.models import dto
 
 def test_me_from_core_tg_only():
     user = dto.User(tg_id=100500, db_id=1, username="tg_harry", first_name="Harry")
-    player = dto.Player(id=1, can_be_author=False, is_dummy=False, username="harry", user=user)
+    player = dto.PlayerWithForum(
+        id=1, can_be_author=False, is_dummy=False, username="harry", user=user
+    )
 
     me = responses.PlayerWithIdentities.from_core(player, email=None)
 
@@ -16,7 +18,7 @@ def test_me_from_core_tg_only():
 
 
 def test_me_from_core_email_only():
-    player = dto.Player(id=2, can_be_author=False, is_dummy=False, username="mail_user")
+    player = dto.PlayerWithForum(id=2, can_be_author=False, is_dummy=False, username="mail_user")
     email = dto.EmailAccount(email="user@example.com", player_id=2, is_verified=True, db_id=948)
 
     me = responses.PlayerWithIdentities.from_core(player, email=email)
@@ -30,7 +32,7 @@ def test_me_from_core_email_only():
 
 def test_me_from_core_forum_and_unverified_email():
     forum = dto.ForumUser(db_id=1, forum_id=7, name="forum_harry", registered=None, player_id=3)
-    player = dto.Player(
+    player = dto.PlayerWithForum(
         id=3, can_be_author=False, is_dummy=False, username="harry", forum_user=forum
     )
     email = dto.EmailAccount(email="h@example.com", player_id=3, is_verified=False, db_id=918)
@@ -45,7 +47,7 @@ def test_me_from_core_forum_and_unverified_email():
 
 
 def test_me_pending_email_is_the_address_being_moved_to():
-    player = dto.Player(id=4, can_be_author=False, is_dummy=False, username="harry")
+    player = dto.PlayerWithForum(id=4, can_be_author=False, is_dummy=False, username="harry")
     email = dto.EmailAccount(email="old@example.com", player_id=4, is_verified=True, db_id=1)
 
     me = responses.PlayerWithIdentities.from_core(
@@ -58,7 +60,7 @@ def test_me_pending_email_is_the_address_being_moved_to():
 
 
 def test_me_pending_email_ignores_the_linked_address_itself():
-    player = dto.Player(id=5, can_be_author=False, is_dummy=False, username="harry")
+    player = dto.PlayerWithForum(id=5, can_be_author=False, is_dummy=False, username="harry")
     email = dto.EmailAccount(email="h@example.com", player_id=5, is_verified=False, db_id=2)
 
     me = responses.PlayerWithIdentities.from_core(

--- a/tests/unit/services/global_search_test.py
+++ b/tests/unit/services/global_search_test.py
@@ -121,7 +121,7 @@ def test_find_level_hits_nothing():
 
 
 def test_classify_player_hit_priority():
-    player = dto.Player(
+    player = dto.PlayerWithForum(
         id=2,
         can_be_author=False,
         is_dummy=False,

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -36,6 +36,11 @@ def _player(id_: int, username: str = "p") -> dto.Player:
     return dto.Player(id=id_, can_be_author=False, is_dummy=False, username=username)
 
 
+def _player_with_forum(id_: int, username: str = "p") -> dto.PlayerWithForum:
+    """A merge operand: merging checks the forum identity, so it must be loaded."""
+    return dto.PlayerWithForum(id=id_, can_be_author=False, is_dummy=False, username=username)
+
+
 def _team(captain: dto.Player | None = None, id_: int = 1, name: str = "Gryffindor") -> dto.Team:
     return dto.Team(
         id=id_,
@@ -184,6 +189,11 @@ class FakePlayerDao:
 
     async def get_by_id(self, player_id: int) -> dto.Player:
         return self._players[player_id]
+
+    async def get_identities_by_id(self, player_id: int) -> dto.PlayerWithForum:
+        player = self._players[player_id]
+        assert isinstance(player, dto.PlayerWithForum)
+        return player
 
 
 class FakePromoter:
@@ -606,8 +616,8 @@ async def test_create_team_merge_request_only_by_captain() -> None:
 
 @pytest.mark.asyncio
 async def test_create_player_merge_request_for_self() -> None:
-    player = _player(3, "harry")
-    forum_copy = _player(8, "harry_forum")
+    player = _player_with_forum(3, "harry")
+    forum_copy = _player_with_forum(8, "harry_forum")
     requests = FakeRequests()
     notifications = FakeNotifications()
     interactor = CreatePlayerMergeRequestInteractor(
@@ -704,8 +714,8 @@ async def test_accept_team_merge_performs_merge(monkeypatch: pytest.MonkeyPatch)
 
 @pytest.mark.asyncio
 async def test_accept_player_merge_performs_merge(monkeypatch: pytest.MonkeyPatch) -> None:
-    player = _player(3, "harry")
-    forum_copy = _player(8, "harry_forum")
+    player = _player_with_forum(3, "harry")
+    forum_copy = _player_with_forum(8, "harry_forum")
     admin = _player(42, "admin")
     requests = FakeRequests()
     requests.rows[1] = ndto.ActionRequest(
@@ -735,8 +745,8 @@ async def test_accept_player_merge_performs_merge(monkeypatch: pytest.MonkeyPatc
 
 @pytest.mark.asyncio
 async def test_accept_player_merge_forwards_timeline(monkeypatch: pytest.MonkeyPatch) -> None:
-    player = _player(3, "harry")
-    forum_copy = _player(8, "harry_forum")
+    player = _player_with_forum(3, "harry")
+    forum_copy = _player_with_forum(8, "harry_forum")
     admin = _player(42, "admin")
     requests = FakeRequests()
     requests.rows[1] = ndto.ActionRequest(


### PR DESCRIPTION
## Why

Every query that loaded a player also joined `forum_users` — 42 eager-load sites across 11 DAO modules, all funnelled through `models.Player.to_dto_user_prefetched()`.

Only six consumers ever read the forum identity:

| consumer | fed by |
|---|---|
| `api/players/responses.py` `PlayerWithIdentities` (`/me`, profile) | `get_by_id` / `get_by_user_id` / email login |
| `api/admin/responses.py` `AdminPlayer` | `search_players`, `get_by_id` |
| `core/players/player.py` `merge_players` guard | `get_by_id` |
| `core/search/interactors.py` `classify_player_hit` | `search_by_any_name` |
| `tgbot/dialogs/main_menu` link offer | current player |
| `Player.name_mention` for a forum-imported dummy | any |

Nothing in the bulk paths — game lists, level lists, waivers, key logs, organizers, team players, file infos — touches it. The shared `api/shared/responses.py` `Player` (game authors, team captains, poll entries) reads only `id`, `can_be_author`, `name_mention`, `username`.

The join was unconditional because `dto.Player` had no way to say "not loaded": `_forum_user is None` meant both "no forum account" and "we didn't ask", so loading it everywhere was the only safe option.

Two things made it redundant rather than merely unused. Migration `d4ddc1efb2ff` backfilled `players.username` for every row (`coalesce(tg username, forum name, 'id'||id)`), and every creation path since sets it via `get_free_and_associated_username` — so `name_mention` returns the username without consulting either identity, and a forum-only player is already found by theirs.

The cost was worst on the hottest path: `PlayerDao.get_by_id`, called for every authenticated API request from `api/app/dependencies/auth.py`, used two `selectinload` options — three roundtrips for a question most endpoints ask only for an id.

## What changed

**The forum identity gets its own dto.** `dto.Player` drops `forum_user`, `has_forum_user()` and `get_forum_name()`; `dto.PlayerWithForum(Player)` adds them back plus the `name_mention` branch for a forum-imported dummy. A subclass rather than a `NOT_LOADED` sentinel: a caller that needs the forum account says so in its signature and mypy rejects a plain `Player` there, instead of the check landing at runtime.

**Two ways to load a player by id.** `get_by_id` loads the telegram user only, with `joinedload` — one statement instead of three. `get_identities_by_id` loads both and returns `PlayerWithForum`, exposed as `PlayerIdentitiesGetter` (and `PlayerMergeOperandsGetter` for interactors needing each). `IdentityProvider.get_player()` still returns a plain `Player`, so `/me` pays for a second lookup instead of every request carrying the join.

**The bot asks for a flag, not the account.** The main menu offers "Былые свершения" only to players without a forum account; `ForumUserDAO.exists_for_player` answers that with one indexed lookup.

**Exports identify a player by username.** `export_stat.Player.from_dto` loses its `forum_name` fallback — the username branch already covers a forum-only player. `PlayerIdentity.forum_name` stays, so the crawler still produces it and old exports still import.

`search_players` keeps the join and returns `PlayerWithForum` for both callers, including the public search which discards it: the query is admin-shaped and already outer-joins `users` and `email_accounts`, so splitting it in two wasn't worth the duplication.

## Effect

Every list of games, levels, waivers, key logs, organizers, team players and files loses one `LEFT OUTER JOIN forum_users`; each authenticated API request loses two roundtrips. `/me` and the admin player card cost one extra query — the rare endpoint pays instead of the common one.

Verified by compiling the queries: the game, waiver and auth selects no longer reference `forum_users`; the profile select still does.

## Notes

- `docs/modules/shep/pages/shep-0011-player-identity-loading.adoc` records the decision, the rejected sentinel alternative, and a phase 2 for the same question about `_user`.
- A forum-imported dummy still carrying the `id{N}` placeholder username is mentioned as `dummy-{id}` on paths loading a plain `Player`; `renew_id_usernames` exists to remove those placeholders.

## Tests

- New `tests/unit/domain/test_player_forum_identity.py`, including a guard that the base `Player` does not grow the forum account back.
- Existing merge / search / `/me` mapper tests updated to the forum-aware dto.
- `ruff format`, `ruff check`, `mypy` and `pytest tests/unit` (531 passed) all clean locally. Integration tests need Docker, so they run in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxaMRqNMVJUtGtisqQKXjY)_