### PR TITLE
feat(api): rename a game without saving its scenario

### DIFF
--- a/shvatka/api/games/requests.py
+++ b/shvatka/api/games/requests.py
@@ -14,6 +14,13 @@ class NewGame:
 
 
 @dataclass
+class GameName:
+    """A new name for an existing game."""
+
+    name: str
+
+
+@dataclass
 class GameStartAt:
     start_at: datetime | None = None
 

--- a/shvatka/api/games/routes.py
+++ b/shvatka/api/games/routes.py
@@ -19,6 +19,7 @@ from shvatka.core.games.editor_interactors import (
     MyGameInteractor,
     MyGamesInteractor,
     PlanGameStartInteractor,
+    RenameGameInteractor,
 )
 from shvatka.core.games.interactors import (
     CheckKeyInteractor,
@@ -89,6 +90,22 @@ async def create_my_game(
 ) -> shared.Game:
     created = await interactor(name=game.name, identity=identity)
     return shared.Game.from_core(created)
+
+
+@inject
+async def rename_my_game(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[RenameGameInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    body: Annotated[requests.GameName, Body()],
+) -> shared.Game:
+    """Rename the game, leaving its scenario alone.
+
+    Saving a scenario renames the game too, but a draft with no levels yet has
+    no scenario to save — this route is how such a game gets its name fixed.
+    """
+    game = await interactor(game_id=id_, name=body.name, identity=identity)
+    return shared.Game.from_core(game)
 
 
 @inject
@@ -371,6 +388,7 @@ def setup() -> APIRouter:
     games_router.add_api_route("/my", get_my_games_list, methods=["GET"])
     games_router.add_api_route("/my", create_my_game, methods=["POST"])
     games_router.add_api_route("/my/{id}", get_my_game, methods=["GET"])
+    games_router.add_api_route("/my/{id}/name", rename_my_game, methods=["PUT"])
     games_router.add_api_route("/my/{id}/scenario", change_my_game_scenario, methods=["PUT"])
     games_router.add_api_route("/my/{id}/start_at", change_my_game_start_at, methods=["PUT"])
     games_router.add_api_route("/my/{id}/status", change_my_game_status, methods=["PUT"])

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -15,6 +15,7 @@ from shvatka.core.interfaces.dal.game import (
     GameByIdGetter,
     GameReleaseGetter,
     GameReleaseSaver,
+    GameRenamer,
     GameStartPlanner,
 )
 from shvatka.core.interfaces.dal.level_times import LevelByTeamGetter
@@ -27,6 +28,15 @@ from shvatka.core.models.enums import GameStatus
 
 class GameKeysReader(TypedKeyGetter, GameByIdGetter, PlayerByUserGetter, Protocol):
     pass
+
+
+class GameNameEditor(GameByIdGetter, GameRenamer, Protocol):
+    """Rename one game draft, addressed by its id.
+
+    Narrower than :class:`~shvatka.core.interfaces.dal.complex.GameScenarioEditor`
+    on purpose: the name is the one thing a game has before it has a scenario,
+    so changing it must not need a scenario to be valid.
+    """
 
 
 class AdminGameScenarioEditor(GameScenarioEditor, GameAuthorTransferer, Protocol):

--- a/shvatka/core/games/editor_interactors.py
+++ b/shvatka/core/games/editor_interactors.py
@@ -12,6 +12,7 @@ from typing import BinaryIO
 
 from adaptix import Retort
 
+from shvatka.core.games.adapters import GameNameEditor
 from shvatka.core.interfaces.clients.file_storage import FileStorage
 from shvatka.core.interfaces.dal.complex import GameScenarioEditor, GameStatusChanger
 from shvatka.core.interfaces.dal.game import (
@@ -36,6 +37,7 @@ from shvatka.core.services.game import (
     get_authors_games,
     get_full_game,
     plain_start,
+    rename_game,
     start_waivers,
     update_game_scenario,
 )
@@ -75,6 +77,24 @@ class CreateGameInteractor:
     async def __call__(self, name: str, identity: IdentityProvider) -> dto.Game:
         author = await identity.get_required_player()
         return await create_game(author=author, name=name, dao=self.dao)
+
+
+@dataclass
+class RenameGameInteractor:
+    """Rename a game draft on its own, without touching its scenario.
+
+    The scenario carries the name too, so saving one renames the game — but a
+    game that has no levels yet has no scenario to save, and that is exactly
+    when a name written in a hurry wants fixing. Hence a route of its own.
+    """
+
+    dao: GameNameEditor
+
+    async def __call__(self, game_id: int, name: str, identity: IdentityProvider) -> dto.Game:
+        author = await identity.get_required_player()
+        check_allow_be_author(author)
+        game = await self.dao.get_by_id(id_=game_id, author=author)
+        return await rename_game(author, game, name, self.dao)
 
 
 @dataclass

--- a/shvatka/core/interfaces/dal/game.py
+++ b/shvatka/core/interfaces/dal/game.py
@@ -54,7 +54,13 @@ class GameCreator(Committer, GameNameChecker, LevelFilesSyncDao, Protocol):
         raise NotImplementedError
 
 
-class GameRenamer(Committer, Protocol):
+class GameRenamer(Committer, GameNameChecker, Protocol):
+    """Rename a game, and tell whether the new name is free.
+
+    Renaming needs the check as much as creating does: the name is what a game
+    is known by, so two games may not share one.
+    """
+
     async def rename_game(self, game: dto.Game, new_name: str):
         raise NotImplementedError
 

--- a/shvatka/core/rules/game.py
+++ b/shvatka/core/rules/game.py
@@ -63,6 +63,20 @@ def check_game_editable(game: dto.Game):
         )
 
 
+def check_game_name(name: str, player: dto.Player) -> None:
+    """Whether a string may be a game's name.
+
+    Only emptiness is refused here — whether the name is *free* is a question
+    for the storage, asked by the caller that writes it.
+    """
+    if not name.strip():
+        raise CantEditGame(
+            player=player,
+            text="game name can not be empty",
+            notify_user="Название игры не может быть пустым",
+        )
+
+
 def check_can_add_file(game: dto.Game, player: dto.Player, is_superuser: bool = False) -> None:
     """Whether a file may still be added to the game.
 

--- a/shvatka/core/services/game.py
+++ b/shvatka/core/services/game.py
@@ -28,6 +28,7 @@ from shvatka.core.rules.game import (
     check_can_read,
     check_can_view_scenario,
     check_game_editable,
+    check_game_name,
 )
 from shvatka.core.rules.level import (
     check_can_link_to_game,
@@ -218,11 +219,30 @@ async def get_game_package(
     )
 
 
-async def rename_game(author: dto.Player, game: dto.Game, new_name: str, dao: GameRenamer):
+async def rename_game(
+    author: dto.Player, game: dto.Game, new_name: str, dao: GameRenamer
+) -> dto.Game:
+    """Give the game another name, answering with the game as it is now.
+
+    Renaming to the name it already has is not an error, it just writes
+    nothing — the caller does not have to compare first.
+    """
     check_can_read(game, author)
     check_game_editable(game)
-    await dao.rename_game(game, new_name)
+    check_game_name(new_name, author)
+    name = new_name.strip()
+    if name != game.name:
+        if not await dao.is_name_available(name):
+            raise CantEditGame(
+                game=game,
+                player=author,
+                text=f"cant rename game to {name} (name is already taken)",
+                notify_user="Игра с таким названием уже есть",
+            )
+        await dao.rename_game(game, name)
+        game.name = name
     await dao.commit()
+    return game
 
 
 async def start_waivers(game: dto.Game, author: dto.Player, dao: WaiverStarter):

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -12,6 +12,7 @@ from shvatka.core.games.adapters import (
     AdminLevelResender,
     GameFileReader,
     GameKeysReader,
+    GameNameEditor,
     GamePlayDao,
     GameReleaseEditor,
     GameReleaseReader,
@@ -33,6 +34,7 @@ from shvatka.core.games.editor_interactors import (
     MyGamesInteractor,
     PlanGameStartInteractor,
     RenameGameFileInteractor,
+    RenameGameInteractor,
     UploadGameFileInteractor,
 )
 from shvatka.core.games.interactors import (
@@ -314,6 +316,12 @@ class GameEditProvider(Provider):
     @provide
     def create_game(self, dao: HolderDao) -> CreateGameInteractor:
         return CreateGameInteractor(dao.game_creator)
+
+    @provide
+    def game_name_editor(self, dao: HolderDao) -> GameNameEditor:
+        return dao.game
+
+    rename_game = provide(RenameGameInteractor)
 
     @provide
     def game_scenario_editor(self, dao: HolderDao) -> GameScenarioEditor:

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -248,6 +248,109 @@ async def test_change_scenario(
 
 
 @pytest.mark.asyncio
+async def test_rename_game(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft to rename", dao=dao.game_creator)
+    resp = await client.put(
+        f"/games/my/{game.id}/name",
+        json={"name": "  переименованная игра  "},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "переименованная игра"
+    stored = await check_dao.game.get_by_id(game.id, author)
+    assert stored.name == "переименованная игра"
+
+
+@pytest.mark.asyncio
+async def test_rename_game_without_a_scenario(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    check_dao: HolderDao,
+):
+    """A game created a moment ago has no levels — and still renames."""
+    cookies = auth_cookies(auth, author)
+    created = await client.post("/games/my", json={"name": "typo in the name"}, cookies=cookies)
+    assert created.status_code == 200, created.text
+    game_id = created.json()["id"]
+
+    resp = await client.put(
+        f"/games/my/{game_id}/name",
+        json={"name": "no typo in the name"},
+        cookies=cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    stored = await check_dao.game.get_by_id(game_id, author)
+    assert stored.name == "no typo in the name"
+
+
+@pytest.mark.asyncio
+async def test_rename_game_to_a_taken_name_forbidden(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    occupied = await create_game(author=author, name="name already used", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft wanting that name", dao=dao.game_creator)
+    resp = await client.put(
+        f"/games/my/{game.id}/name",
+        json={"name": occupied.name},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "CantEditGame"
+    stored = await check_dao.game.get_by_id(game.id, author)
+    assert stored.name == "draft wanting that name"
+
+
+@pytest.mark.asyncio
+async def test_rename_game_to_an_empty_name_forbidden(
+    client: AsyncClient,
+    auth: AuthProperties,
+    author: dto.Player,
+    dao: HolderDao,
+    check_dao: HolderDao,
+):
+    game = await create_game(author=author, name="draft keeping its name", dao=dao.game_creator)
+    resp = await client.put(
+        f"/games/my/{game.id}/name",
+        json={"name": "   "},
+        cookies=auth_cookies(auth, author),
+    )
+    assert resp.status_code == 422, resp.text
+    stored = await check_dao.game.get_by_id(game.id, author)
+    assert stored.name == "draft keeping its name"
+
+
+@pytest.mark.asyncio
+async def test_rename_foreign_game_forbidden(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    # harry is not the author of `game`
+    resp = await client.put(
+        f"/games/my/{game.id}/name",
+        json={"name": "hacked"},
+        cookies=auth_cookies(auth, harry),
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "GameHasAnotherAuthor"
+    stored = await check_dao.game.get_by_id(game.id)
+    assert stored.name == game.name
+
+
+@pytest.mark.asyncio
 async def test_change_start_at(
     client: AsyncClient,
     auth: AuthProperties,

--- a/tests/unit/services/game_edit_interactors_test.py
+++ b/tests/unit/services/game_edit_interactors_test.py
@@ -6,6 +6,7 @@ import pytest
 from shvatka.core.games.editor_interactors import (
     ChangeGameStatusInteractor,
     PlanGameStartInteractor,
+    RenameGameInteractor,
 )
 from shvatka.core.models import dto
 from shvatka.core.models.dto import GameResults, hints
@@ -61,9 +62,17 @@ class FakeGameDao:
     start_at: datetime | None = None
     cancelled: bool = False
     release: dto.GameRelease | None = None
+    taken_names: set[str] = field(default_factory=set)
+    renames: list[str] = field(default_factory=list)
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return self.game
+
+    async def is_name_available(self, name: str) -> bool:
+        return name not in self.taken_names
+
+    async def rename_game(self, game: dto.Game, new_name: str) -> None:
+        self.renames.append(new_name)
 
     async def get_active_game(self) -> dto.Game | None:
         return self.active_game
@@ -210,3 +219,87 @@ async def test_cancel_planned_start_does_not_write_game_log():
 
     assert dao.cancelled is True
     assert game_log.calls == []
+
+
+@pytest.mark.asyncio
+async def test_rename_game_writes_the_trimmed_name():
+    author = make_player(1)
+    game = make_game(author, GameStatus.underconstruction)
+    dao = FakeGameDao(game=game)
+    interactor = RenameGameInteractor(dao=dao)
+
+    renamed = await interactor(
+        game_id=game.id,
+        name="  другое имя  ",
+        identity=MockIdentityProvider(player=author),
+    )
+
+    assert dao.renames == ["другое имя"]
+    assert dao.committed == 1
+    assert renamed.name == "другое имя"
+
+
+@pytest.mark.asyncio
+async def test_rename_game_to_a_taken_name_is_refused():
+    author = make_player(1)
+    game = make_game(author, GameStatus.underconstruction)
+    dao = FakeGameDao(game=game, taken_names={"занято"})
+    interactor = RenameGameInteractor(dao=dao)
+
+    with pytest.raises(exceptions.CantEditGame):
+        await interactor(
+            game_id=game.id,
+            name="занято",
+            identity=MockIdentityProvider(player=author),
+        )
+    assert dao.renames == []
+    assert game.name == "my game"
+
+
+@pytest.mark.asyncio
+async def test_rename_game_to_an_empty_name_is_refused():
+    author = make_player(1)
+    game = make_game(author, GameStatus.underconstruction)
+    dao = FakeGameDao(game=game)
+    interactor = RenameGameInteractor(dao=dao)
+
+    with pytest.raises(exceptions.CantEditGame):
+        await interactor(
+            game_id=game.id,
+            name="   ",
+            identity=MockIdentityProvider(player=author),
+        )
+    assert dao.renames == []
+
+
+@pytest.mark.asyncio
+async def test_rename_game_to_its_own_name_writes_nothing():
+    """The name a game already has is free for it — and nothing to write."""
+    author = make_player(1)
+    game = make_game(author, GameStatus.underconstruction)
+    dao = FakeGameDao(game=game, taken_names={game.name})
+    interactor = RenameGameInteractor(dao=dao)
+
+    await interactor(
+        game_id=game.id,
+        name=game.name,
+        identity=MockIdentityProvider(player=author),
+    )
+
+    assert dao.renames == []
+
+
+@pytest.mark.asyncio
+async def test_rename_started_game_is_refused():
+    author = make_player(1)
+    game = make_game(author, GameStatus.started)
+    dao = FakeGameDao(game=game)
+    interactor = RenameGameInteractor(dao=dao)
+
+    with pytest.raises(exceptions.CantEditGame):
+        await interactor(
+            game_id=game.id,
+            name="поздно",
+            identity=MockIdentityProvider(player=author),
+        )
+    assert dao.renames == []


### PR DESCRIPTION
Closes #338 (engine half; the site half is bomzheg/shvatka-ui).

## Why

The game's name reached the engine from the site only inside a scenario
(`PUT /games/my/{id}/scenario` renames the game when the name differs). A draft
that has no levels yet cannot save a scenario at all — the ui refuses it, and so
would the engine — so exactly the game whose name was typed in a hurry had no way
to be renamed on the site. The bot has had a rename button all along.

## What changed

- `PUT /games/my/{id}/name` — new route, body `{"name": "..."}`, answers with the
  game (same shape as the other `/games/my` writes).
- `RenameGameInteractor` (`core/games/editor_interactors.py`) behind a new
  `GameNameEditor` adapter — narrow enough to read a game by id and write its
  name, and nothing else. Wired in `GameEditProvider`.
- `rename_game` now gets the checks creating a game already had: an empty name is
  refused, and so is a name another game holds — the bot silently took both
  before. Renaming to the name the game already carries stays a no-op rather than
  an error, so a caller does not have to compare first. `GameRenamer` composes
  `GameNameChecker` for that.
- `check_game_name` in `core/rules/game.py` holds the emptiness rule.

Authorization is unchanged and comes from the existing checks: the game is read
with `author=`, so another player's game answers `GameHasAnotherAuthor` (422),
and `check_game_editable` closes the route once the game has started.

## Tests

- `tests/unit/services/game_edit_interactors_test.py` — the trimmed name is
  written and committed; a taken name, an empty name and a started game are each
  refused without a write; renaming to its own name writes nothing.
- `tests/integration/api_full/test_game_edit.py` — the route renames, works on a
  game created a moment ago with no scenario, and refuses a taken name, an empty
  name and a foreign game (asserted through `check_dao`).

`ruff format --check`, `ruff check`, `mypy` and `pytest tests/unit` all pass
locally; the integration suite needs Docker, which this environment has none of,
so CI is the check on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMdK1YhRNJEa17geYvvaf9


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMdK1YhRNJEa17geYvvaf9)_