### PR TITLE
test(load): shape the locust profile like a real game night

### DIFF
--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -139,6 +139,39 @@ the intended way to notice.
 | `SHVATKA_LOAD_KEY_SCENARIO` | `tests/load/scenario.yml` | the scenario of the game on the target |
 
 
+## A note on the locust version
+
+The lockfile pins **locust 2.39.1**, which has a bug that crashes a run at
+random on python 3.13: up to 2.40, `ResponseContextManager` aliases the
+response's `__dict__` rather than copying it, while `request_meta` inside that
+dict points back at the response — so once `HttpSession.request` returns, the
+response is reachable only through that cycle. A garbage collection inside a
+`with ... catch_response=True` block then clears the dict the context manager is
+living in, and `__exit__` dies with `KeyError: 'name'`
+([locustio/locust#3050](https://github.com/locustio/locust/issues/3050),
+[#3207](https://github.com/locustio/locust/issues/3207)).
+
+`ShvatkaUser.measured` works around it by binding the response before entering
+the block, which keeps the cycle reachable for as long as the block runs. That
+is why every request here goes through it rather than calling `self.client.get`
+directly — a plain `with self.client.get(..., catch_response=True)` in this file
+will crash under load.
+
+The workaround can go once locust can be bumped past 2.40. It cannot be bumped
+today: locust >= 2.41 requires `pytest >= 8.3.3` and this project pins
+`pytest < 8.0`, so raising the floor makes the dependencies unsatisfiable.
+Either move the suite to pytest 8 first, or declare the two groups mutually
+exclusive so uv resolves them apart:
+
+```toml
+[tool.uv]
+conflicts = [[{ group = "dev" }, { group = "test" }]]
+```
+
+That resolves (locust 2.46.4 for `dev`, pytest 7.4.4 for `test`, and CI's
+`uv sync --group test` is unaffected), at the cost of not being able to install
+both groups into one environment.
+
 ## Reading the results
 
 Requests are reported under templated names (`/games/{id}/keys`, not

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -15,19 +15,21 @@ is **~80% of everything the api answers on a game night** — 15.7K calls agains
 909 for the next endpoint. The web client polls it. Any load test that spreads
 its calls evenly across the routes is testing traffic the api never sees.
 
-## Three kinds of client
+## Four kinds of client
 
 The endpoints split by who calls them, and the split matters as much as the
 rates — the same request count means something different coming from three
-dashboards than from three hundred phones.
+dashboards than from three hundred phones. Three of these classes are the
+measured night; the fourth is opt-in and explained at the end.
 
 | class            | how many                | what it does |
 |------------------|-------------------------|--------------|
 | `PlayerUser`     | whatever `-u` says      | polls unread-count and the current level, pulls hint files, browses teams and games |
 | `OrganizerUser`  | `fixed_count = 3`       | reloads the keys and stat dashboards — the two expensive queries of the night |
 | `AdminUser`      | `fixed_count = 1`       | looks players up in the admin panel |
+| `KeySubmittingUser` | off by default       | types keys at the running game — see below |
 
-`fixed_count` on the last two is deliberate: there are three orgs on a night
+`fixed_count` on the org and admin classes is deliberate: there are three orgs on a night
 whether two hundred people are playing or two thousand, so their load must not
 scale with `-u`.
 
@@ -77,6 +79,65 @@ environment without a fixture dump. Two knobs cover what it cannot discover:
   (`PUT /games/my/{id}/scenario`, 105 calls on the measured game, and the
   heaviest write the api takes), so it is off unless you name a game for it.
   Discovery never picks one.
+
+## Typing keys (opt-in)
+
+`KeySubmittingUser` submits keys to `POST /games/running/key`. It is off unless
+you ask for it:
+
+```shell
+SHVATKA_LOAD_KEY_USERS=5 uv run locust -f tests/load/locustfile.py \
+    --host https://staging.example.org
+```
+
+**These rates are the one judgement call in the profile, not a measurement.**
+On the measured night keys arrived through the bot webhook (`/webhook/bot`,
+3.54K) rather than through the api, so the panel says nothing about how often
+this endpoint was called. What is modelled is the *shape* of what a team types —
+mostly wrong, some right, plenty of repeats — at weights chosen to look like a
+team playing, not to reproduce a measured rate. Faking the webhook itself was
+considered and dropped: it would mean forging Telegram updates and having the
+bot answer them, which is a different test.
+
+### `scenario.yml` is part of the test, not documentation
+
+The profile parses `tests/load/scenario.yml` before the run and works out which
+keys it may send. **It must be the scenario of the game on the target.**
+
+A level advances when every key of a condition has been typed, so the plan holds
+one key of every condition back and never sends it. What is safe to send is
+recomputed from `/games/running/level/current` on every poll, because a key
+somebody typed before the run counts towards the condition just the same — a
+level the team is halfway through yields *more* safe keys, not fewer. Keys of
+other levels are sent too, as realistic wrong keys; the current level's keys are
+never among them, the held-back one least of all.
+
+The consequence to keep in mind:
+
+- A scenario naming **fewer** keys than the real level is safe. Worst case
+  nothing it sends is correct at all, and the run is just wrong-key load.
+- A scenario naming **more** is not. If this file thinks a level has three keys
+  and the real one has a single key, the "safe" pair includes the real level's
+  only key, and the team levels up.
+- A level number the file doesn't cover degrades to generated keys only, with a
+  warning naming the level — that warning means the file does not match the game.
+
+So it never *finishes* a game, and a run can be repeated against the same game
+indefinitely. It is still not read-only: every submission is written to the key
+log, and correct ones count as found for the team. Point it at staging.
+
+The account in `SHVATKA_LOAD_KEY_USERNAME` / `SHVATKA_LOAD_KEY_PASSWORD`
+(defaulting to the player account) must be **waivered for the running game** and
+in a team, or every submission comes back 422. That shows up in locust's error
+table as `key refused: WaiverError` rather than as a latency number, which is
+the intended way to notice.
+
+| variable | default | meaning |
+|---|---|---|
+| `SHVATKA_LOAD_KEY_USERS` | `0` (off) | how many clients type keys |
+| `SHVATKA_LOAD_KEY_USERNAME` / `_PASSWORD` | the player's | who types them |
+| `SHVATKA_LOAD_KEY_SCENARIO` | `tests/load/scenario.yml` | the scenario of the game on the target |
+
 
 ## Reading the results
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -90,14 +90,37 @@ SHVATKA_LOAD_KEY_USERS=5 uv run locust -f tests/load/locustfile.py \
     --host https://staging.example.org
 ```
 
-**These rates are the one judgement call in the profile, not a measurement.**
-On the measured night keys arrived through the bot webhook (`/webhook/bot`,
-3.54K) rather than through the api, so the panel says nothing about how often
-this endpoint was called. What is modelled is the *shape* of what a team types —
-mostly wrong, some right, plenty of repeats — at weights chosen to look like a
-team playing, not to reproduce a measured rate. Faking the webhook itself was
-considered and dropped: it would mean forging Telegram updates and having the
-bot answer them, which is a different test.
+Keys arrived through the bot webhook (`/webhook/bot`, 3.54K) rather than
+through the api that night, so the http panel says nothing about this endpoint.
+The **rate** is measured all the same, from the bot's own outgoing counters:
+
+```promql
+sum by (method) (increase(tgbot_api_requests_total[6h]))
+```
+
+which for the measured game gives `SendMessage` 994, `PinChatMessage` 580,
+`UnpinChatMessage` 287, **`SetMessageReaction` 235**, `SendPhoto` 44,
+`GetChatMember` 44, `SendVideo` 28, and a long tail — about 2.3K outgoing calls
+against 3.54K incoming updates, so most of what the bot reads it answers with
+nothing.
+
+`SetMessageReaction` is the useful one. `BotView` sets a reaction on exactly
+three key outcomes — 😴 for a duplicate, 👎 for a wrong key, and the
+`map_effect_to_reaction` emoji for one carrying effects — and on nothing else. A
+plain correct key that doesn't finish a level only sends a message, so **235 over
+six hours is a floor on keys typed**: roughly 40 an hour across every team.
+
+That is much less traffic than it feels like from inside a game, and it is worth
+saying plainly because the first version of this class was **150x** over it. Each
+client now submits about 20 keys an hour, so two of them reproduce the night and
+anything more is deliberate stress rather than an accident.
+
+What is still an estimate is the *split* between wrong, stale and correct keys: a
+reaction doesn't say which of the three it was. The weights model a team that
+mostly guesses wrong, retypes what worked before, and occasionally lands one.
+
+Faking the webhook itself was considered and dropped: it would mean forging
+Telegram updates and having the bot answer them, which is a different test.
 
 ### `scenario.yml` is part of the test, not documentation
 

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,90 @@
+# Load test
+
+`locustfile.py` replays the shape of a real game night against the api.
+
+## Where the numbers come from
+
+The task weights are the number of 2xx responses each endpoint served during one
+actual game, read off the `asgi-monitor` request counters (the *Percent of 2xx
+Requests* panel). They are written into the file as those raw counts rather than
+normalised, so the profile can be re-derived from a later game by pasting new
+numbers in.
+
+The one thing worth knowing before reading them: `GET /notifications/unread-count`
+is **~80% of everything the api answers on a game night** — 15.7K calls against
+909 for the next endpoint. The web client polls it. Any load test that spreads
+its calls evenly across the routes is testing traffic the api never sees.
+
+## Three kinds of client
+
+The endpoints split by who calls them, and the split matters as much as the
+rates — the same request count means something different coming from three
+dashboards than from three hundred phones.
+
+| class            | how many                | what it does |
+|------------------|-------------------------|--------------|
+| `PlayerUser`     | whatever `-u` says      | polls unread-count and the current level, pulls hint files, browses teams and games |
+| `OrganizerUser`  | `fixed_count = 3`       | reloads the keys and stat dashboards — the two expensive queries of the night |
+| `AdminUser`      | `fixed_count = 1`       | looks players up in the admin panel |
+
+`fixed_count` on the last two is deliberate: there are three orgs on a night
+whether two hundred people are playing or two thousand, so their load must not
+scale with `-u`.
+
+## Running it
+
+```shell
+uv sync --group dev
+SHVATKA_LOAD_PASSWORD=... uv run locust -f tests/load/locustfile.py \
+    --host https://staging.example.org
+```
+
+or headless, for a fixed shape:
+
+```shell
+uv run locust -f tests/load/locustfile.py --host http://localhost:8000 \
+    --headless -u 200 -r 10 -t 10m
+```
+
+**Point it at staging, not production.** The profile writes the way the real
+clients do: it marks notifications read, and it subscribes and unsubscribes a
+synthetic push endpoint (paired, so it leaves no rows behind).
+
+### Accounts
+
+| variable | default | used by |
+|---|---|---|
+| `SHVATKA_LOAD_USERNAME` / `SHVATKA_LOAD_PASSWORD` | `bomzheg` / `1234` | `PlayerUser`, and the fallback for the two below |
+| `SHVATKA_LOAD_ORG_USERNAME` / `SHVATKA_LOAD_ORG_PASSWORD` | the player's | `OrganizerUser` — needs to be an org of the running game, or the keys/stat calls answer 403 |
+| `SHVATKA_LOAD_ADMIN_USERNAME` / `SHVATKA_LOAD_ADMIN_PASSWORD` | the player's | `AdminUser` — needs to be a superuser |
+
+Every virtual user of a class logs in as the same account. That is fine for the
+read load and wrong for anything that measures per-player cache behaviour; if
+you need distinct players, that is the change to make.
+
+### What to point it at
+
+The profile discovers its own targets on start — the active game, the player's
+team, and the file guids of the current level — so it runs against any
+environment without a fixture dump. Two knobs cover what it cannot discover:
+
+- `SHVATKA_LOAD_GAME_ID` — a game to fall back on when nothing is running, so
+  the game card / keys / stat / release calls still have something to ask about.
+  Without it the profile falls back to a random completed game, and if there are
+  none, quietly skips those tasks.
+- `SHVATKA_LOAD_SCENARIO_GAME_ID` — a **throwaway draft game whose scenario may
+  be overwritten**. This is the one genuinely destructive call of the night
+  (`PUT /games/my/{id}/scenario`, 105 calls on the measured game, and the
+  heaviest write the api takes), so it is off unless you name a game for it.
+  Discovery never picks one.
+
+## Reading the results
+
+Requests are reported under templated names (`/games/{id}/keys`, not
+`/games/17/keys`), the same way `asgi-monitor` labels them — so locust's table
+lines up row for row with the Grafana panel it was built from.
+
+An idle target is not an error: no running game means 404 from `/games/active`
+and friends, and 403 means this account is not an org of the game it is looking
+at. Both are counted as successes, because reporting them as failures buries the
+real ones on any environment that simply has no game on right now.

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -1,24 +1,448 @@
-from locust import HttpUser, between, task  # type: ignore[import, unused-ignore]
+"""A load profile shaped like a real game night.
+
+The task weights are the number of 2xx responses each endpoint actually served
+during one game, as counted by ``asgi-monitor``'s request metrics. They are kept
+as the raw observed numbers rather than normalised, so the mix stays readable —
+and the mix is the point. Four out of five requests the api answers on a game
+night are ``GET /notifications/unread-count``: the web client polls it, and it
+outweighs every other endpoint by more than an order of magnitude. A load test
+that spreads its calls evenly over the routes tests something the api never does.
+
+The profile is *similar*, not exact. Endpoints are grouped into the three kinds
+of client that generate them, because a rate alone doesn't reproduce the load:
+the orgs' keys/stat dashboards are a handful of clients hammering two expensive
+queries, while the unread-count poll is hundreds of clients doing something
+cheap. Locust models that with ``fixed_count`` for the few and ``weight`` for
+the crowd.
+
+Run it against a *staging* copy of the api — it writes (push subscriptions, read
+marks) as the real clients do::
+
+    SHVATKA_LOAD_PASSWORD=... uv run locust -f tests/load/locustfile.py \
+        --host https://staging.example.org
+
+Every user needs an account on the target; see ``tests/load/README.md`` for the
+environment variables that name them.
+"""
+
+import logging
+import os
+import random
+import uuid
+from typing import Any
+
+from locust import (  # type: ignore[import, unused-ignore]
+    HttpUser,
+    between,
+    task,
+)
+from locust.exception import StopUser  # type: ignore[import, unused-ignore]
+
+logger = logging.getLogger(__name__)
+
+PLAYER_USERNAME = os.getenv("SHVATKA_LOAD_USERNAME", "bomzheg")
+PLAYER_PASSWORD = os.getenv("SHVATKA_LOAD_PASSWORD", "1234")
+ORG_USERNAME = os.getenv("SHVATKA_LOAD_ORG_USERNAME", PLAYER_USERNAME)
+ORG_PASSWORD = os.getenv("SHVATKA_LOAD_ORG_PASSWORD", PLAYER_PASSWORD)
+ADMIN_USERNAME = os.getenv("SHVATKA_LOAD_ADMIN_USERNAME", PLAYER_USERNAME)
+ADMIN_PASSWORD = os.getenv("SHVATKA_LOAD_ADMIN_PASSWORD", PLAYER_PASSWORD)
+
+# A game to fall back on when nothing is running on the target: the read-only
+# game endpoints (card, keys, stat, release) need *some* id to ask about.
+FALLBACK_GAME_ID = os.getenv("SHVATKA_LOAD_GAME_ID")
+# A throwaway draft game whose scenario may be overwritten. Left unset, the
+# scenario upload — the one genuinely destructive call of the night — is skipped.
+SCENARIO_GAME_ID = os.getenv("SHVATKA_LOAD_SCENARIO_GAME_ID")
+
+# Statuses that are a legitimate answer rather than a broken server: no game is
+# running (404), the level has no files yet (404), this account is not an org of
+# the game it is looking at (403). Reporting them as failures would drown the
+# real errors on a target that simply has no game on right now.
+EXPECTED_STATUSES = (403, 404)
 
 
-class PlayerUser(HttpUser):
-    wait_time = between(1, 5)
-    token: str = ""
+class ShvatkaUser(HttpUser):
+    """Logs in once and keeps the auth cookie on the session, like a browser."""
 
-    @task
-    def me(self) -> None:
-        self.client.get(
-            "/users/me",
-            cookies={"Authorization": self.token},
-        )
-
-    @task
-    def active_game(self) -> None:
-        self.client.get("/games/active")
+    abstract = True
+    username = PLAYER_USERNAME
+    password = PLAYER_PASSWORD
 
     def on_start(self) -> None:
+        self.login()
+
+    def login(self) -> None:
         with self.client.post(
-            "/auth/token", data={"username": "bomzheg", "password": "1234"}
+            "/auth/token",
+            data={"username": self.username, "password": self.password},
+            name="/auth/token",
+            catch_response=True,
         ) as resp:
-            assert resp.ok
-            self.token = resp.cookies["Authorization"]
+            if not resp.ok:
+                resp.failure(f"login as {self.username} failed: {resp.status_code}")
+                logger.error(
+                    "cannot log in as %s (%s) — stopping the user",
+                    self.username,
+                    resp.status_code,
+                )
+                raise StopUser
+        # HttpSession is a requests.Session, so the Authorization cookie the
+        # login set is carried by everything below without being passed around.
+
+    def read(self, url: str, *, name: str | None = None) -> Any:
+        """GET ``url``, returning the decoded body or ``None``.
+
+        ``name`` is the templated path (``/games/{id}``) the request is counted
+        under, so locust's stats line up with the Grafana panel this profile was
+        built from instead of exploding into one row per id.
+        """
+        with self.client.get(url, name=name or url, catch_response=True) as resp:
+            if resp.status_code in EXPECTED_STATUSES:
+                resp.success()
+                return None
+            if not resp.ok:
+                return None
+            try:
+                return resp.json()
+            except ValueError:
+                return None
+
+
+class PlayerUser(ShvatkaUser):
+    """The crowd: a phone in a car with the game open, polling.
+
+    This is what ``-u`` spawns. Weights are the observed 2xx counts, so the
+    unread-count poll dominates here exactly as it does in production.
+    """
+
+    weight = 1
+    wait_time = between(1, 3)
+
+    game_id: int | None = None
+    team_id: int | None = None
+    player_id: int | None = None
+
+    def on_start(self) -> None:
+        super().on_start()
+        self.file_guids: list[str] = []
+        self.unread_ids: list[int] = []
+        self.discover()
+
+    def discover(self) -> None:
+        """Find a game, a team and some file guids to ask for.
+
+        Everything the parametrised tasks need is read from the target itself,
+        so the profile runs against any environment without a fixture dump.
+        """
+        game = self.read("/games/active", name="/games/active")
+        if game:
+            self.game_id = game.get("id")
+        elif FALLBACK_GAME_ID:
+            self.game_id = int(FALLBACK_GAME_ID)
+        else:
+            page = self.read("/games", name="/games")
+            content = (page or {}).get("content") or []
+            if content:
+                self.game_id = random.choice(content).get("id")
+
+        me = self.read("/users/me", name="/users/me")
+        if me:
+            self.player_id = me.get("id")
+
+        role = self.read("/games/active/me", name="/games/active/me")
+        team = (role or {}).get("team")
+        if team:
+            self.team_id = team.get("id")
+
+        self.refresh_level()
+
+    def refresh_level(self) -> None:
+        level = self.read("/games/running/level/current", name="/games/running/level/current")
+        if level:
+            self.file_guids = collect_guids(level.get("hints"), [])
+
+    @task(15_700)
+    def unread_count(self) -> None:
+        """The poll that is four fifths of everything the api answers."""
+        self.read("/notifications/unread-count")
+
+    @task(909)
+    def active_game(self) -> None:
+        self.read("/games/active", name="/games/active")
+
+    @task(789)
+    def game_file(self) -> None:
+        """A hint's picture. The heaviest response a player pulls."""
+        if self.game_id is None or not self.file_guids:
+            return
+        guid = random.choice(self.file_guids)
+        self.read(
+            f"/cdn/games/{self.game_id}/files/{guid}",
+            name="/cdn/games/{id}/files/{guid}",
+        )
+
+    @task(387)
+    def game_release(self) -> None:
+        if self.game_id is None:
+            return
+        self.read(f"/games/{self.game_id}/release", name="/games/{id}/release")
+
+    @task(228)
+    def current_waivers(self) -> None:
+        self.read("/waivers/game/current", name="/waivers/game/current")
+
+    @task(227)
+    def version(self) -> None:
+        self.read("/version")
+
+    @task(212)
+    def users_me(self) -> None:
+        self.read("/users/me", name="/users/me")
+
+    @task(210)
+    def current_level(self) -> None:
+        """The other poll: what the team is looking at right now.
+
+        It also refreshes the guids the file task downloads, so a level change
+        during the run moves the load onto the new level's pictures.
+        """
+        self.refresh_level()
+
+    @task(201)
+    def my_role(self) -> None:
+        self.read("/games/active/me", name="/games/active/me")
+
+    @task(119)
+    def game_card(self) -> None:
+        if self.game_id is None:
+            return
+        self.read(f"/games/{self.game_id}", name="/games/{id}")
+
+    @task(111)
+    def team_players(self) -> None:
+        if self.team_id is None:
+            return
+        self.read(f"/teams/{self.team_id}/players", name="/teams/{id}/players")
+
+    @task(70)
+    def user_details(self) -> None:
+        if self.player_id is None:
+            return
+        self.read(f"/users/{self.player_id}/details", name="/users/{id}/details")
+
+    @task(63)
+    def games_list(self) -> None:
+        self.read("/games", name="/games")
+
+    @task(59)
+    def push_config(self) -> None:
+        self.read("/push/config", name="/push/config")
+
+    @task(51)
+    def push_subscription(self) -> None:
+        """Subscribe and unsubscribe a synthetic endpoint.
+
+        Paired on purpose: the subscription is deleted again, so a load run
+        doesn't leave a row per virtual user behind on the target.
+        """
+        subscription = {
+            "endpoint": f"https://fcm.googleapis.com/fcm/send/{uuid.uuid4()}",
+            "keys": {"p256dh": "BL" + "a" * 85, "auth": "b" * 22},
+        }
+        self.client.put("/push/subscriptions", json=subscription, name="/push/subscriptions")
+        self.client.delete("/push/subscriptions", json=subscription, name="/push/subscriptions")
+
+    @task(43)
+    def user_stat(self) -> None:
+        if self.player_id is None:
+            return
+        self.read(f"/users/{self.player_id}/stat", name="/users/{id}/stat")
+
+    @task(40)
+    def requests_list(self) -> None:
+        self.read("/requests?direction=incoming&pending=true", name="/requests")
+
+    @task(39)
+    def teams_list(self) -> None:
+        self.read("/teams", name="/teams")
+
+    @task(27)
+    def team_card(self) -> None:
+        if self.team_id is None:
+            return
+        self.read(f"/teams/{self.team_id}", name="/teams/{id}")
+
+    @task(24)
+    def team_stat(self) -> None:
+        if self.team_id is None:
+            return
+        self.read(f"/teams/{self.team_id}/stat", name="/teams/{id}/stat")
+
+    @task(24)
+    def my_captained_teams(self) -> None:
+        self.read("/teams/my/captained", name="/teams/my/captained")
+
+    @task(21)
+    def notifications(self) -> None:
+        page = self.read("/notifications?limit=50&offset=0", name="/notifications")
+        self.unread_ids = [n["id"] for n in (page or {}).get("items", []) if not n["read"]]
+
+    @task(16)
+    def mark_read(self) -> None:
+        """Marking read is what the list is opened for, so it follows it."""
+        if not self.unread_ids:
+            return
+        batch, self.unread_ids = self.unread_ids[:10], self.unread_ids[10:]
+        self.client.post("/notifications/read", json={"ids": batch}, name="/notifications/read")
+
+
+class OrganizerUser(ShvatkaUser):
+    """A few people watching the game from the other side.
+
+    ``fixed_count`` rather than ``weight``: there are three orgs on a night
+    whether two hundred players are playing or two thousand, and it is the
+    absolute number that matters — these two dashboards are the expensive
+    queries of the profile, and their cost does not scale with the crowd.
+    """
+
+    fixed_count = 3
+    wait_time = between(2, 8)
+    username = ORG_USERNAME
+    password = ORG_PASSWORD
+
+    game_id: int | None = None
+
+    def on_start(self) -> None:
+        super().on_start()
+        self.my_game_ids: list[int] = []
+        game = self.read("/games/active", name="/games/active")
+        if game:
+            self.game_id = game.get("id")
+        elif FALLBACK_GAME_ID:
+            self.game_id = int(FALLBACK_GAME_ID)
+        page = self.read("/games/my", name="/games/my")
+        self.my_game_ids = [g["id"] for g in (page or {}).get("content", [])]
+
+    @task(394)
+    def game_keys(self) -> None:
+        """The keys table, reloaded over and over while the game runs."""
+        if self.game_id is None:
+            return
+        self.read(f"/games/{self.game_id}/keys", name="/games/{id}/keys")
+
+    @task(382)
+    def game_stat(self) -> None:
+        if self.game_id is None:
+            return
+        self.read(f"/games/{self.game_id}/stat", name="/games/{id}/stat")
+
+    @task(105)
+    def upload_scenario(self) -> None:
+        """Rewrite a draft game's scenario — the heaviest write of the night.
+
+        Off unless ``SHVATKA_LOAD_SCENARIO_GAME_ID`` names a game that may be
+        overwritten: unlike everything else here, this one destroys what it
+        touches, so it is never pointed at a game by discovery.
+        """
+        if SCENARIO_GAME_ID is None:
+            return
+        self.client.put(
+            f"/games/my/{SCENARIO_GAME_ID}/scenario",
+            json=build_scenario(),
+            name="/games/my/{id}/scenario",
+        )
+
+    @task(23)
+    def my_games(self) -> None:
+        self.read("/games/my", name="/games/my")
+
+    @task(19)
+    def my_game(self) -> None:
+        if not self.my_game_ids:
+            return
+        self.read(f"/games/my/{random.choice(self.my_game_ids)}", name="/games/my/{id}")
+
+    @task(16)
+    def organizers(self) -> None:
+        if self.game_id is None:
+            return
+        self.read(f"/games/{self.game_id}/organizers", name="/games/{id}/organizers")
+
+
+class AdminUser(ShvatkaUser):
+    """One person in the admin panel, mostly looking players up."""
+
+    fixed_count = 1
+    wait_time = between(5, 15)
+    username = ADMIN_USERNAME
+    password = ADMIN_PASSWORD
+
+    def on_start(self) -> None:
+        super().on_start()
+        self.player_ids: list[int] = []
+        found = self.read("/admin/players?active=true", name="/admin/players")
+        self.player_ids = [p["id"] for p in (found or {}).get("items", [])][:50]
+
+    @task(78)
+    def list_players(self) -> None:
+        self.read("/admin/players?active=true", name="/admin/players")
+
+    @task(26)
+    def player_card(self) -> None:
+        if not self.player_ids:
+            return
+        self.read(f"/admin/players/{random.choice(self.player_ids)}", name="/admin/players/{id}")
+
+    @task(8)
+    def waiver_points(self) -> None:
+        if not self.player_ids:
+            return
+        self.read(
+            f"/admin/players/{random.choice(self.player_ids)}/waiver-points",
+            name="/admin/players/{id}/waiver-points",
+        )
+
+
+def collect_guids(node: Any, found: list[str]) -> list[str]:
+    """Every ``file_guid`` anywhere in a hints tree.
+
+    Hint parts nest (a hint holds parts, a part may carry a thumbnail), and the
+    shape differs per hint type, so walking the json beats mirroring the models.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in ("file_guid", "thumb_guid") and isinstance(value, str):
+                found.append(value)
+            else:
+                collect_guids(value, found)
+    elif isinstance(node, list):
+        for item in node:
+            collect_guids(item, found)
+    return found
+
+
+def build_scenario() -> dict[str, Any]:
+    """A structurally real scenario for the upload task.
+
+    Shaped after ``tests/fixtures/resources/simple_scn.yml`` — the endpoint
+    parses and stores the whole tree, so a payload that skips the model version
+    or the conditions would be rejected before any of that work happens, and
+    would measure the validator instead of the write.
+    """
+    return {
+        "__model_version__": 1,
+        "name": f"load-test-{uuid.uuid4().hex[:8]}",
+        "levels": [
+            {
+                "id": f"level-{number}",
+                "__model_version__": 1,
+                "conditions": [{"type": "WIN_KEY", "keys": [f"SH{number}ABC"]}],
+                "time_hints": [
+                    {"time": 0, "hint": [{"type": "text", "text": f"hint {number}"}]},
+                    {"time": 10, "hint": [{"type": "text", "text": f"hint {number} later"}]},
+                ],
+            }
+            for number in range(1, 6)
+        ],
+        "files": [],
+    }

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -320,7 +320,7 @@ class PlayerUser(ShvatkaUser):
         if level:
             self.file_guids = collect_guids(level.get("hints"), [])
 
-    @task(15_700)
+    @task(100)
     def unread_count(self) -> None:
         """The poll that is four fifths of everything the api answers."""
         self.read("/notifications/unread-count")

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -35,6 +35,8 @@ import os
 import random
 import string
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -203,11 +205,11 @@ class ShvatkaUser(HttpUser):
         self.login()
 
     def login(self) -> None:
-        with self.client.post(
+        with self.measured(
+            "POST",
+            "/auth/token",
             "/auth/token",
             data={"username": self.username, "password": self.password},
-            name="/auth/token",
-            catch_response=True,
         ) as resp:
             if not resp.ok:
                 resp.failure(f"login as {self.username} failed: {resp.status_code}")
@@ -220,6 +222,32 @@ class ShvatkaUser(HttpUser):
         # HttpSession is a requests.Session, so the Authorization cookie the
         # login set is carried by everything below without being passed around.
 
+    @contextmanager
+    def measured(self, method: str, url: str, name: str, **kwargs: Any) -> Iterator[Any]:
+        """A ``catch_response`` block that survives a garbage collection.
+
+        Up to locust 2.40, ``ResponseContextManager.__init__`` aliases the
+        response's ``__dict__`` instead of copying it, while ``request_meta``
+        inside that dict points back at the response — so once
+        ``HttpSession.request`` returns, the response object is reachable only
+        through that cycle. A gc pass *inside* the block collects it and clears
+        the very dict the context manager is living in, and ``__exit__`` then
+        fails with ``KeyError: 'name'`` (locustio/locust#3050, #3207). It shows
+        up as an intermittent crash under load, on python 3.13, and the pinned
+        2.39.1 has it.
+
+        Binding the response to a local keeps it reachable until the block ends,
+        which is all the cycle needs to stay uncollectable. On 2.41+, where the
+        response *is* the context manager, the line is a harmless no-op — so
+        this can go once the project's pytest pin allows a newer locust.
+        """
+        catcher = self.client.request(method, url, name=name, catch_response=True, **kwargs)
+        # Not dead code, and it has to happen here rather than inside the block:
+        # the response is already collectable the moment `request` returns.
+        _keep_reachable = catcher.request_meta["response"]
+        with catcher as response:
+            yield response
+
     def read(self, url: str, *, name: str | None = None) -> Any:
         """GET ``url``, returning the decoded body or ``None``.
 
@@ -227,7 +255,7 @@ class ShvatkaUser(HttpUser):
         under, so locust's stats line up with the Grafana panel this profile was
         built from instead of exploding into one row per id.
         """
-        with self.client.get(url, name=name or url, catch_response=True) as resp:
+        with self.measured("GET", url, name or url) as resp:
             if resp.status_code in EXPECTED_STATUSES:
                 resp.success()
                 return None
@@ -590,12 +618,7 @@ class KeySubmittingUser(ShvatkaUser):
             )
 
     def submit(self, key: str, name: str) -> None:
-        with self.client.post(
-            "/games/running/key",
-            json={"text": key},
-            name=name,
-            catch_response=True,
-        ) as resp:
+        with self.measured("POST", "/games/running/key", name, json={"text": key}) as resp:
             if resp.status_code == 422:
                 # not a load problem: the account is not waivered for this game,
                 # or no game is running. Name it so the error table says which.

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -569,13 +569,21 @@ class KeySubmittingUser(ShvatkaUser):
     class whose safety depends on the scenario file matching the game — see
     ``plan_safe_keys`` and the README.
 
-    Its rates are the one **judgement call** in this file rather than a
-    measurement: key submission reached the api through the bot webhook on the
-    measured night, not through ``POST /games/running/key``, so the panel says
-    nothing about how often it was called. What is modelled is the shape of what
-    a team types — mostly keys that turn out to be wrong, some that are right,
-    and a good share of both typed more than once, because a team that finds a
-    key sends it and a team that is stuck guesses.
+    Keys reached the api through the bot webhook on the measured night, not
+    through ``POST /games/running/key``, so the http panel says nothing about
+    them. The **rate** still comes from that night, out of the bot's outgoing
+    counters: ``tgbot_api_requests_total`` shows 235 ``SetMessageReaction`` calls
+    over the six hours, and ``BotView`` sets a reaction on exactly three key
+    outcomes — 😴 for a duplicate, 👎 for a wrong key, and the
+    ``map_effect_to_reaction`` emoji for one carrying effects. A plain correct
+    key that doesn't finish a level only sends a message, so 235 is a floor on
+    keys typed, not the whole count: call it 40 an hour across every team.
+
+    That is *far* less traffic than it feels like from the inside, and the
+    ``wait_time`` below says so — about 20 submissions an hour per client, so
+    two of them reproduce the night and more is deliberate stress. Only the
+    split between wrong, stale and correct is still an estimate: a reaction
+    doesn't say which of the three it was.
     """
 
     # `abstract` is what actually keeps it out of a run: locust reads
@@ -583,7 +591,9 @@ class KeySubmittingUser(ShvatkaUser):
     # key typists against a target nobody opted in for.
     abstract = KEY_USERS <= 0
     fixed_count = KEY_USERS
-    wait_time = between(1, 4)
+    # ~20 keys/hour/client: 83% of tasks submit, so a 150s mean wait lands on the
+    # measured rate. between(1, 4) — the first guess here — was 150x too hot.
+    wait_time = between(60, 240)
     username = KEY_USERNAME
     password = KEY_PASSWORD
 

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -8,12 +8,17 @@ night are ``GET /notifications/unread-count``: the web client polls it, and it
 outweighs every other endpoint by more than an order of magnitude. A load test
 that spreads its calls evenly over the routes tests something the api never does.
 
-The profile is *similar*, not exact. Endpoints are grouped into the three kinds
-of client that generate them, because a rate alone doesn't reproduce the load:
-the orgs' keys/stat dashboards are a handful of clients hammering two expensive
+The profile is *similar*, not exact. Endpoints are grouped into the kinds of
+client that generate them, because a rate alone doesn't reproduce the load: the
+orgs' keys/stat dashboards are a handful of clients hammering two expensive
 queries, while the unread-count poll is hundreds of clients doing something
 cheap. Locust models that with ``fixed_count`` for the few and ``weight`` for
 the crowd.
+
+A fourth class, ``KeySubmittingUser``, types keys at the running game. It is off
+by default and its rates are a judgement call rather than a measurement — key
+traffic reached the api through the bot webhook that night, not through
+``POST /games/running/key`` — so it is kept apart from the observed weights.
 
 Run it against a *staging* copy of the api — it writes (push subscriptions, read
 marks) as the real clients do::
@@ -28,9 +33,12 @@ environment variables that name them.
 import logging
 import os
 import random
+import string
 import uuid
+from pathlib import Path
 from typing import Any
 
+import yaml
 from locust import (  # type: ignore[import, unused-ignore]
     HttpUser,
     between,
@@ -54,11 +62,134 @@ FALLBACK_GAME_ID = os.getenv("SHVATKA_LOAD_GAME_ID")
 # scenario upload — the one genuinely destructive call of the night — is skipped.
 SCENARIO_GAME_ID = os.getenv("SHVATKA_LOAD_SCENARIO_GAME_ID")
 
+# How many clients type keys at the running game, and as whom. Zero (the
+# default) spawns none: unlike everything else here, key submission needs the
+# scenario file to match the game on the target, so it is never on by accident.
+KEY_USERS = int(os.getenv("SHVATKA_LOAD_KEY_USERS", "0"))
+KEY_USERNAME = os.getenv("SHVATKA_LOAD_KEY_USERNAME", PLAYER_USERNAME)
+KEY_PASSWORD = os.getenv("SHVATKA_LOAD_KEY_PASSWORD", PLAYER_PASSWORD)
+KEY_SCENARIO_PATH = Path(
+    os.getenv("SHVATKA_LOAD_KEY_SCENARIO", str(Path(__file__).parent / "scenario.yml"))
+)
+
 # Statuses that are a legitimate answer rather than a broken server: no game is
 # running (404), the level has no files yet (404), this account is not an org of
 # the game it is looking at (403). Reporting them as failures would drown the
 # real errors on a target that simply has no game on right now.
 EXPECTED_STATUSES = (403, 404)
+
+
+KEY_CONDITIONS = ("WIN_KEY", "EFFECTS_KEY")
+WRONG_KEY_ALPHABET = string.ascii_uppercase + string.digits
+
+
+def parse_scenario(path: Path) -> list[list[set[str]]]:
+    """The key sets of every level's key conditions, in level order.
+
+    Level order is the index the api reports as ``level_number`` — it is the
+    level's position in the game, counted from zero, so the list can be indexed
+    with it directly.
+    """
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return [
+        [
+            {str(key) for key in condition.get("keys", ())}
+            for condition in level.get("conditions", ())
+            if condition.get("type") in KEY_CONDITIONS and condition.get("keys")
+        ]
+        for level in raw.get("levels", ())
+    ]
+
+
+def load_key_plan() -> tuple[list[list[set[str]]], set[str]]:
+    """Read the scenario, at import, before locust spawns anything.
+
+    Deliberately not deferred to ``test_start``: a handler that raises there is
+    logged and the run carries on, and a key run that quietly found no scenario
+    would type generated keys at a game nobody meant to load-test that way. A
+    missing or keyless file has to stop the run, so it is read where locust
+    still refuses to start.
+    """
+    if KEY_USERS <= 0:
+        return [], set()
+    levels = parse_scenario(KEY_SCENARIO_PATH)
+    all_keys = {key for level in levels for keys in level for key in keys}
+    if not all_keys:
+        msg = f"{KEY_SCENARIO_PATH} holds no key conditions — nothing to type"
+        raise RuntimeError(msg)
+    logger.info(
+        "key load: %s levels, %s keys from %s", len(levels), len(all_keys), KEY_SCENARIO_PATH
+    )
+    return levels, all_keys
+
+
+# Key conditions of the scenario, level by level: LEVEL_KEYS[n] holds the key
+# sets of level n's conditions. Empty unless key users were asked for.
+LEVEL_KEYS, ALL_SCENARIO_KEYS = load_key_plan()
+
+
+def plan_safe_keys(level_number: int | None, typed: set[str]) -> list[str]:
+    """The correct keys that can be typed without completing a level.
+
+    A condition fires when every one of its keys has been typed, so holding one
+    back keeps the level where it is however many times the rest are submitted.
+    Which one is held back depends on what the team has typed already, read from
+    the api rather than assumed — a key someone typed before the run counts
+    towards the condition just the same.
+
+    Keys already typed are always safe to send again: they are duplicates, and a
+    duplicate advances nothing. So a level the team is halfway through gives more
+    safe keys than a fresh one, not fewer. That holds even for a condition whose
+    keys have all been typed, which is why nothing special is done about one:
+    both key conditions test ``is_duplicate`` before ``_is_all_typed``, so a key
+    seen before decides ``NO_ACTION`` and never reaches the level-up branch.
+    """
+    if level_number is None or not 0 <= level_number < len(LEVEL_KEYS):
+        return []
+    safe: list[str] = []
+    for keys in LEVEL_KEYS[level_number]:
+        safe.extend(sorted(keys & typed))
+        untyped = sorted(keys - typed)
+        # the last one would complete the condition, so it is never sent
+        safe.extend(untyped[:-1])
+    return safe
+
+
+def keys_of_other_levels(level_number: int | None) -> list[str]:
+    """Scenario keys belonging to some level other than this one.
+
+    Every key of the current level is excluded, the held-back one above all: it
+    is the only thing keeping the level from advancing, and sending it as a
+    "wrong" key would complete the condition exactly as sending it as a right
+    one would. A key that appears on two levels counts as this level's.
+    """
+    if level_number is None or not 0 <= level_number < len(LEVEL_KEYS):
+        # the scenario doesn't describe the level the team is on, so it cannot
+        # say which keys are this level's — send none of them rather than guess
+        return []
+    mine = {key for keys in LEVEL_KEYS[level_number] for key in keys}
+    others = {
+        key
+        for number, level in enumerate(LEVEL_KEYS)
+        if number != level_number
+        for keys in level
+        for key in keys
+    }
+    return sorted(others - mine)
+
+
+def make_wrong_key() -> str:
+    """A key-shaped string the scenario does not contain.
+
+    It has to pass ``KEY_REGEXP`` — a wrong key is one the game rejects on its
+    own terms, and a string that isn't a key at all would be dropped before the
+    check ever runs, measuring nothing.
+    """
+    for _ in range(10):
+        key = "SH" + "".join(random.choices(WRONG_KEY_ALPHABET, k=7))
+        if key not in ALL_SCENARIO_KEYS:
+            return key
+    return "SH" + uuid.uuid4().hex[:10].upper()
 
 
 class ShvatkaUser(HttpUser):
@@ -401,6 +532,104 @@ class AdminUser(ShvatkaUser):
             f"/admin/players/{random.choice(self.player_ids)}/waiver-points",
             name="/admin/players/{id}/waiver-points",
         )
+
+
+class KeySubmittingUser(ShvatkaUser):
+    """Teams typing keys at the running game.
+
+    Off unless ``SHVATKA_LOAD_KEY_USERS`` says how many, because this is the one
+    class whose safety depends on the scenario file matching the game — see
+    ``plan_safe_keys`` and the README.
+
+    Its rates are the one **judgement call** in this file rather than a
+    measurement: key submission reached the api through the bot webhook on the
+    measured night, not through ``POST /games/running/key``, so the panel says
+    nothing about how often it was called. What is modelled is the shape of what
+    a team types — mostly keys that turn out to be wrong, some that are right,
+    and a good share of both typed more than once, because a team that finds a
+    key sends it and a team that is stuck guesses.
+    """
+
+    # `abstract` is what actually keeps it out of a run: locust reads
+    # fixed_count = 0 as "not set" and falls back to weight, which would spawn
+    # key typists against a target nobody opted in for.
+    abstract = KEY_USERS <= 0
+    fixed_count = KEY_USERS
+    wait_time = between(1, 4)
+    username = KEY_USERNAME
+    password = KEY_PASSWORD
+
+    def on_start(self) -> None:
+        super().on_start()
+        self.level_number: int | None = None
+        self.safe_correct: list[str] = []
+        self.other_level_keys: list[str] = []
+        self.refresh_plan()
+
+    def refresh_plan(self) -> None:
+        """Re-read the level and work out what is safe to type on it.
+
+        Called from a task as well as on start: the team moves between levels
+        during a run (someone playing for real, another shape of load), and the
+        plan is only safe for the level it was built from.
+        """
+        level = self.read("/games/running/level/current", name="/games/running/level/current")
+        if not level:
+            self.level_number, self.safe_correct, self.other_level_keys = None, [], []
+            return
+        self.level_number = level.get("level_number")
+        typed = {key["text"] for key in level.get("typed_keys", ()) if key.get("type_") != "wrong"}
+        self.safe_correct = plan_safe_keys(self.level_number, typed)
+        self.other_level_keys = keys_of_other_levels(self.level_number)
+        if not self.safe_correct and not self.other_level_keys:
+            logger.warning(
+                "scenario %s says nothing about level %s — typing generated keys only. "
+                "Is it the scenario of the game on the target?",
+                KEY_SCENARIO_PATH.name,
+                self.level_number,
+            )
+
+    def submit(self, key: str, name: str) -> None:
+        with self.client.post(
+            "/games/running/key",
+            json={"text": key},
+            name=name,
+            catch_response=True,
+        ) as resp:
+            if resp.status_code == 422:
+                # not a load problem: the account is not waivered for this game,
+                # or no game is running. Name it so the error table says which.
+                body = resp.json() if resp.content else {}
+                resp.failure(f"key refused: {body.get('type', resp.status_code)}")
+            elif resp.status_code in EXPECTED_STATUSES:
+                resp.success()
+
+    @task(70)
+    def wrong_key(self) -> None:
+        """A key that isn't this level's — a misread, or a guess."""
+        self.submit(make_wrong_key(), name="/games/running/key [wrong]")
+
+    @task(15)
+    def stale_key(self) -> None:
+        """A key of another level: right-looking, wrong place.
+
+        Worth its own task because it is the realistic wrong key — a real team
+        retypes what worked before far more often than it invents a string.
+        """
+        if not self.other_level_keys:
+            return
+        self.submit(random.choice(self.other_level_keys), name="/games/running/key [wrong]")
+
+    @task(15)
+    def correct_key(self) -> None:
+        """One of this level's keys — the first time a level-up candidate, then a duplicate."""
+        if not self.safe_correct:
+            return
+        self.submit(random.choice(self.safe_correct), name="/games/running/key [correct]")
+
+    @task(20)
+    def poll_level(self) -> None:
+        self.refresh_plan()
 
 
 def collect_guids(node: Any, found: list[str]) -> list[str]:

--- a/tests/load/scenario.yml
+++ b/tests/load/scenario.yml
@@ -1,0 +1,109 @@
+# The scenario of the game the key load is pointed at.
+#
+# This file is not decoration: the profile parses it before the run to work out
+# which keys it may submit. It holds one key of every condition back, so no
+# submission ever completes a level and the run leaves the game where it found
+# it — see tests/load/README.md.
+#
+# That guarantee only holds while this file matches the game on the target. A
+# scenario naming *fewer* keys than the real level is safe (the run just never
+# completes anything); one naming *more* is not, because a key this file thinks
+# is one of three may be the real level's only key. Replace this with the
+# scenario of the game you are testing.
+__model_version__: 1
+name: "Load test game"
+levels:
+  - id: warmup
+    __model_version__: 1
+    conditions:
+      - type: WIN_KEY
+        keys:
+          - "SHWARMUP1"
+          - "SHWARMUP2"
+          - "SHWARMUP3"
+    time_hints:
+      - time: 0
+        hint:
+          - type: text
+            text: "загадка первого уровня"
+      - time: 10
+        hint:
+          - type: text
+            text: "подсказка"
+  - id: second
+    __model_version__: 1
+    conditions:
+      - type: WIN_KEY
+        keys:
+          - "SHSECOND1"
+          - "SHSECOND2"
+          - "SHSECOND3"
+          - "SHSECOND4"
+    time_hints:
+      - time: 0
+        hint:
+          - type: text
+            text: "загадка второго уровня"
+      - time: 10
+        hint:
+          - type: text
+            text: "подсказка"
+  - id: third
+    __model_version__: 1
+    conditions:
+      - type: WIN_KEY
+        keys:
+          - "SHTHIRD1"
+          - "SHTHIRD2"
+          - "SHTHIRD3"
+      - type: EFFECTS_KEY
+        keys:
+          - "SHBONUS1"
+          - "SHBONUS2"
+        effects:
+          id: "b0a1c2d3-0000-4000-8000-000000000001"
+          level_up: false
+    time_hints:
+      - time: 0
+        hint:
+          - type: text
+            text: "загадка третьего уровня"
+      - time: 10
+        hint:
+          - type: text
+            text: "подсказка"
+  - id: fourth
+    __model_version__: 1
+    conditions:
+      - type: WIN_KEY
+        keys:
+          - "SHFOURTH1"
+          - "SHFOURTH2"
+          - "SHFOURTH3"
+    time_hints:
+      - time: 0
+        hint:
+          - type: text
+            text: "загадка четвёртого уровня"
+      - time: 10
+        hint:
+          - type: text
+            text: "подсказка"
+  - id: final
+    __model_version__: 1
+    conditions:
+      - type: WIN_KEY
+        keys:
+          - "SHFINAL1"
+          - "SHFINAL2"
+          - "SHFINAL3"
+    time_hints:
+      - time: 0
+        hint:
+          - type: text
+            text: "загадка последнего уровня"
+      - time: 10
+        hint:
+          - type: text
+            text: "подсказка"
+files: []


### PR DESCRIPTION
Reweights `tests/load/locustfile.py` from the `asgi-monitor` 2xx counters of an actual game night, so the profile reproduces the traffic the api really takes instead of two endpoints at equal weight.

## The shape it reproduces

`GET /notifications/unread-count` is **~80% of everything the api answers** — 15.7K calls against 909 for the next endpoint — because the web client polls it. That single fact is the profile: a load test spreading its calls evenly across the routes exercises traffic that never happens.

Task weights are the raw observed counts (`@task(15_700)`, `@task(909)`, …) rather than normalised numbers, so the profile can be re-derived from a later game by pasting new ones in.

## Three kinds of client, not one

The endpoints are split by who calls them, because a rate alone doesn't reproduce the load — three org dashboards hammering the keys and stat queries is a different shape from three hundred phones polling something cheap.

| class | how many | what it does |
|---|---|---|
| `PlayerUser` | whatever `-u` says | unread-count and current-level polling, hint file downloads, teams/games browsing |
| `OrganizerUser` | `fixed_count = 3` | reloads the keys and stat dashboards |
| `AdminUser` | `fixed_count = 1` | player lookups in the admin panel |

`fixed_count` on the last two is the point: there are three orgs on a night whether two hundred people play or two thousand, so their load must not scale with `-u`.

## Running anywhere

The profile discovers its own targets on start — the active game, the player's team, the current level's file guids — so it needs no fixture dump. `403`/`404` are counted as successes, so an environment with no game running reports zero failures instead of all red. Requests are reported under templated names (`/games/{id}/keys`), matching how `asgi-monitor` labels them, so locust's table lines up row for row with the Grafana panel.

Writes match what the real clients do (read marks; a push subscription that is subscribed and unsubscribed in a pair, leaving no rows behind). The scenario upload is the one genuinely destructive call, so it is gated behind `SHVATKA_LOAD_SCENARIO_GAME_ID` naming a throwaway draft game and is never pointed at a game by discovery.

## Testing

`ruff format --check`, `ruff check` and `mypy` pass. Driven end to end with locust 2.x against three stub servers: a running game (all 25 endpoint rows fire, `fixed_count` honoured, zero failures, unread-count lands at ~83% of player traffic), an idle one (404 everywhere game-scoped — zero failures, parametrised tasks skip), and one refusing the login (users stop with a readable error instead of a traceback loop).

`tests/load/README.md` covers the accounts, the env vars and why the numbers are what they are. Nothing here runs in CI — `locust` is in the `dev` group and pytest does not collect `locustfile.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01892kj6DVWdjRpoDhrjCTfn)_