### PR TITLE
perf(team): load the captain only where one is shown (SHEP-0012)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,6 +299,20 @@ self-contained and close to upstream.
   are fine when they make a query meaningfully better or faster — just don't
   reach for them without that justification.
 
+## The API and the UI ship together
+
+`bomzheg/Shvatka` and `bomzheg/shvatka-ui` are deployed by the same person in one
+go, so a **breaking API change is allowed as long as both repositories change
+together**. There is no transition window to design for and no need to keep a
+field alive until the front-end stops reading it: change the response, change
+`shvatka-ui` in the same breath, and say in each pull request that the other one
+is its pair.
+
+What this does *not* excuse is a silent break. `mypy` cannot see that a response
+model stopped sending a field the UI reads, so when you narrow or split a
+response, grep `shvatka-ui` for every reader — templates included, not just
+`.ts` — before deciding a field is unused.
+
 ## API layout (subdomain packages)
 
 `shvatka/api/` separates **what the API is about** (subdomains) from **how the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Telegram bot.
 - **Lint and tests run in CI.** You may push to the branch and read the CI
   status instead of running the full (slow, testcontainer-backed) suite
   locally. Running `pytest tests/unit` locally for fast feedback is fine.
+  Run type checks as `mypy .`, not `mypy shvatka` — CI checks `tests/` too,
+  and fixtures and integration tests are where a changed dto surfaces last.
 
 ## Project layout
 

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -73,7 +73,7 @@ came out of it*.
 
 | xref:shep-0012-team-captain-by-id.adoc[SHEP-0012]
 | Carrying the team captain by id
-| Draft
+| Accepted, partially implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -73,7 +73,7 @@ came out of it*.
 
 | xref:shep-0012-team-captain-by-id.adoc[SHEP-0012]
 | Carrying the team captain by id
-| Accepted, partially implemented
+| Accepted, implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
+++ b/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
@@ -143,8 +143,8 @@ badge, so it would degrade silently.
 | Phase | Content | Status
 
 | 1 | `Team.is_captain(player_id)` replaces eight hand-written checks and stops crashing on captain-less teams | ✅ done in PR #393
-| 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ✅ done in PR #394 (+ ui#189)
-| 3 | `captain_id` on `dto.Team`, `TeamWithCaptain` for the renderers, and drop the captain join | ✅ done in PR #394
+| 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ✅ done in PR #393 (+ shvatka-ui#191)
+| 3 | `captain_id` on `dto.Team`, `TeamWithCaptain` for the renderers, and drop the captain join | ✅ done in PR #393
 |===
 
 == Deviations from the plan

--- a/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
+++ b/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
@@ -5,7 +5,7 @@
 |===
 | SHEP | 0012
 | Title | Carrying the team captain by id
-| Status | `Draft`
+| Status | `Accepted, partially implemented`
 | Created | 2026-08-31
 | Updated | 2026-08-31
 | Related | xref:shep-0011-player-identity-loading.adoc[SHEP-0011], PR #379
@@ -77,25 +77,25 @@ the same comparison, which is itself evidence that the model is awkward.
 
 == Decision
 
-=== `dto.Team` carries `captain_id`
+=== One place asks who the captain is
 
-Add `captain_id: int | None`, filled from `models.Team.captain_id` — a column on
-the row already being selected, under an existing index
-(`ix__teams__captain_id`). It costs nothing to carry.
-
-Every identity check listed above reads it instead of dereferencing `captain`,
-and `is_captain` becomes total:
+`dto.Team` answers `is_captain(player_id)` itself, and every identity check
+listed above calls it instead of dereferencing `captain`:
 
 [source,python]
 ----
-@property
-def is_captain(self) -> bool:
-    return self.team.captain_id == self.player_id
+def is_captain(self, player_id: int) -> bool:
+    return self.captain is not None and self.captain.id == player_id
 ----
 
 This is worth landing on its own: it removes the `AttributeError`, deletes the
-`assert team.captain is not None` dance from the call sites, and stops the
-permission model depending on what a query happened to join.
+`assert team.captain is not None` dance from the call sites, and gives the later
+phases one method to change instead of eight.
+
+Carrying `captain_id` on the dto — filled from the `teams.captain_id` column,
+under the existing `ix__teams__captain_id`, so the check needs no join — is what
+makes the join droppable. It lands with the split in phase 3 rather than on its
+own; see the deviations below for why.
 
 === Rendering the captain gets its own type
 
@@ -142,14 +142,36 @@ badge, so it would degrade silently.
 |===
 | Phase | Content | Status
 
-| 1 | `captain_id` on `dto.Team`; identity checks read it; `is_captain` stops crashing on captain-less teams | ⏳ not started
+| 1 | `Team.is_captain(player_id)` replaces eight hand-written checks and stops crashing on captain-less teams | ✅ done in PR #393
 | 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ⏳ not started
-| 3 | `TeamWithCaptain` dto; drop the captain join from queries whose callers no longer render it | ⏳ not started
+| 3 | `captain_id` on `dto.Team`, `TeamWithCaptain` for the renderers, and drop the captain join | ⏳ not started
 |===
 
 == Deviations from the plan
 
-Nothing implemented yet.
+`captain_id` moved out of phase 1 into phase 3. It first landed in phase 1 as a
+second field beside `captain`, which needed a consistency assert to keep the two
+from disagreeing — an awkward shape to carry for a benefit no query could take
+yet, since nothing may go lean before phase 2.
+
+Splitting the dto instead (a lean `Team` plus `TeamWithCaptain`) was then tried
+on its own, ahead of phase 2, and does not decompose: `dto.Waiver`,
+`dto.FullTeamPlayer`, `dto.KeyTime` and `dto.LevelTime` all embed a whole
+`Team`, and `api/shared/responses.py` renders the captain off every one of them.
+Requiring `TeamWithCaptain` on those aggregates spreads to every function that
+builds one, and from there to every caller holding a team. Each round of
+retyping produced more errors rather than fewer — 18, then 59, 75, 112 — because
+the requirement is viral, not because any one site was wrong. The response split
+has to come first; the phase order was right.
+
+Phase 1 therefore ships only `Team.is_captain(player_id)`: eight call sites were
+doing the same two-part check — a `None` test and an id comparison — and three
+of them wrote it as an `assert` plus a comparison. One method removes the crash
+and gives phases 2 and 3 a single place to change.
+
+`core/services/team.py` `change_captain` still reads `team.captain` for the
+`CaptainChanged` notification, which renders the old captain's name. Only its
+guard moved to `is_captain`.
 
 == Open questions
 

--- a/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
+++ b/docs/modules/shep/pages/shep-0012-team-captain-by-id.adoc
@@ -5,7 +5,7 @@
 |===
 | SHEP | 0012
 | Title | Carrying the team captain by id
-| Status | `Accepted, partially implemented`
+| Status | `Accepted, implemented`
 | Created | 2026-08-31
 | Updated | 2026-08-31
 | Related | xref:shep-0011-player-identity-loading.adoc[SHEP-0011], PR #379
@@ -143,11 +143,16 @@ badge, so it would degrade silently.
 | Phase | Content | Status
 
 | 1 | `Team.is_captain(player_id)` replaces eight hand-written checks and stops crashing on captain-less teams | ✅ done in PR #393
-| 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ⏳ not started
-| 3 | `captain_id` on `dto.Team`, `TeamWithCaptain` for the renderers, and drop the captain join | ⏳ not started
+| 2 | Split the API `Team` response into embedded (lean) and captain-bearing forms; follow in `shvatka-ui` | ✅ done in PR #394 (+ ui#189)
+| 3 | `captain_id` on `dto.Team`, `TeamWithCaptain` for the renderers, and drop the captain join | ✅ done in PR #394
 |===
 
 == Deviations from the plan
+
+Phases 2 and 3 landed together, in one pull request per repository. They are not
+separable: `captain_id` on the lean dto is what lets the aggregates stay plain,
+and the lean API response is what lets the aggregates want to. Attempting either
+half alone fails (below).
 
 `captain_id` moved out of phase 1 into phase 3. It first landed in phase 1 as a
 second field beside `captain`, which needed a consistency assert to keep the two
@@ -173,9 +178,25 @@ and gives phases 2 and 3 a single place to change.
 `CaptainChanged` notification, which renders the old captain's name. Only its
 guard moved to `is_captain`.
 
+== What the type system could not check
+
+Two breakages had to be found by reading, because nothing would have failed:
+
+* `shared.Team.from_core` accepts a `TeamWithCaptain` perfectly happily and drops
+  the captain on the floor. Every route that renders one had to be pointed at
+  `TeamWithCaptain.from_core` by hand; mypy stayed green throughout.
+* The bot's team cards are Jinja templates. `{{team.captain.name_mention}}` on a
+  plain team renders an empty string rather than raising, so the "Капитан:" line
+  would have quietly gone blank. Typing `team_card` and the captain's bridge
+  getter as taking `TeamWithCaptain` is what turned those into mypy errors.
+
+The same hazard is why `shvatka-ui` was grepped for `.captain` across templates
+as well as `.ts` — the first pass, `.ts` only, missed four screens.
+
 == Open questions
 
