### PR TITLE
feat(merge): narrow the waiver point to one hour before the game

### DIFF
--- a/context.md
+++ b/context.md
@@ -72,7 +72,7 @@ the edge-specific twist.
 | **Forum user** | Пользователь форума | An account imported from the old forum, attached to a player. | `dto.ForumUser` |
 | **Merge (player)** | Слияние игроков | Folding a dummy (usually forum-sourced) player into a live one so one person has one history. Requires admin approval and a manually built team timeline. | `player.merge_players`, `RequestType.player_merge` |
 | **Timeline** | История команд | The manually built sequence of team memberships used when merging players. Must cover every *waiver point*. | `players.dto.TimelineItem` |
-| **Waiver point** | — | An interval (`start_at − 12h` … `start_at + 48h`) in which a waiver proves the player was in a given team, so a merged timeline may not contradict it. | `players.dto.WaiverPoint` |
+| **Waiver point** | — | An interval (`start_at − 1h` … `start_at + 48h`) in which a waiver proves the player was in a given team, so a merged timeline may not contradict it. | `players.dto.WaiverPoint` |
 | **One-time login link** | Одноразовая ссылка | A short-lived link that logs a player into the web UI without a password. | `services/one_time_link.py` |
 | **Achievement** | Ачивка | A named thing a player did once, recorded for fun. | `dto.Achievement`, `enums.Achievement` |
 

--- a/shvatka/core/players/dto.py
+++ b/shvatka/core/players/dto.py
@@ -4,7 +4,7 @@ from datetime import datetime, time, timedelta
 from shvatka.core.models import dto
 from shvatka.core.utils.datetime_utils import tz_game
 
-WAIVER_POINT_BEFORE_GAME = timedelta(hours=12)
+WAIVER_POINT_BEFORE_GAME = timedelta(hours=1)
 WAIVER_POINT_AFTER_GAME = timedelta(hours=48)
 SUNDAY = 6
 
@@ -29,7 +29,7 @@ class PlayerIdentitiesInfo:
 class WaiverPoint:
     """An interval during which a merged timeline must keep the player in the given team.
 
-    Derived from a waiver: around the game start (``start_at - 12h`` .. ``start_at + 48h``)
+    Derived from a waiver: around the game start (``start_at - 1h`` .. ``start_at + 48h``)
     the player provably acted as a member of that team, so any manually built
     team history must cover the whole interval with that team.
     """

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -404,7 +404,7 @@ async def test_get_player_waiver_points(
     point = items[0]
     assert point["game"]["id"] == game.id
     assert point["team"]["id"] == gryffindor.id
-    assert datetime.fromisoformat(point["at_since"]) == GAME_START_AT - timedelta(hours=12)
+    assert datetime.fromisoformat(point["at_since"]) == GAME_START_AT - timedelta(hours=1)
     assert datetime.fromisoformat(point["at_until"]) == GAME_START_AT + timedelta(hours=48)
 
 

--- a/tests/unit/services/merge_timeline_test.py
+++ b/tests/unit/services/merge_timeline_test.py
@@ -68,7 +68,7 @@ class FakeWaiversDao:
 
 def test_waiver_point_interval():
     point = create_point(create_team(), create_game())
-    assert point.at_since == START_AT - timedelta(hours=12)
+    assert point.at_since == START_AT - timedelta(hours=1)
     assert point.at_until == START_AT + timedelta(hours=48)
     assert point.at_since == START_AT - WAIVER_POINT_BEFORE_GAME
     assert point.at_until == START_AT + WAIVER_POINT_AFTER_GAME
@@ -219,7 +219,7 @@ def test_timeline_with_wrong_team_fails():
 def test_timeline_partially_covering_point_fails():
     point = create_point(create_team(1), create_game())
     # joined after the protected interval started
-    timeline = [TimelineItem(team_id=1, date_joined=START_AT - timedelta(hours=1))]
+    timeline = [TimelineItem(team_id=1, date_joined=START_AT - timedelta(minutes=30))]
     with pytest.raises(exceptions.MergeError):
         check_timeline_matches_points(timeline, [point])
 


### PR DESCRIPTION
A waiver point locked the merge timeline for 12 hours before the game start, which made the interval unnecessarily wide: a merged timeline had to keep the player in that team half a day before they actually played, and the bars dominated the timeline editor's chart.

`WAIVER_POINT_BEFORE_GAME` is now `1 hour`, so a point spans `start_at - 1h … start_at + 48h`. The right edge is unchanged.

Changes:
- `shvatka/core/players/dto.py` — `WAIVER_POINT_BEFORE_GAME = timedelta(hours=1)`, docstring updated.
- `context.md` — glossary entry for *Waiver point* updated.
- `tests/unit/services/merge_timeline_test.py` — interval assertion updated; `test_timeline_partially_covering_point_fails` now joins 30 minutes before the start, since joining an hour before is exactly the (now valid) left edge.
- `tests/integration/api_full/test_admin.py` — `at_since` assertion updated.

`pytest tests/unit` passes locally (523 passed); the integration suite needs testcontainers and is left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLVqb3BJaMjAYtFoVrPRND)_