### PR TITLE
docs(shep-0012): spec carrying the team captain by id

### DIFF
--- a/docs/modules/shep/nav.adoc
+++ b/docs/modules/shep/nav.adoc
@@ -10,4 +10,5 @@
 ** xref:shep-0009-key-submission-latency.adoc[SHEP-0009 Key submission latency]
 ** xref:shep-0010-message-outbox.adoc[SHEP-0010 Message outbox]
 ** xref:shep-0011-player-identity-loading.adoc[SHEP-0011 Player identity loading]
+** xref:shep-0012-team-captain-by-id.adoc[SHEP-0012 Team captain by id]
 ** xref:template.adoc[SHEP template]

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -69,7 +69,11 @@ came out of it*.
 
 | xref:shep-0011-player-identity-loading.adoc[SHEP-0011]
 | Loading a player without their forum account
-| Accepted, implemented
+| Accepted, partially implemented
+
+| xref:shep-0012-team-captain-by-id.adoc[SHEP-0012]
+| Carrying the team captain by id
+| Draft
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0011-player-identity-loading.adoc
+++ b/docs/modules/shep/pages/shep-0011-player-identity-loading.adoc
@@ -115,7 +115,8 @@ unchanged.
 | Phase | Content | Status
 
 | 1 | Split the dto, add `get_identities_by_id`, drop the join from the bulk queries | ✅ done in PR #379
-| 2 | Same treatment for `models.Player.user` where only `username` is read | ⏳ not started
+| 2 | Same treatment for `models.Player.user` | ❌ not worth it — see the open question
+| 3 | Identify a player by username alone in `export_stat`, then drop the join from `log_keys` | ⏳ not started
 |===
 
 == Deviations from the plan
@@ -127,6 +128,27 @@ splitting it in two to save one more join was not worth the duplication.
 
 == Open questions
 
-Whether `_user` deserves the same split. It is read far more widely — every bot
-player card links to the telegram account — but list endpoints that render only
-`username` do not need it either. Phase 2 above.
+Whether `_user` deserves the same split — investigated, and the answer is no.
+The forum account had six consumers; the telegram one has around forty-six,
+spread across the whole bot view and notification layer, and the hot path needs
+it: `ApiIdentityProvider.get_user()` derives the API's current `dto.User`
+entirely from `player._user`, so `get_by_id` cannot drop it the way it dropped
+the forum join. Checked one by one, every bulk query's player is either linked
+or messaged by some bot view — `file_info.author` through
+`file_gateway.upload_to_tg`, `team.captain` and `team_player.player` through the
+player cards, `organizer.player` and `game.author` through their notifications.
+
+The one exception is `log_keys`: the telegraph log renders `name_mention` only.
+It is blocked because the same query feeds the zip export, and
+`export_stat.Player.from_dto` still reads `has_user()` for its `tg_user_id`
+identity. Dropping that branch the way the `forum_name` branch was dropped —
+`players.username` is unique and non-null since `d4ddc1efb2ff` — unblocks four
+eager-load sites. That is phase 3; it is small, and worth doing only alongside
+other work in the same files.
+
+A type split would also invert badly here: `PlayerWithTg` would be the dominant
+type in the bot and a bare `Player` the exception, which is the signal that the
+split is the wrong way round.
+
+The team aggregate is the better target, and moved to
+xref:shep-0012-team-captain-by-id.adoc[SHEP-0012].