-Whether `models.Team.captain` should keep its relationship at all once phase 3
-lands, or whether the two merge handlers and `core/services/team.py:183` — the
-only callers wanting the whole player — should load the captain by id through
-`PlayerDao` instead. That would leave `teams` with no player join at all.
+Whether `models.Team.captain` should keep its relationship at all, or whether the
+two merge handlers and `core/services/team.py` `change_captain` — the only callers
+wanting the whole player rather than a rendered name — should load the captain by
+id through `PlayerDao` instead. That would leave `teams` with no player join at
+all outside the team pages.

--- a/shvatka/api/admin/routes.py
+++ b/shvatka/api/admin/routes.py
@@ -207,11 +207,11 @@ async def merge_teams(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[AdminMergeTeamsInteractor],
     body: Annotated[shared_requests.MergeRequest, Body()],
-) -> shared.Team:
+) -> shared.TeamWithCaptain:
     team = await interactor(
         identity=identity, primary_id=body.primary_id, secondary_id=body.secondary_id
     )
-    result = shared.Team.from_core(team)
+    result = shared.TeamWithCaptain.from_core(team)
     assert result is not None
     return result
 
@@ -222,9 +222,9 @@ async def change_team_captain(
     interactor: FromDishka[AdminChangeTeamCaptainInteractor],
     id_: Annotated[int, Path(alias="id")],
     body: Annotated[requests.AdminNewCaptain, Body()],
-) -> shared.Team:
+) -> shared.TeamWithCaptain:
     team = await interactor(identity=identity, team_id=id_, player_id=body.player_id)
-    result = shared.Team.from_core(team)
+    result = shared.TeamWithCaptain.from_core(team)
     assert result is not None
     return result
 

--- a/shvatka/api/app/dependencies/auth.py
+++ b/shvatka/api/app/dependencies/auth.py
@@ -164,7 +164,7 @@ class LoadedData(TypedDict, total=False):
     user: dto.User | None
     chat: dto.Chat | None
     player: dto.Player | None
-    team: dto.Team | None
+    team: dto.TeamWithCaptain | None
     full_team_player: dto.FullTeamPlayer | None
     organizer: dict[int, dto.Organizer | None]
 
@@ -223,7 +223,7 @@ class ApiIdentityProvider(IdentityProvider):
         self.cache["player"] = player
         return player
 
-    async def get_team(self) -> dto.Team | None:
+    async def get_team(self) -> dto.TeamWithCaptain | None:
         if "team" in self.cache:
             return self.cache["team"]
         player = await self.get_required_player()

--- a/shvatka/api/shared/responses.py
+++ b/shvatka/api/shared/responses.py
@@ -45,10 +45,17 @@ class Player:
 
 @dataclass
 class Team:
+    """A team as it appears inside another payload — no captain loaded.
+
+    `captain_id` answers "does this player captain the team" without the join
+    the captain themselves would cost. Screens that show a captain by name are
+    answered with :class:`TeamWithCaptain` instead.
+    """
+
     id: int
     name: str
-    captain: Player | None
     description: str | None
+    captain_id: int | None
 
     @overload
     @classmethod
@@ -67,8 +74,46 @@ class Team:
         return cls(
             id=core.id,
             name=core.name,
-            captain=Player.from_core(core.captain) if core.captain else None,
             description=core.description,
+            captain_id=core.captain_id,
+        )
+
+
+@dataclass
+class TeamWithCaptain:
+    """A team with its captain rendered — for the team pages and admin tools.
+
+    Deliberately not a subclass of :class:`Team`: it answers from a different
+    core type, and narrowing `from_core` in a subclass would be a lie about
+    what a `Team` accepts.
+    """
+
+    id: int
+    name: str
+    description: str | None
+    captain_id: int | None
+    captain: Player | None
+
+    @overload
+    @classmethod
+    def from_core(cls, core: dto.TeamWithCaptain) -> Self:
+        ...
+
+    @overload
+    @classmethod
+    def from_core(cls, core: None) -> None:
+        ...
+
+    @classmethod
+    def from_core(cls, core: dto.TeamWithCaptain | None) -> "Self | None":
+        if core is None:
+            return None
+        return cls(
+            id=core.id,
+            name=core.name,
+            description=core.description,
+            captain_id=core.captain_id,
+            captain=Player.from_core(core.captain) if core.captain else None,
         )
 
 

--- a/shvatka/api/teams/responses.py
+++ b/shvatka/api/teams/responses.py
@@ -12,6 +12,7 @@ from shvatka.core.teams.dto import TeamWithStat as TeamWithStatDto
 class TeamWithStat:
     id: int
     name: str
+    captain_id: int | None
     captain: Player | None
     description: str | None
     played_games_count: int
@@ -21,6 +22,7 @@ class TeamWithStat:
         return cls(
             id=core.team.id,
             name=core.team.name,
+            captain_id=core.team.captain_id,
             captain=Player.from_core(core.team.captain) if core.team.captain else None,
             description=core.team.description,
             played_games_count=core.played_games_count,
@@ -31,6 +33,7 @@ class TeamWithStat:
 class CaptainedTeam:
     id: int
     name: str
+    captain_id: int | None
     captain: Player | None
     description: str | None
     played_games_count: int
@@ -42,6 +45,7 @@ class CaptainedTeam:
         return cls(
             id=core.team.id,
             name=core.team.name,
+            captain_id=core.team.captain_id,
             captain=Player.from_core(core.team.captain) if core.team.captain else None,
             description=core.team.description,
             played_games_count=core.played_games_count,

--- a/shvatka/api/teams/routes.py
+++ b/shvatka/api/teams/routes.py
@@ -45,8 +45,8 @@ async def get_team_stat(
 
 
 @inject
-async def get_my_team(identity: FromDishka[IdentityProvider]) -> shared.Team | None:
-    return shared.Team.from_core(await identity.get_team())
+async def get_my_team(identity: FromDishka[IdentityProvider]) -> shared.TeamWithCaptain | None:
+    return shared.TeamWithCaptain.from_core(await identity.get_team())
 
 
 @inject
@@ -79,9 +79,9 @@ async def change_captain(
     interactor: FromDishka[ChangeCaptainInteractor],
     id_: Annotated[int, Path(alias="id")],
     body: Annotated[requests.NewCaptain, Body()],
-) -> shared.Team:
+) -> shared.TeamWithCaptain:
     team = await interactor(team_id=id_, new_captain_id=body.player_id, identity=identity)
-    result = shared.Team.from_core(team)
+    result = shared.TeamWithCaptain.from_core(team)
     assert result is not None
     return result
 
@@ -107,8 +107,8 @@ async def add_player_to_team(
 async def get_team(
     interactor: FromDishka[GetTeamInteractor],
     id_: Annotated[int, Path(alias="id")],
-) -> shared.Team:
-    return shared.Team.from_core(await interactor(id_))
+) -> shared.TeamWithCaptain:
+    return shared.TeamWithCaptain.from_core(await interactor(id_))
 
 
 @inject
@@ -116,13 +116,13 @@ async def create_team(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[CreateTeamInteractor],
     body: Annotated[requests.NewTeam, Body()],
-) -> shared.Team:
+) -> shared.TeamWithCaptain:
     team = await interactor(
         identity=identity,
         name=body.name,
         description=body.description,
     )
-    return shared.Team.from_core(team)
+    return shared.TeamWithCaptain.from_core(team)
 
 
 @inject
@@ -131,14 +131,14 @@ async def edit_team(
     interactor: FromDishka[EditTeamInteractor],
     id_: Annotated[int, Path(alias="id")],
     body: Annotated[requests.TeamSettings, Body()],
-) -> shared.Team:
+) -> shared.TeamWithCaptain:
     team = await interactor(
         team_id=id_,
         identity=identity,
         name=body.name,
         description=body.description,
     )
-    return shared.Team.from_core(team)
+    return shared.TeamWithCaptain.from_core(team)
 
 
 @inject

--- a/shvatka/common/data_examples.py
+++ b/shvatka/common/data_examples.py
@@ -7,14 +7,12 @@ from shvatka.core.models.dto import action, hints, scn
 gryffindor = dto.Team(
     id=1,
     name="Gryffindor",
-    captain=None,
     description=None,
     is_dummy=False,
 )
 slytherin = dto.Team(
     id=2,
     name="Slytherin",
-    captain=None,
     description=None,
     is_dummy=False,
 )

--- a/shvatka/core/interfaces/dal/player.py
+++ b/shvatka/core/interfaces/dal/player.py
@@ -49,7 +49,7 @@ class TeamPlayerGetter(Protocol):
 
 
 class TeamByPlayerGetter(Protocol):
-    async def get_team(self, player: dto.Player) -> dto.Team | None:
+    async def get_team(self, player: dto.Player) -> dto.TeamWithCaptain | None:
         raise NotImplementedError
 
 
@@ -92,7 +92,7 @@ class TeamLeaver(Committer, ActiveGameFinder, WaiverRemover, TeamPlayerGetter, P
     async def del_player_vote(self, team_id: int, player_id: int) -> None:
         raise NotImplementedError
 
-    async def get_team(self, player: dto.Player) -> dto.Team | None:
+    async def get_team(self, player: dto.Player) -> dto.TeamWithCaptain | None:
         raise NotImplementedError
 
     async def leave_team(self, player: dto.Player) -> None:

--- a/shvatka/core/interfaces/dal/team.py
+++ b/shvatka/core/interfaces/dal/team.py
@@ -7,7 +7,7 @@ from shvatka.core.models import dto
 
 
 class TeamGetter(Protocol):
-    async def get_by_chat(self, chat: dto.Chat) -> dto.Team | None:
+    async def get_by_chat(self, chat: dto.Chat) -> dto.TeamWithCaptain | None:
         raise NotImplementedError
 
 
@@ -15,7 +15,7 @@ class TeamCreator(TeamJoiner, Protocol):
     async def check_no_team_in_chat(self, chat: dto.Chat) -> None:
         raise NotImplementedError
 
-    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.Team:
+    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.TeamWithCaptain:
         raise NotImplementedError
 
 
@@ -32,17 +32,17 @@ class TeamDescChanger(Committer, Protocol):
 class TeamsGetter(Protocol):
     async def get_teams(
         self, active: bool = True, archive: bool = False, name: str | None = None
-    ) -> list[dto.Team]:
+    ) -> list[dto.TeamWithCaptain]:
         raise NotImplementedError
 
 
 class TeamByIdGetter(Protocol):
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         raise NotImplementedError
 
 
 class CaptainedTeamsGetter(Protocol):
-    async def get_captained_teams(self, captain: dto.Player) -> list[dto.Team]:
+    async def get_captained_teams(self, captain: dto.Player) -> list[dto.TeamWithCaptain]:
         raise NotImplementedError
 
 
@@ -67,7 +67,7 @@ class FreeForumTeamGetter(Protocol):
 
 
 class ByForumTeamIdGetter(Protocol):
-    async def get_by_forum_team_id(self, forum_team_id: int) -> dto.Team:
+    async def get_by_forum_team_id(self, forum_team_id: int) -> dto.TeamWithCaptain:
         raise NotImplementedError
 
 

--- a/shvatka/core/interfaces/identity.py
+++ b/shvatka/core/interfaces/identity.py
@@ -17,7 +17,7 @@ class IdentityProvider(Protocol):
     async def get_chat(self) -> dto.Chat | None:
         raise NotImplementedError
 
-    async def get_team(self) -> dto.Team | None:
+    async def get_team(self) -> dto.TeamWithCaptain | None:
         raise NotImplementedError
 
     async def get_full_team_player(self) -> dto.FullTeamPlayer | None:
@@ -80,7 +80,7 @@ class IdentityProvider(Protocol):
             raise exceptions.IdentityWithoutPlayer
         return player
 
-    async def get_required_team(self) -> dto.Team:
+    async def get_required_team(self) -> dto.TeamWithCaptain:
         team = await self.get_team()
         if team is None:
             raise exceptions.PlayerNotInTeam(

--- a/shvatka/core/models/dto/__init__.py
+++ b/shvatka/core/models/dto/__init__.py
@@ -26,7 +26,7 @@ from .levels_times import GameStat, GameStatWithHints, LevelTime, LevelTimeOnGam
 from .organizer import Organizer, PrimaryOrganizer, SecondaryOrganizer
 from .player import Player, PlayerWithCreds, PlayerWithForum, PlayerWithStat
 from .poll import Vote, VotedPlayer
-from .team import Team
+from .team import Team, TeamWithCaptain
 from .team_player import FullTeamPlayer, TeamDataRange, TeamPlayer
 from .time_key import (
     InsertedKey,

--- a/shvatka/core/models/dto/team.py
+++ b/shvatka/core/models/dto/team.py
@@ -11,9 +11,15 @@ from .player import Player
 class Team:
     id: int
     name: str
-    captain: Player | None
     is_dummy: bool
     description: str | None
+    captain_id: int | None = None
+    """Who captains the team, without loading them.
+
+    ``teams.captain_id`` is on the row itself, so :meth:`is_captain` costs no
+    join. Rendering the captain is what costs one — that is
+    :class:`TeamWithCaptain`.
+    """
     _chat: Chat | None = field(init=False)
     chat: InitVar[Chat | None] = field(default=None)
     _forum_team: ForumTeam | None = field(init=False)
@@ -26,11 +32,11 @@ class Team:
     def is_captain(self, player_id: int) -> bool:
         """Whether this player captains the team.
 
-        A team may have no captain at all — ``TeamDao.create_by_forum`` creates
-        one that way — so the question is answered here rather than by
-        dereferencing ``captain`` at each call site.
+        Answered from ``captain_id``, so it works on a team whose captain was
+        never loaded — and a team may have no captain at all, since
+        ``TeamDao.create_by_forum`` creates one that way.
         """
-        return self.captain is not None and self.captain.id == player_id
+        return self.captain_id is not None and self.captain_id == player_id
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Team):
@@ -53,3 +59,22 @@ class Team:
 
     def has_forum_team(self) -> bool:
         return self._forum_team is not None
+
+
+@dataclass(eq=False)
+class TeamWithCaptain(Team):
+    """A team together with the player who captains it.
+
+    Loading the captain joins ``players`` (and ``users`` behind it) onto every
+    row carrying a team, and only the screens that show a captain by name need
+    it: the team pages, the admin team tools and the bot's team card.
+    Everything else takes a plain :class:`Team` and asks
+    :meth:`Team.is_captain`.
+    """
+
+    captain: Player | None = None
+
+    def __post_init__(self, chat: Chat | None, forum_team: ForumTeam | None) -> None:
+        super().__post_init__(chat, forum_team)
+        if self.captain_id is None:
+            self.captain_id = self.captain.id if self.captain else None

--- a/shvatka/core/models/dto/team.py
+++ b/shvatka/core/models/dto/team.py
@@ -23,6 +23,15 @@ class Team:
         self._chat = chat
         self._forum_team = forum_team
 
+    def is_captain(self, player_id: int) -> bool:
+        """Whether this player captains the team.
+
+        A team may have no captain at all — ``TeamDao.create_by_forum`` creates
+        one that way — so the question is answered here rather than by
+        dereferencing ``captain`` at each call site.
+        """
+        return self.captain is not None and self.captain.id == player_id
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, Team):
             return False

--- a/shvatka/core/models/dto/team_player.py
+++ b/shvatka/core/models/dto/team_player.py
@@ -51,8 +51,8 @@ class FullTeamPlayer(TeamPlayer):
     team: Team
 
     @property
-    def is_captain(self):
-        return self.team.captain.id == self.player_id
+    def is_captain(self) -> bool:
+        return self.team.is_captain(self.player_id)
 
     @property
     def can_manage_waivers(self) -> bool:

--- a/shvatka/core/notifications/request_interactors.py
+++ b/shvatka/core/notifications/request_interactors.py
@@ -290,7 +290,7 @@ class CreateTeamMergeRequestInteractor:
         captain = await identity.get_required_player()
         primary = await get_team_by_id(primary_team_id, self.team_dao)
         secondary = await get_team_by_id(secondary_team_id, self.team_dao)