--- a/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
+++ b/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
@@ -1,0 +1,159 @@
+= SHEP-0012 — Carrying the team captain by id
+:navtitle: SHEP-0012 Team captain by id
+
+[cols="1,4"]
+|===
+| SHEP | 0012
+| Title | Carrying the team captain by id
+| Status | `Draft`
+| Created | 2026-08-31
+| Updated | 2026-08-31
+| Related | xref:shep-0011-player-identity-loading.adoc[SHEP-0011], PR #379
+|===
+
+== Summary
+
+`dto.Team` carries its captain as a whole `Player`, so every query that returns
+a team joins `players` and `users` for it — even though most callers only
+compare the captain's id. `teams.captain_id` is already on the row and already
+indexed. Carrying it on the dto answers every identity check for free, removes a
+latent `AttributeError` on captain-less teams, and is the precondition for ever
+dropping the join.
+
+== Context
+
+SHEP-0011 removed the forum join from the player dto. The same question asked of
+the team aggregate gives a different answer, because the cost is not one column
+— it is that `dto.Team` materialises three satellites (`captain`, `_chat`,
+`_forum_team`), and `dto.Waiver` / `dto.FullTeamPlayer` require a whole `Team`.
+
+Compiled join counts of the real option sets:
+
+[cols="4,1,4",options="header"]
+|===
+| query | joins | tables
+
+| `waiver.get_all_by_player(player)` | 8 | teams, chats, forum_teams, games, players, users
+| `waiver.get_all_by_game(game)` | 7 | teams, chats, forum_teams, players, users
+| `team_player.get_full_history(player)` | 7 | teams, chats, forum_teams, players, users
+| `team.get_team_options()` | 4 | chats, forum_teams, players, users
+| `waiver.get_all_by_team(game, team)` | 2 | players, users
+| `team_player.get_players(team)` | 2 | players, users
+|===
+
+The split is not carelessness. The two-join queries take their parent as an
+argument and fill the dto from it; the seven-join ones cannot, because the
+parent varies per row, and then the dto's required fields force the whole
+aggregate. These are all to-one joins, so the cost is width rather than row
+multiplication — a game with 20 teams × 10 players repeats each team's chat,
+forum team, captain and captain's user across 200 rows.
+
+Of the three satellites, `captain` is the one almost nobody dereferences.
+Counting the call sites:
+
+*Need only the id* — `FullTeamPlayer.is_captain`, and through it all five
+permission properties and every `TeamPlayerFilter`; `core/services/team.py`
+(three checks), `core/players/player.py:174`,
+`core/notifications/request_interactors.py:293`,
+`tgbot/filters/team_player.py:34`, `tgbot/dialogs/team_manage/getters.py:36`.
+
+*Need the rendered name* — `api/shared/responses.py` and `api/teams/responses.py`,
+`tgbot/views/team.py:28`, and three dialog templates.
+
+*Need the whole player* — the two merge handlers and `core/services/team.py:183`.
+
+There is also a bug in the current shape. `FullTeamPlayer.is_captain` reads
+
+[source,python]
+----
+return self.team.captain.id == self.player_id
+----
+
+with no `None` guard, while `dto.Team.captain` is `Player | None` and
+`TeamDao.create_by_forum` creates teams with `captain_id=None`. A member of a
+captain-less team raises `AttributeError` from any permission property.
+`tgbot/filters/team_player.py:33` guards it with an ad-hoc `assert` before making
+the same comparison, which is itself evidence that the model is awkward.
+
+== Decision
+
+=== `dto.Team` carries `captain_id`
+
+Add `captain_id: int | None`, filled from `models.Team.captain_id` — a column on
+the row already being selected, under an existing index
+(`ix__teams__captain_id`). It costs nothing to carry.
+
+Every identity check listed above reads it instead of dereferencing `captain`,
+and `is_captain` becomes total:
+
+[source,python]
+----
+@property
+def is_captain(self) -> bool:
+    return self.team.captain_id == self.player_id
+----
+
+This is worth landing on its own: it removes the `AttributeError`, deletes the
+`assert team.captain is not None` dance from the call sites, and stops the
+permission model depending on what a query happened to join.
+
+=== Rendering the captain gets its own type
+
+Following SHEP-0011: a lean `Team` plus `TeamWithCaptain(Team)` carrying
+`captain: Player`, so a caller that renders the captain says so in its
+signature and mypy rejects a lean `Team` there.
+
+The alternative — keep one `Team` and let `captain` be `None` when unloaded —
+loses the same way it would have for the forum account: `None` would mean both
+"this team has no captain" and "this query did not ask", and a page that stopped
+showing the captain would look fine.
+
+=== Dropping the join is gated on the API response
+
+`api/shared/responses.py` `Team` carries `captain` unconditionally, and that
+response is embedded in the waivers, games, players, teams and admin payloads.
+So almost every team-bearing query has a caller that renders the captain today,
+and the join cannot come out until that response is split into a lean embedded
+form and a captain-bearing one for the two places that use it — the team card
+(`team-card.component`) and the admin teams list (`admin-teams.component`).
+
+That is a `shvatka-ui` contract change, which is why it is phase 2 here rather
+than a detail of phase 1. Quietly nulling `captain` on the embedded responses is
+not an option: the UI reads `team.captain.id` for member sorting and the captain
+badge, so it would degrade silently.
+
+== Consequences
+
+* Phase 1 alone fixes a reachable crash and simplifies eight call sites, at the
+  cost of one more field on `dto.Team`. No query changes, no contract changes.
+* Once phases 2 and 3 land, the captain chain comes out of the team-bearing
+  queries: `waiver.get_all_by_game` 7 → 5, `get_all_by_player` 8 → 6,
+  `team_player.get_full_history` 7 → 5, `team.get_team_options` 4 → 2.
+* Two ways to say "who captains this team" exist during the transition —
+  `captain_id` and `captain.id`. Phase 1 should convert every identity check so
+  the second is only ever used for rendering.
+* `_chat` and `_forum_team` stay mandatory. `Team.get_chat_id()` is how the bot
+  addresses every team chat, so they have the same "needed everywhere" shape as
+  `Player._user`; see the open question in SHEP-0011.
+
+== Phases and status
+
+[cols="1,4,2",options="header"]
+|===
+| Phase | Content | Status
+
+| 1 | `captain_id` on `dto.Team`; identity checks read it; `is_captain` stops crashing on captain-less teams | ⏳ not started
+| 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ⏳ not started
+| 3 | `TeamWithCaptain` dto; drop the captain join from queries whose callers no longer render it | ⏳ not started
+|===
+
+== Deviations from the plan
+
+Nothing implemented yet.
+
+== Open questions
+
+Whether `models.Team.captain` should keep its relationship at all once phase 3
+lands, or whether the two merge handlers and `core/services/team.py:183` — the
+only callers wanting the whole player — should load the captain by id through
+`PlayerDao` instead. That would leave `teams` with no player join at all.