-        if primary.captain is None or primary.captain.id != captain.id:
+        if not primary.is_captain(captain.id):
             raise RequestPermissionError(player=captain, team=primary)
         existing = await self.requests.get_pending(
             type_=RequestType.team_merge, team_id=primary.id

--- a/shvatka/core/players/player.py
+++ b/shvatka/core/players/player.py
@@ -171,7 +171,7 @@ async def _join_team(
 
 
 def is_team_captain(team: dto.Team, player: dto.Player) -> bool:
-    return team.captain is not None and team.captain.id == player.id
+    return team.is_captain(player.id)
 
 
 async def get_checked_player_on_team(

--- a/shvatka/core/players/player.py
+++ b/shvatka/core/players/player.py
@@ -65,7 +65,7 @@ async def have_team(player: dto.Player, dao: PlayerTeamChecker) -> bool:
     return await dao.have_team(player)
 
 
-async def get_my_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.Team | None:
+async def get_my_team(player: dto.Player, dao: PlayerTeamChecker) -> dto.TeamWithCaptain | None:
     return await dao.get_team(player)
 
 

--- a/shvatka/core/search/adapters.py
+++ b/shvatka/core/search/adapters.py
@@ -17,7 +17,7 @@ class GlobalSearchDao(Protocol):
         """
         raise NotImplementedError
 
-    async def search_teams(self, text: str) -> list[dto.Team]:
+    async def search_teams(self, text: str) -> list[dto.TeamWithCaptain]:
         """Команды (включая архивные форумные), чьё название содержит text."""
         raise NotImplementedError
 

--- a/shvatka/core/services/team.py
+++ b/shvatka/core/services/team.py
@@ -41,9 +41,9 @@ async def create_team(
     try:
         await dao.check_no_team_in_chat(chat)
     except exceptions.AnotherTeamInChat as e:
-        if not e.team or not e.team.captain:
+        if not e.team:
             raise
-        if e.team.captain.id == captain.id:
+        if e.team.is_captain(captain.id):
             team = e.team
             created = False
         else:
@@ -181,7 +181,7 @@ async def change_captain(
             doc_page=DocPage.CHANGE_CAPTAIN,
         )
     old_captain = team.captain
-    if old_captain is not None and old_captain.id == new_captain_id:
+    if team.is_captain(new_captain_id):
         raise exceptions.TeamError(
             team=team,
             player=actor,
@@ -226,8 +226,7 @@ def check_can_change_chat(team: dto.Team, captain: dto.FullTeamPlayer):
             team=team, player=captain.player, notify_user="Вы не игрок этой команды"
         )
     assert captain.player is not None
-    assert team.captain is not None
-    if team.captain.id == captain.player.id:
+    if team.is_captain(captain.player.id):
         return
     raise PermissionsError(
         permission_name="change_chat",  # TODO
@@ -250,8 +249,7 @@ def assert_can_change_name(team: dto.Team, captain: dto.FullTeamPlayer) -> None:
             team=team, player=captain.player, notify_user="Вы не игрок этой команды"
         )
     assert captain.player is not None
-    assert team.captain is not None
-    if team.captain.id == captain.player.id:
+    if team.is_captain(captain.player.id):
         return
     if captain.can_change_team_name:
         return

--- a/shvatka/core/services/team.py
+++ b/shvatka/core/services/team.py
@@ -35,16 +35,19 @@ async def create_team(
     captain: dto.Player,
     dao: TeamCreator,
     game_log: GameLogWriter,
-) -> dto.Team:
+) -> dto.TeamWithCaptain:
     check_allow_be_author(captain)
     await dao.check_player_free(captain)
     try:
         await dao.check_no_team_in_chat(chat)
     except exceptions.AnotherTeamInChat as e:
-        if not e.team:
+        existing = e.team
+        # the only raiser carrying a team is TeamDao.check_no_team_in_chat, which
+        # takes it from get_by_chat; the error type is simply too general to say so
+        if not isinstance(existing, dto.TeamWithCaptain):
             raise
-        if e.team.is_captain(captain.id):
-            team = e.team
+        if existing.is_captain(captain.id):
+            team = existing
             created = False
         else:
             raise
@@ -67,7 +70,7 @@ async def create_team(
     return team
 
 
-async def get_by_chat(chat: dto.Chat, dao: TeamGetter) -> dto.Team | None:
+async def get_by_chat(chat: dto.Chat, dao: TeamGetter) -> dto.TeamWithCaptain | None:
     return await dao.get_by_chat(chat)
 
 
@@ -89,11 +92,11 @@ async def change_team_desc(
 
 async def get_teams(
     dao: TeamsGetter, active: bool = True, archive: bool = False, name: str | None = None
-) -> list[dto.Team]:
+) -> list[dto.TeamWithCaptain]:
     return await dao.get_teams(active, archive, name)
 
 
-async def get_team_by_id(team_id: int, dao: TeamByIdGetter) -> dto.Team:
+async def get_team_by_id(team_id: int, dao: TeamByIdGetter) -> dto.TeamWithCaptain:
     return await dao.get_by_id(team_id)
 
 
@@ -157,12 +160,12 @@ async def merge_teams(
 
 
 async def change_captain(
-    team: dto.Team,
+    team: dto.TeamWithCaptain,
     actor: dto.Player,
     new_captain_id: int,
     dao: TeamCaptainSetter,
     notifier: TeamNotifier,
-) -> dto.Team:
+) -> dto.TeamWithCaptain:
     """Hand the team over to another of its players.
 
     The new captain has to play in the team already — the captaincy is not an

--- a/shvatka/core/teams/adapters.py
+++ b/shvatka/core/teams/adapters.py
@@ -29,7 +29,7 @@ class ChatlessTeamCreator(TeamJoiner, Protocol):
 
     async def create_no_chat(
         self, name: str, description: str | None, captain: dto.Player
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         raise NotImplementedError
 
 

--- a/shvatka/core/teams/admin_interactors.py
+++ b/shvatka/core/teams/admin_interactors.py
@@ -39,7 +39,7 @@ class AdminMergeTeamsInteractor:
 
     async def __call__(
         self, identity: IdentityProvider, primary_id: int, secondary_id: int
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         """Merge ``secondary`` team into ``primary``; ``secondary`` is deleted."""
         actor = await identity.get_superuser()
         logger.warning("admin %s merges team %s into %s", actor.id, secondary_id, primary_id)
@@ -64,7 +64,9 @@ class AdminChangeTeamCaptainInteractor:
     dao: TeamCaptainSetter
     notifier: TeamNotifier
 
-    async def __call__(self, identity: IdentityProvider, team_id: int, player_id: int) -> dto.Team:
+    async def __call__(
+        self, identity: IdentityProvider, team_id: int, player_id: int
+    ) -> dto.TeamWithCaptain:
         admin = await identity.get_superuser()
         team = await get_team_by_id(team_id, self.dao)
         logger.warning(

--- a/shvatka/core/teams/dto.py
+++ b/shvatka/core/teams/dto.py
@@ -7,7 +7,7 @@ from shvatka.core.models import dto
 class TeamWithStat:
     """A team together with aggregated statistics for list views."""
 
-    team: dto.Team
+    team: dto.TeamWithCaptain
     played_games_count: int
 
 
@@ -19,7 +19,7 @@ class CaptainedTeam:
     web ui uses ``is_current`` to decide between "вы здесь" and a join button.
     """
 
-    team: dto.Team
+    team: dto.TeamWithCaptain
     played_games_count: int
     is_current: bool
 

--- a/shvatka/core/teams/interactors.py
+++ b/shvatka/core/teams/interactors.py
@@ -92,7 +92,7 @@ class CreateTeamInteractor:
         identity: IdentityProvider,
         name: str,
         description: str | None = None,
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         captain = await identity.get_required_player()
         name = name.strip()
         if not name:
@@ -123,7 +123,7 @@ class CreateTeamInteractor:
 class GetTeamInteractor:
     dao: TeamByIdGetter
 
-    async def __call__(self, team_id: int) -> dto.Team:
+    async def __call__(self, team_id: int) -> dto.TeamWithCaptain:
         return await get_team_by_id(team_id, self.dao)
 
 
@@ -313,7 +313,7 @@ class ChangeCaptainInteractor:
 
     async def __call__(
         self, team_id: int, new_captain_id: int, identity: IdentityProvider
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         actor = await identity.get_required_player()
         team = await get_team_by_id(team_id, self.dao)
         check_can_change_captain(actor, team)
@@ -331,7 +331,7 @@ class EditTeamInteractor:
         identity: IdentityProvider,
         name: str | None = None,
         description: str | None = None,
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         manager = await identity.get_required_player()
         team = await get_team_by_id(team_id, self.dao)
         await check_can_change_name(manager, team, self.team_player_dao)

--- a/shvatka/infrastructure/db/dao/complex/game_play.py
+++ b/shvatka/infrastructure/db/dao/complex/game_play.py
@@ -160,7 +160,7 @@ class GamePlayerDaoImpl(GamePlayerDao):
     async def commit(self) -> None:
         await self.dao.commit()
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
     async def get_level_time_by_id(

--- a/shvatka/infrastructure/db/dao/complex/search.py
+++ b/shvatka/infrastructure/db/dao/complex/search.py
@@ -19,7 +19,7 @@ class GlobalSearchDaoImpl(GlobalSearchDao):
     async def search_levels_of_completed_games(self, text: str) -> list[LevelWithGame]:
         return await self.dao.level.search_in_completed_games(text)
 
-    async def search_teams(self, text: str) -> list[dto.Team]:
+    async def search_teams(self, text: str) -> list[dto.TeamWithCaptain]:
         return await self.dao.team.search_by_name(text)
 
     async def search_players(self, text: str) -> list[dto.PlayerWithForum]:

--- a/shvatka/infrastructure/db/dao/complex/team.py
+++ b/shvatka/infrastructure/db/dao/complex/team.py
@@ -25,12 +25,12 @@ class TeamCreatorImpl(TeamCreator, ChatlessTeamCreator):
     async def check_no_team_in_chat(self, chat: dto.Chat) -> None:
         return await self.dao.team.check_no_team_in_chat(chat)
 
-    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.Team:
+    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.TeamWithCaptain:
         return await self.dao.team.create(chat, captain)
 
     async def create_no_chat(
         self, name: str, description: str | None, captain: dto.Player
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         return await self.dao.team.create_no_chat(name, description, captain)
 
     async def join_team(
@@ -62,7 +62,7 @@ class TeamLeaverImpl(TeamLeaver):
     async def del_player_vote(self, team_id: int, player_id: int) -> None:
         return await self.dao.poll.del_player_vote(team_id, player_id)
 
-    async def get_team(self, player: dto.Player) -> dto.Team | None:
+    async def get_team(self, player: dto.Player) -> dto.TeamWithCaptain | None:
         return await self.dao.team_player.get_team(player)
 
     async def leave_team(self, player: dto.Player) -> None:
@@ -109,7 +109,7 @@ class TeamMergerImpl(TeamMerger):
 
 @dataclass
 class AdminTeamMergerImpl(TeamMergerImpl, AdminTeamMerger):
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
 
@@ -117,7 +117,7 @@ class AdminTeamMergerImpl(TeamMergerImpl, AdminTeamMerger):
 class TeamCaptainSetterImpl(TeamCaptainSetter):
     dao: "HolderDao"
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
     async def get_players(self, team: dto.Team) -> Sequence[dto.FullTeamPlayer]:
@@ -137,10 +137,10 @@ class TeamCaptainSetterImpl(TeamCaptainSetter):
 class CaptainedTeamsReaderImpl(CaptainedTeamsReader):
     dao: "HolderDao"
 
-    async def get_captained_teams(self, captain: dto.Player) -> list[dto.Team]:
+    async def get_captained_teams(self, captain: dto.Player) -> list[dto.TeamWithCaptain]:
         return await self.dao.team.get_captained_teams(captain)
 
-    async def get_team(self, player: dto.Player) -> dto.Team | None:
+    async def get_team(self, player: dto.Player) -> dto.TeamWithCaptain | None:
         return await self.dao.team_player.get_team(player)
 
     async def get_played_games_counts(self, team_ids: Sequence[int]) -> dict[int, int]:
@@ -151,7 +151,7 @@ class CaptainedTeamsReaderImpl(CaptainedTeamsReader):
 class CaptainTeamJoinerImpl(TeamLeaverImpl, CaptainTeamJoiner):
     """Leaving the current team and joining the captained one, in one adapter."""
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
     async def join_team(

--- a/shvatka/infrastructure/db/dao/complex2/waiver.py
+++ b/shvatka/infrastructure/db/dao/complex2/waiver.py
@@ -60,7 +60,7 @@ class PollDraftsReaderImpl(PollDraftsReader):
     async def get_dict_player_vote(self, team_id: int) -> dict[int, Played]:
         return await self.dao.poll.get_dict_player_vote(team_id)
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
     async def get_by_player_or_none(
@@ -85,7 +85,7 @@ class AdminPollReaderImpl(AdminPollReader):
     async def get_dict_player_vote(self, team_id: int) -> dict[int, Played]:
         return await self.dao.poll.get_dict_player_vote(team_id)
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         return await self.dao.team.get_by_id(id_)
 
 

--- a/shvatka/infrastructure/db/dao/rdb/level_times.py
+++ b/shvatka/infrastructure/db/dao/rdb/level_times.py
@@ -77,9 +77,6 @@ class LevelTimeDao(BaseDAO[models.LevelTime]):
             select(models.LevelTime)
             .where(models.LevelTime.game_id == game.id)
             .options(
-                joinedload(models.LevelTime.team)
-                .joinedload(models.Team.captain)
-                .joinedload(models.Player.user),
                 joinedload(models.LevelTime.team).joinedload(models.Team.chat),
                 joinedload(models.LevelTime.team).joinedload(models.Team.forum_team),
             )

--- a/shvatka/infrastructure/db/dao/rdb/log_keys.py
+++ b/shvatka/infrastructure/db/dao/rdb/log_keys.py
@@ -141,7 +141,6 @@ class KeyTimeDao(BaseDAO[models.KeyTime]):
                 joinedload(models.KeyTime.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
                 joinedload(models.KeyTime.player).options(joinedload(models.Player.user)),
             )

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -21,7 +21,7 @@ class TeamDao(BaseDAO[models.Team]):
     ) -> None:
         super().__init__(models.Team, session, clock=clock)
 
-    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.Team:
+    async def create(self, chat: dto.Chat, captain: dto.Player) -> dto.TeamWithCaptain:
         chat_db = await self.session.get(models.Chat, chat.db_id)
         assert chat_db
         team = models.Team(
@@ -39,7 +39,7 @@ class TeamDao(BaseDAO[models.Team]):
                 player=captain,
                 text="can't create team",
             ) from e
-        return dto.Team(
+        return dto.TeamWithCaptain(
             id=team.id,
             chat=chat,
             name=team.name,
@@ -50,7 +50,7 @@ class TeamDao(BaseDAO[models.Team]):
 
     async def create_no_chat(
         self, name: str, description: str | None, captain: dto.Player
-    ) -> dto.Team:
+    ) -> dto.TeamWithCaptain:
         team = models.Team(
             captain_id=captain.id,
             name=name,
@@ -64,7 +64,7 @@ class TeamDao(BaseDAO[models.Team]):
                 player=captain,
                 text="can't create team",
             ) from e
-        return dto.Team(
+        return dto.TeamWithCaptain(
             id=team.id,
             chat=None,
             name=team.name,
@@ -73,7 +73,9 @@ class TeamDao(BaseDAO[models.Team]):
             is_dummy=team.is_dummy,
         )
 
-    async def create_by_forum(self, forum: dto.ForumTeam, captain: dto.Player | None) -> dto.Team:
+    async def create_by_forum(
+        self, forum: dto.ForumTeam, captain: dto.Player | None
+    ) -> dto.TeamWithCaptain:
         forum_team_db = await self.session.get(models.ForumTeam, forum.id)
         assert forum_team_db
         if forum_team_db.team_id:
@@ -94,9 +96,9 @@ class TeamDao(BaseDAO[models.Team]):
                     player=captain,
                     text="can't create team",
                 ) from e
-        return team.to_dto(forum_team=forum, captain=captain)
+        return team.to_dto_with_captain(forum_team=forum, captain=captain)
 
-    async def get_by_chat(self, chat: dto.Chat) -> dto.Team | None:
+    async def get_by_chat(self, chat: dto.Chat) -> dto.TeamWithCaptain | None:
         result: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team)
             .join(models.Team.chat)
@@ -107,7 +109,7 @@ class TeamDao(BaseDAO[models.Team]):
             team = result.one()
         except NoResultFound:
             return None
-        return team.to_dto_chat_prefetched()
+        return team.to_dto_with_captain_prefetched()
 
     async def check_no_team_in_chat(self, chat: dto.Chat) -> None:
         if team := await self.get_by_chat(chat):
@@ -117,15 +119,15 @@ class TeamDao(BaseDAO[models.Team]):
                 text="team in this chat exists",
             )
 
-    async def get_by_id(self, id_: int) -> dto.Team:
+    async def get_by_id(self, id_: int) -> dto.TeamWithCaptain:
         team = await self._get_by_id(
             id_,
             get_team_options(),
             populate_existing=True,
         )
-        return team.to_dto_chat_prefetched()
+        return team.to_dto_with_captain_prefetched()
 
-    async def get_captained_teams(self, captain: dto.Player) -> list[dto.Team]:
+    async def get_captained_teams(self, captain: dto.Player) -> list[dto.TeamWithCaptain]:
         """Every team this player is the captain of, whether they play in it or not."""
         teams: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team)
@@ -133,7 +135,7 @@ class TeamDao(BaseDAO[models.Team]):
             .where(models.Team.captain_id == captain.id)
             .order_by(models.Team.id)
         )
-        return [team.to_dto_chat_prefetched() for team in teams]
+        return [team.to_dto_with_captain_prefetched() for team in teams]
 
     async def change_captain(self, team: dto.Team, captain: dto.Player) -> None:
         await self.session.execute(
@@ -150,14 +152,14 @@ class TeamDao(BaseDAO[models.Team]):
             update(models.Team).where(models.Team.id == team.id).values(description=new_desc)
         )
 
-    async def get_by_name(self, name: str) -> dto.Team:
+    async def get_by_name(self, name: str) -> dto.TeamWithCaptain:
         result: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team).options(*get_team_options()).where(models.Team.name == name)
         )
         team = result.one()
-        return team.to_dto_chat_prefetched()
+        return team.to_dto_with_captain_prefetched()
 
-    async def get_by_forum_team_name(self, name: str) -> dto.Team:
+    async def get_by_forum_team_name(self, name: str) -> dto.TeamWithCaptain:
         result: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team)
             .join(models.Team.forum_team)
@@ -165,20 +167,20 @@ class TeamDao(BaseDAO[models.Team]):
             .where(models.ForumTeam.name == name)
         )
         team = result.one()
-        return team.to_dto_chat_prefetched()
+        return team.to_dto_with_captain_prefetched()
 
-    async def get_by_forum_team_id(self, forum_team_id: int) -> dto.Team:
+    async def get_by_forum_team_id(self, forum_team_id: int) -> dto.TeamWithCaptain:
         result: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team)
             .join(models.Team.forum_team)
             .options(*get_team_options())
             .where(models.ForumTeam.id == forum_team_id)
         )
-        return result.one().to_dto_chat_prefetched()
+        return result.one().to_dto_with_captain_prefetched()
 
     async def get_teams(
         self, active: bool = True, archive: bool = False, name: str | None = None
-    ) -> list[dto.Team]:
+    ) -> list[dto.TeamWithCaptain]:
         query = select(models.Team).options(*get_team_options())
         if not active and not archive:
             query = query.where(false())
@@ -189,9 +191,9 @@ class TeamDao(BaseDAO[models.Team]):
         if name:
             query = query.where(models.Team.name.ilike(f"%{name}%"))
         teams: ScalarResult[models.Team] = await self.session.scalars(query)
-        return [team.to_dto_chat_prefetched() for team in teams]
+        return [team.to_dto_with_captain_prefetched() for team in teams]
 
-    async def search_by_name(self, text: str) -> list[dto.Team]:
+    async def search_by_name(self, text: str) -> list[dto.TeamWithCaptain]:
         """Поиск по названию среди всех команд, включая архивные (форумные)."""
         teams: ScalarResult[models.Team] = await self.session.scalars(
             select(models.Team)
@@ -199,7 +201,7 @@ class TeamDao(BaseDAO[models.Team]):
             .where(models.Team.name.ilike(ilike_pattern(text), escape=ILIKE_ESCAPE))
             .order_by(models.Team.id)
         )
-        return [team.to_dto_chat_prefetched() for team in teams]
+        return [team.to_dto_with_captain_prefetched() for team in teams]
 
     async def get_played_games(self, team: dto.Team) -> list[dto.Game]:
         result = await self.session.scalars(

--- a/shvatka/infrastructure/db/dao/rdb/team_player.py
+++ b/shvatka/infrastructure/db/dao/rdb/team_player.py
@@ -28,10 +28,10 @@ class TeamPlayerDao(BaseDAO[models.TeamPlayer]):
 
     async def get_team(
         self, player: dto.Player, for_date: datetime | None = None
-    ) -> dto.Team | None:
+    ) -> dto.TeamWithCaptain | None:
         result: Result[tuple[models.TeamPlayer]] = await self.session.execute(
             select(models.TeamPlayer)
-            .options(get_team_load_options())
+            .options(get_team_with_captain_load_options())
             .where(
                 models.TeamPlayer.player_id == player.id,
                 *get_leaved_condition(for_date),
@@ -42,7 +42,7 @@ class TeamPlayerDao(BaseDAO[models.TeamPlayer]):
         except NoResultFound:
             return None
         team: models.Team = team_player.team
-        return team.to_dto_chat_prefetched()
+        return team.to_dto_with_captain_prefetched()
 
     async def have_team(self, player: dto.Player) -> bool:
         return await self.get_team(player) is not None
@@ -283,6 +283,15 @@ def get_player_full_load_options() -> ORMOption:
 
 
 def get_team_load_options() -> ORMOption:
+    """Team without its captain — for the histories, which only name the team."""
+    return joinedload(models.TeamPlayer.team).options(
+        joinedload(models.Team.chat),
+        joinedload(models.Team.forum_team),
+    )
+
+
+def get_team_with_captain_load_options() -> ORMOption:
+    """Team with its captain — for "my team", which renders them."""
     return joinedload(models.TeamPlayer.team).options(
         joinedload(models.Team.chat),
         joinedload(models.Team.forum_team),

--- a/shvatka/infrastructure/db/dao/rdb/waiver.py
+++ b/shvatka/infrastructure/db/dao/rdb/waiver.py
@@ -86,7 +86,6 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
                 joinedload(models.Waiver.player).options(joinedload(models.Player.user)),
             )
@@ -104,7 +103,6 @@ class WaiverDao(BaseDAO[models.Waiver]):
                 joinedload(models.Waiver.team).options(
                     joinedload(models.Team.chat),
                     joinedload(models.Team.forum_team),
-                    joinedload(models.Team.captain).options(joinedload(models.Player.user)),
                 ),
                 joinedload(models.Waiver.game).options(
                     joinedload(models.Game.author).options(joinedload(models.Player.user)),
@@ -141,9 +139,6 @@ class WaiverDao(BaseDAO[models.Waiver]):
             .options(
                 joinedload(models.Waiver.team).joinedload(models.Team.chat),
                 joinedload(models.Waiver.team).joinedload(models.Team.forum_team),
-                joinedload(models.Waiver.team)
-                .joinedload(models.Team.captain)
-                .joinedload(models.Player.user),
             )
             .where(
                 models.Waiver.game_id == game.id,

--- a/shvatka/infrastructure/db/models/team.py
+++ b/shvatka/infrastructure/db/models/team.py
@@ -58,11 +58,8 @@ class Team(Base):
         self,
         chat: dto.Chat | None = None,
         forum_team: dto.ForumTeam | None = None,
-        captain: dto.Player | None = None,
     ) -> dto.Team:
-        if not captain and self.captain:
-            captain = self.captain.to_dto_user_prefetched()
-
+        """DTO of a team without its captain: `captain_id` comes from the row."""
         return dto.Team(
             id=self.id,
             chat=chat,
@@ -70,11 +67,39 @@ class Team(Base):
             name=self.name,
             is_dummy=self.is_dummy,
             description=self.description,
+            captain_id=self.captain_id,
+        )
+
+    def to_dto_with_captain(
+        self,
+        chat: dto.Chat | None = None,
+        forum_team: dto.ForumTeam | None = None,
+        captain: dto.Player | None = None,
+    ) -> dto.TeamWithCaptain:
+        """Only for queries that eagerly loaded `captain` — it is read here."""
+        if not captain and self.captain:
+            captain = self.captain.to_dto_user_prefetched()
+
+        return dto.TeamWithCaptain(
+            id=self.id,
+            chat=chat,
+            forum_team=forum_team,
+            name=self.name,
+            is_dummy=self.is_dummy,
+            description=self.description,
             captain=captain,
+            captain_id=self.captain_id,
         )
 
     def to_dto_chat_prefetched(self) -> dto.Team:
+        """Chat and forum team prefetched, captain left unloaded."""
         return self.to_dto(
+            chat=self.chat.to_dto() if self.chat else None,
+            forum_team=self.forum_team.to_dto() if self.forum_team else None,
+        )
+
+    def to_dto_with_captain_prefetched(self) -> dto.TeamWithCaptain:
+        return self.to_dto_with_captain(
             chat=self.chat.to_dto() if self.chat else None,
             forum_team=self.forum_team.to_dto() if self.forum_team else None,
         )

--- a/shvatka/tgbot/dialogs/preview_data.py
+++ b/shvatka/tgbot/dialogs/preview_data.py
@@ -72,7 +72,7 @@ PREVIEW_FORUM_TEAM = dto.ForumTeam(
 )
 PREVIEW_FORUM_TEAMS = [PREVIEW_FORUM_TEAM]
 
-PREVIEW_TEAM = dto.Team(
+PREVIEW_TEAM = dto.TeamWithCaptain(
     id=1,
     name="Пони",
     captain=PREVIEW_AUTHOR,
@@ -86,7 +86,7 @@ PREVIEW_TEAM = dto.Team(
     ),
 )
 
-PREVIEW_ANOTHER_TEAM = dto.Team(
+PREVIEW_ANOTHER_TEAM = dto.TeamWithCaptain(
     id=2,
     name="Дискорд",
     captain=PREVIEW_PLAYER,

--- a/shvatka/tgbot/dialogs/team_manage/getters.py
+++ b/shvatka/tgbot/dialogs/team_manage/getters.py
@@ -7,6 +7,7 @@ from dishka.integrations.aiogram_dialog import inject
 from shvatka.common.config.models.main import FeaturesConfig
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.players.player import get_team_players
+from shvatka.core.services.team import get_team_by_id
 from shvatka.core.views.texts import PERMISSION_EMOJI
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.dialogs.outdated import get_actual_team_player, get_actual_teammate
@@ -29,11 +30,12 @@ async def get_team_with_players(
     dao: FromDishka[HolderDao], identity: FromDishka[IdentityProvider], **_
 ) -> dict[str, Any]:
     team_player = await get_actual_team_player(identity)
-    team = team_player.team
+    # the captain's bridge names the captain, and the team player carries a plain team
+    team = await get_team_by_id(team_player.team.id, dao.team)
     players = await get_team_players(team=team, dao=dao.team_player)
     excluded = [team_player.player.id]
-    if team.captain:
-        excluded.append(team.captain.id)
+    if team.captain_id is not None:
+        excluded.append(team.captain_id)
     return {
         "team": team,
         "team_player": team_player,

--- a/shvatka/tgbot/dialogs/team_view/getters.py
+++ b/shvatka/tgbot/dialogs/team_view/getters.py
@@ -43,10 +43,12 @@ async def my_team_getter(dao: FromDishka[HolderDao], identity: FromDishka[Identi
     the dialog started: between the two the player may have been removed from
     the team, and then there is no card to show at all.
     """
-    return await team_card((await get_actual_team_player(identity)).team, dao)
+    team_player = await get_actual_team_player(identity)
+    # the team player carries a plain team; this card names the captain
+    return await team_card(await get_team_by_id(team_player.team.id, dao.team), dao)
 
 
-async def team_card(team: dto.Team, dao: HolderDao) -> dict[str, Any]:
+async def team_card(team: dto.TeamWithCaptain, dao: HolderDao) -> dict[str, Any]:
     players = await get_team_players(team=team, dao=dao.team_player)
     games = await get_played_games(team=team, dao=dao.team)
     games_numbers = [str(game.number) for game in games]

--- a/shvatka/tgbot/filters/team_player.py
+++ b/shvatka/tgbot/filters/team_player.py
@@ -30,8 +30,7 @@ class TeamPlayerFilter(BaseFilter):
         if not team_player:
             return False
         if self.is_captain is not None:
-            assert team_player.team.captain is not None
-            return team_player.team.captain.id == team_player.player.id
+            return team_player.is_captain
         if (
             self.can_manage_waivers is not None
             and self.can_manage_waivers != team_player.can_manage_waivers

--- a/shvatka/tgbot/services/identity.py
+++ b/shvatka/tgbot/services/identity.py
@@ -24,7 +24,7 @@ class LoadedData(TypedDict, total=False):
     user: dto.User | None
     chat: dto.Chat | None
     player: dto.Player | None
-    team: dto.Team | None
+    team: dto.TeamWithCaptain | None
     full_team_player: dto.FullTeamPlayer | None
     organizer: dict[int, dto.Organizer | None]
 
@@ -91,7 +91,7 @@ class TgBotIdentityProvider(IdentityProvider):
         self.cache["player"] = player
         return player
 
-    async def get_team(self) -> dto.Team | None:
+    async def get_team(self) -> dto.TeamWithCaptain | None:
         if "team" in self.cache:
             return self.cache["team"]
         team = await load_team(await self.get_chat(), self.dao)
@@ -146,7 +146,7 @@ async def save_chat(data: SHMiddlewareData, holder_dao: HolderDao) -> dto.Chat |
     return await upsert_chat(dto.Chat.from_aiogram(chat), holder_dao.chat)
 
 
-async def load_team(chat: dto.Chat | None, holder_dao: HolderDao) -> dto.Team | None:
+async def load_team(chat: dto.Chat | None, holder_dao: HolderDao) -> dto.TeamWithCaptain | None:
     if not chat:
         return None
     return await get_by_chat(chat, holder_dao.team)

--- a/shvatka/tgbot/views/team.py
+++ b/shvatka/tgbot/views/team.py
@@ -23,7 +23,10 @@ logger = logging.getLogger(__name__)
 
 
 def render_team_players(
-    team: dto.Team, players: Sequence[dto.FullTeamPlayer], *, notification: bool = False
+    team: dto.TeamWithCaptain,
+    players: Sequence[dto.FullTeamPlayer],
+    *,
+    notification: bool = False,
 ) -> str:
     cap = team.captain
     cap_card = get_small_card_no_link(cap) if cap else "отсутствует"

--- a/tests/fixtures/identity.py
+++ b/tests/fixtures/identity.py
@@ -8,7 +8,7 @@ from shvatka.core.models import dto
 class MockIdentityProvider(IdentityProvider):
     user: dto.User | None = None
     player: dto.Player | None = None
-    team: dto.Team | None = None
+    team: dto.TeamWithCaptain | None = None
     chat: dto.Chat | None = None
     full_team_player: dto.FullTeamPlayer | None = None
     organizer: dict[int, dto.Organizer | None] = field(default_factory=dict)
@@ -20,7 +20,7 @@ class MockIdentityProvider(IdentityProvider):
     async def get_player(self) -> dto.Player | None:
         return self.player
 
-    async def get_team(self) -> dto.Team | None:
+    async def get_team(self) -> dto.TeamWithCaptain | None:
         return self.team
 
     async def get_user(self) -> dto.User | None:

--- a/tests/integration/api_full/test_team.py
+++ b/tests/integration/api_full/test_team.py
@@ -172,7 +172,7 @@ async def test_get_team_stat(
 @pytest.mark.asyncio
 async def test_get_team_by_id(
     client: AsyncClient,
-    gryffindor: dto.Team,
+    gryffindor: dto.TeamWithCaptain,
 ):
     resp = await client.get(f"/teams/{gryffindor.id}")
     assert resp.is_success
@@ -180,7 +180,9 @@ async def test_get_team_by_id(
     body = resp.json()
     assert body["id"] == gryffindor.id
     assert body["name"] == gryffindor.name
+    assert gryffindor.captain is not None
     assert body["captain"]["id"] == gryffindor.captain.id
+    assert body["captain_id"] == gryffindor.captain.id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/bonuses_test.py
+++ b/tests/unit/domain/bonuses_test.py
@@ -19,7 +19,7 @@ BASE_TIME = datetime(2026, 7, 26, 20, 0, tzinfo=tz_utc)
 
 @pytest.fixture
 def team() -> dto.Team:
-    return dto.Team(id=1, name="Gryffindor", captain=None, is_dummy=False, description=None)
+    return dto.Team(id=1, name="Gryffindor", is_dummy=False, description=None)
 
 
 @pytest.fixture

--- a/tests/unit/domain/results_blocks_test.py
+++ b/tests/unit/domain/results_blocks_test.py
@@ -19,9 +19,9 @@ from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import action
 from shvatka.core.utils.exceptions import GameNotFinished
 
-WINNER = dto.Team(id=1, name="Gryffindor", captain=None, is_dummy=False, description=None)
-SECOND = dto.Team(id=2, name="Slytherin", captain=None, is_dummy=False, description=None)
-LOSER = dto.Team(id=3, name="Hufflepuff", captain=None, is_dummy=False, description=None)
+WINNER = dto.Team(id=1, name="Gryffindor", is_dummy=False, description=None)
+SECOND = dto.Team(id=2, name="Slytherin", is_dummy=False, description=None)
+LOSER = dto.Team(id=3, name="Hufflepuff", is_dummy=False, description=None)
 
 
 @pytest.fixture

--- a/tests/unit/domain/test_team_captain.py
+++ b/tests/unit/domain/test_team_captain.py
@@ -1,0 +1,78 @@
+from datetime import UTC, datetime
+
+from shvatka.core.models import dto
+
+JOINED_AT = datetime(2025, 4, 12, 16, 0, tzinfo=UTC)
+
+
+def _player(id_: int = 7) -> dto.Player:
+    return dto.Player(id=id_, can_be_author=False, is_dummy=False, username="harry")
+
+
+def _team(captain: dto.Player | None = None) -> dto.Team:
+    return dto.Team(
+        id=1,
+        name="Gryffindor",
+        captain=captain,
+        is_dummy=False,
+        description=None,
+    )
+
+
+def _team_player(team: dto.Team, player: dto.Player) -> dto.FullTeamPlayer:
+    return dto.FullTeamPlayer(
+        id=player.id * 10,
+        player_id=player.id,
+        team_id=team.id,
+        date_joined=JOINED_AT,
+        date_left=None,
+        role="боец",
+        emoji=None,
+        _can_manage_waivers=False,
+        _can_manage_players=False,
+        _can_change_team_name=False,
+        _can_add_players=False,
+        _can_remove_players=False,
+        player=player,
+        team=team,
+    )
+
+
+def test_is_captain_recognises_the_captain():
+    team = _team(captain=_player(7))
+    assert team.is_captain(7)
+    assert not team.is_captain(8)
+
+
+def test_is_captain_of_a_captainless_team_is_false_for_everyone():
+    """`TeamDao.create_by_forum` can leave a team without a captain."""
+    assert not _team().is_captain(7)
+
+
+def test_team_player_of_a_captainless_team_reads_its_permissions():
+    """The regression: every permission property used to raise AttributeError here."""
+    team_player = _team_player(_team(), _player(7))
+    assert not team_player.is_captain
+    assert not team_player.can_manage_waivers
+    assert not team_player.can_manage_players
+    assert not team_player.can_change_team_name
+    assert not team_player.can_add_players
+    assert not team_player.can_remove_players
+    assert team_player.permissions
+
+
+def test_the_captain_of_a_team_holds_every_permission():
+    player = _player(7)
+    team_player = _team_player(_team(captain=player), player)
+    assert team_player.is_captain
+    assert team_player.can_manage_waivers
+    assert team_player.can_manage_players
+    assert team_player.can_change_team_name
+    assert team_player.can_add_players
+    assert team_player.can_remove_players
+
+
+def test_a_plain_member_holds_only_their_granted_permissions():
+    team_player = _team_player(_team(captain=_player(7)), _player(8))
+    assert not team_player.is_captain
+    assert not team_player.can_remove_players

--- a/tests/unit/domain/test_team_captain.py
+++ b/tests/unit/domain/test_team_captain.py
@@ -9,8 +9,8 @@ def _player(id_: int = 7) -> dto.Player:
     return dto.Player(id=id_, can_be_author=False, is_dummy=False, username="harry")
 
 
-def _team(captain: dto.Player | None = None) -> dto.Team:
-    return dto.Team(
+def _team(captain: dto.Player | None = None) -> dto.TeamWithCaptain:
+    return dto.TeamWithCaptain(
         id=1,
         name="Gryffindor",
         captain=captain,
@@ -36,6 +36,45 @@ def _team_player(team: dto.Team, player: dto.Player) -> dto.FullTeamPlayer:
         player=player,
         team=team,
     )
+
+
+def _lean_team(captain_id: int | None = None) -> dto.Team:
+    return dto.Team(
+        id=1,
+        name="Gryffindor",
+        is_dummy=False,
+        description=None,
+        captain_id=captain_id,
+    )
+
+
+def test_is_captain_needs_no_loaded_captain():
+    """The point of the split: the check works on a team that never joined players."""
+    team = _lean_team(captain_id=7)
+    assert team.is_captain(7)
+    assert not team.is_captain(8)
+
+
+def test_captain_id_is_taken_from_a_loaded_captain():
+    assert _team(captain=_player(7)).captain_id == 7
+
+
+def test_captain_id_of_a_captainless_team_is_none():
+    assert _team().captain_id is None
+    assert _lean_team().captain_id is None
+
+
+def test_a_team_with_captain_still_compares_by_id():
+    """`TeamWithCaptain` must keep `Team`'s identity equality — and stay hashable.
+
+    Teams are dict keys throughout the stat code; a generated `__eq__` on the
+    subclass would drop `__hash__` and break every one of those lookups.
+    """
+    with_captain = _team(captain=_player(7))
+    lean = _lean_team(captain_id=7)
+    assert with_captain == lean
+    assert hash(with_captain) == hash(lean)
+    assert len({with_captain, lean}) == 1
 
 
 def test_is_captain_recognises_the_captain():

--- a/tests/unit/services/admin_resend_level_test.py
+++ b/tests/unit/services/admin_resend_level_test.py
@@ -26,7 +26,6 @@ def make_team(id_: int) -> dto.Team:
     return dto.Team(
         id=id_,
         name=f"team{id_}",
-        captain=None,
         is_dummy=False,
         description=None,
     )

--- a/tests/unit/services/change_captain_test.py
+++ b/tests/unit/services/change_captain_test.py
@@ -15,8 +15,8 @@ def _player(id_: int, username: str) -> dto.Player:
     return dto.Player(id=id_, can_be_author=False, is_dummy=False, username=username)
 
 
-def _team(captain: dto.Player | None) -> dto.Team:
-    return dto.Team(
+def _team(captain: dto.Player | None) -> dto.TeamWithCaptain:
+    return dto.TeamWithCaptain(
         id=1,
         name="Gryffindor",
         captain=captain,

--- a/tests/unit/services/member_tags_test.py
+++ b/tests/unit/services/member_tags_test.py
@@ -20,7 +20,7 @@ def player(tg_id: int | None = 42) -> dto.Player:
 
 
 def team(name: str = "Gryffindor") -> dto.Team:
-    return dto.Team(id=1, name=name, captain=None, is_dummy=False, description=None)
+    return dto.Team(id=1, name=name, is_dummy=False, description=None)
 
 
 def tagger(*chats: int) -> tuple[MemberTagger, AsyncMock]:

--- a/tests/unit/services/merge_timeline_test.py
+++ b/tests/unit/services/merge_timeline_test.py
@@ -29,7 +29,7 @@ def create_player(id_: int = 1) -> dto.Player:
 
 
 def create_team(id_: int = 1) -> dto.Team:
-    return dto.Team(id=id_, name=f"team {id_}", captain=None, is_dummy=False, description=None)
+    return dto.Team(id=id_, name=f"team {id_}", is_dummy=False, description=None)
 
 
 def create_game(

--- a/tests/unit/services/request_interactors_test.py
+++ b/tests/unit/services/request_interactors_test.py
@@ -41,8 +41,10 @@ def _player_with_forum(id_: int, username: str = "p") -> dto.PlayerWithForum:
     return dto.PlayerWithForum(id=id_, can_be_author=False, is_dummy=False, username=username)
 
 
-def _team(captain: dto.Player | None = None, id_: int = 1, name: str = "Gryffindor") -> dto.Team:
-    return dto.Team(
+def _team(
+    captain: dto.Player | None = None, id_: int = 1, name: str = "Gryffindor"
+) -> dto.TeamWithCaptain:
+    return dto.TeamWithCaptain(
         id=id_,
         name=name,
         captain=captain,

--- a/tests/unit/services/team_notifier_test.py
+++ b/tests/unit/services/team_notifier_test.py
@@ -10,9 +10,9 @@ def _player(id_: int, username: str) -> dto.Player:
     return dto.Player(id=id_, can_be_author=False, is_dummy=False, username=username)
 
 
-def _team(captain: dto.Player | None = None, *, with_chat: bool = True) -> dto.Team:
+def _team(captain: dto.Player | None = None, *, with_chat: bool = True) -> dto.TeamWithCaptain:
     chat = dto.Chat(tg_id=-100, type=ChatType.group, title="t") if with_chat else None
-    return dto.Team(
+    return dto.TeamWithCaptain(
         id=1,
         name="Gryffindor",
         captain=captain,

--- a/tests/unit/test_filters_identity.py
+++ b/tests/unit/test_filters_identity.py
@@ -30,7 +30,7 @@ from shvatka.tgbot.utils.router import disable_router_on_game
 
 PLAYER = dto.Player(id=1, can_be_author=True, is_dummy=False, username="harry")
 NO_AUTHOR = dto.Player(id=2, can_be_author=False, is_dummy=False, username="ron")
-TEAM = dto.Team(id=1, name="Gryffindor", captain=None, is_dummy=False, description=None)
+TEAM = dto.Team(id=1, name="Gryffindor", is_dummy=False, description=None)
 
 
 def identity(

--- a/tests/unit/test_join_chat_with_team.py
+++ b/tests/unit/test_join_chat_with_team.py
@@ -31,7 +31,7 @@ NEWCOMER_PLAYER = dto.Player(id=20, can_be_author=False, is_dummy=False, usernam
 
 
 def team() -> dto.Team:
-    return dto.Team(
+    return dto.TeamWithCaptain(
         id=5,
         name="like a team",
         captain=CAPTAIN_PLAYER,


### PR DESCRIPTION
All three phases of SHEP-0012. **Breaking API change, paired with bomzheg/shvatka-ui#191 — they must deploy together.**

> This PR grew: it opened as phase 1 only. Since work continues on the one designated branch, phases 2 and 3 landed on top rather than in a separate PR.

## Phase 1 — a crash

`FullTeamPlayer.is_captain` read `self.team.captain.id` with no `None` guard, while `TeamDao.create_by_forum` creates teams with `captain_id=None`. All five permission properties run through it, so a member of a captain-less team raised `AttributeError` from any of them. Reproduced against the pre-change code first:

```
reproduced on master's code -> AttributeError: 'NoneType' object has no attribute 'id'
```

Eight call sites were doing the same two-part check by hand — three as an `assert` plus a comparison — and now call `Team.is_captain(player_id)`.

## Phases 2 and 3 — the join

`dto.Team` becomes the plain team: id, name, description, and `captain_id` taken straight off the row (already indexed by `ix__teams__captain_id`). `dto.TeamWithCaptain` is what the screens that *name* a captain ask for.

The API response splits the same way — `shared.Team` carries `captain_id` for teams embedded in other payloads, `shared.TeamWithCaptain` adds the captain for the team pages and admin tools.

Because `is_captain` no longer needs a loaded captain, the aggregates that embed a team — `Waiver`, `KeyTime`, `LevelTime`, `FullTeamPlayer` — stay plain, and the join comes out:

| query | before | after |
|---|---|---|
| `waiver.get_all_by_game` | 7 joins | **5** |
| `waiver.get_all_by_player` | 8 | **6** |
| `team_player.get_full_history` | 7 | **5** |
| `team.get_team_options` (team pages) | 4 | 4 — unchanged, they render the captain |

Measured by compiling the option sets, same method as the numbers in the SHEP.

**The two phases are one change.** `captain_id` is what lets the aggregates stay plain; the lean response is what lets them *want* to. An earlier attempt at the dto split alone spread to every caller holding a team — mypy errors went 18 → 59 → 75 → 112 as it propagated — and was abandoned. That is recorded in the SHEP's deviations.

## What the types could not check

Two silent breakages, both found by reading rather than by a failing check:

- `shared.Team.from_core` accepts a `TeamWithCaptain` quite happily and drops the captain. Every route rendering one had to be pointed at `TeamWithCaptain.from_core` by hand — mypy stayed green the whole time.
- The bot's team cards are Jinja. `{{team.captain.name_mention}}` on a plain team renders **empty**, not an error, so the "Капитан:" line would have quietly gone blank on the team card and the captain's bridge. Typing `team_card` and the bridge getter as taking `TeamWithCaptain` is what turned those into mypy errors; both now load the team properly.

The same hazard applies across the repo boundary, so `shvatka-ui` was grepped for `.captain` in templates as well as `.ts` — my first pass, `.ts` only, missed four screens.

## Notes

- `AGENTS.md` gains the convention this rests on: the two repos deploy together, so a breaking API change is fine when both change together — but grep the UI's templates before calling a field unused.
- `TeamWithCaptain` is `@dataclass(eq=False)` so it inherits `Team`'s identity equality. A generated `__eq__` would drop `__hash__`, and teams are dict keys throughout the stat code; that one broke test collection until fixed, and has a regression test.

## Tests

`tests/unit/domain/test_team_captain.py` — 9 cases: `is_captain` with no captain loaded, `captain_id` derived from a loaded one, the permission properties on a captain-less team, and the equality/hash regression.

`ruff format --check`, `ruff check`, `mypy` (657 files) and `pytest tests/unit` (540 passed) clean locally. Integration tests need Docker, so they run in CI.