### PR DESCRIPTION
Docs only — a spec for the follow-up to #379, plus the answer to the open question that PR left behind.

## SHEP-0012 — carrying the team captain by id

`dto.Team` carries its captain as a whole `Player`, so every query that returns a team joins `players` and `users` for it. Compiled join counts of the real option sets:

| query | joins | tables |
|---|---|---|
| `waiver.get_all_by_player(player)` | **8** | teams, chats, forum_teams, games, players, users |
| `waiver.get_all_by_game(game)` | **7** | teams, chats, forum_teams, players, users |
| `team_player.get_full_history(player)` | **7** | teams, chats, forum_teams, players, users |
| `team.get_team_options()` | **4** | chats, forum_teams, players, users |
| `waiver.get_all_by_team(game, team)` | 2 | players, users |
| `team_player.get_players(team)` | 2 | players, users |

The split is not carelessness: the two-join queries take their parent as an argument, the seven-join ones can't because it varies per row, and then the dto's required fields force the whole aggregate.

Of the three satellites `Team` materialises, `captain` is the one almost nobody dereferences — `FullTeamPlayer.is_captain` (and through it all five permission properties and every `TeamPlayerFilter`), plus six other call sites, only compare its id. `teams.captain_id` is already on the row, under an existing `ix__teams__captain_id`.

**It also fixes a bug.** `FullTeamPlayer.is_captain` reads `self.team.captain.id` with no `None` guard, while `dto.Team.captain` is `Player | None` and `TeamDao.create_by_forum` creates teams with `captain_id=None`. A member of a captain-less team raises `AttributeError` from any permission property. `tgbot/filters/team_player.py:33` guards the same comparison with an ad-hoc `assert`, which is itself a sign the model is awkward.

**Dropping the join is gated**, and the spec says so rather than promising it: `api/shared/responses.py` `Team` carries `captain` on every embedded team — waivers, games, players, teams, admin — so the join can only come out after that response is split, with a `shvatka-ui` change behind it. Quietly nulling the field is not an option, since the UI reads `team.captain.id` for member sorting and the captain badge.

Hence three phases: `captain_id` on the dto (free, fixes the crash, no contract change) → split the API response → `TeamWithCaptain` and drop the join.

## SHEP-0011 — the open question, answered

Phase 2 was "same treatment for `Player.user`". Investigated; the answer is **no**, and the SHEP now records why rather than leaving it as an inviting stub:

- The forum account had 6 consumers; the telegram one has ~46, across the whole bot view and notification layer.
- The hot path needs it: `ApiIdentityProvider.get_user()` derives the API's current `dto.User` entirely from `player._user`, so `get_by_id` can't drop it the way it dropped the forum join.
- Checked group by group, every bulk query's player is linked or messaged by some bot view — `file_info.author` via `file_gateway.upload_to_tg`, `team.captain` and `team_player.player` via the player cards, `organizer.player` and `game.author` via their notifications.
- A type split would invert badly: `PlayerWithTg` would be the dominant type in the bot and bare `Player` the exception.

The one survivor is a new phase 3: `log_keys` renders `name_mention` only, but the same query feeds the zip export, which still reads `has_user()` for its `tg_user_id` identity. Dropping that branch — as the `forum_name` branch was dropped, on the same `d4ddc1efb2ff` guarantee — unblocks four eager-load sites. Small; worth doing only alongside other work in those files.

Register status moves to `Accepted, partially implemented`.

## Notes

- No code changes, so nothing to test; `docs/` has no build in CI, so the AsciiDoc is unvalidated by machine. Every file and line reference in both documents was checked against `master` by hand.
- Numbers come from compiling the actual option sets (`get_team_options`, `get_player_full_load_options`, `get_team_load_options` and the waiver blocks) against the postgres dialect and counting joins — not from reading the source.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxaMRqNMVJUtGtisqQKXjY)_