### PR TITLE
fix(bot): name the player when announcing a leave in a group

### DIFF
--- a/shvatka/tgbot/handlers/player.py
+++ b/shvatka/tgbot/handlers/player.py
@@ -167,7 +167,7 @@ async def leave_handler(
         private=message.chat.type == ChatType.PRIVATE,
     )
     if text is not None:
-        await message.answer(text)
+        await message.reply(text)
 
 
 def setup() -> Router:

--- a/shvatka/tgbot/handlers/player.py
+++ b/shvatka/tgbot/handlers/player.py
@@ -33,7 +33,7 @@ from shvatka.tgbot import keyboards as kb
 from shvatka.tgbot.filters.is_inviter import is_inviter
 from shvatka.tgbot.utils.router import disable_router_on_game
 from shvatka.tgbot.views.commands import LEAVE_COMMAND, PLAYERS_COMMAND, TEAM_COMMAND
-from shvatka.tgbot.views.team import render_team_players
+from shvatka.tgbot.views.team import render_leave_confirmation, render_team_players
 
 
 @inject
@@ -157,10 +157,17 @@ async def leave_handler(
     player = await identity.get_required_player()
     team = await get_my_team(player, dao.team_player)
     if team is None:
-        await message.answer("Ты не состоишь в команде")
+        await message.reply("Ты не состоишь в команде")
         return
     await leave(player, player, dao.team_leaver, notifier=team_notifier)
-    await message.answer(f"Ты вышел из команды {hd.quote(team.name)}")
+    text = render_leave_confirmation(
+        player,
+        team,
+        chat_id=message.chat.id,
+        private=message.chat.type == ChatType.PRIVATE,
+    )
+    if text is not None:
+        await message.answer(text)
 
 
 def setup() -> Router:

--- a/shvatka/tgbot/views/team.py
+++ b/shvatka/tgbot/views/team.py
@@ -47,9 +47,9 @@ def render_leave_confirmation(
 ) -> str | None:
     """What the bot says in the chat where ``/leave`` was typed.
 
-    «Ты» is unambiguous only in a private chat — elsewhere the bot answers with a
-    plain message, so the player has to be named. In the team's own chat there is
-    nothing to add: :class:`BotTeamNotifier` already announces the leave there.
+    «Ты» belongs to a private chat — in a group the player is named instead. In
+    the team's own chat there is nothing to add: :class:`BotTeamNotifier` already
+    announces the leave there.
     """
     if private:
         return f"Ты вышел из команды {hd.quote(team.name)}"

--- a/shvatka/tgbot/views/team.py
+++ b/shvatka/tgbot/views/team.py
@@ -42,6 +42,22 @@ def render_team_players(
     return rez
 
 
+def render_leave_confirmation(
+    player: dto.Player, team: dto.Team, *, chat_id: int, private: bool
+) -> str | None:
+    """What the bot says in the chat where ``/leave`` was typed.
+
+    «Ты» is unambiguous only in a private chat — elsewhere the bot answers with a
+    plain message, so the player has to be named. In the team's own chat there is
+    nothing to add: :class:`BotTeamNotifier` already announces the leave there.
+    """
+    if private:
+        return f"Ты вышел из команды {hd.quote(team.name)}"
+    if team.get_chat_id() == chat_id:
+        return None
+    return f"Игрок {hd.quote(player.name_mention)} вышел из команды {hd.quote(team.name)}"
+
+
 @dataclass
 class BotTeamNotifier(TeamNotifier):
     bot: Bot
@@ -86,7 +102,7 @@ class BotTeamNotifier(TeamNotifier):
                     return f"Игрок {hd.quote(event.removed.name_mention)} вышел из команды."
                 return (
                     f"Игрок {hd.quote(event.removed.name_mention)} удалён из команды "
-                    f"(капитан {hd.quote(event.actor.name_mention)})."
+                    f"(удалил {hd.quote(event.actor.name_mention)})."
                 )
             case CaptainChanged():
                 text = f"👑Новый капитан команды — {hd.quote(event.new_captain.name_mention)}."

--- a/tests/unit/services/team_notifier_test.py
+++ b/tests/unit/services/team_notifier_test.py
@@ -3,7 +3,7 @@ import pytest
 from shvatka.core.models import dto
 from shvatka.core.models.enums.chat_type import ChatType
 from shvatka.core.views.team import CaptainChanged, PlayerJoinedTeam, PlayerLeftTeam
-from shvatka.tgbot.views.team import BotTeamNotifier
+from shvatka.tgbot.views.team import BotTeamNotifier, render_leave_confirmation
 
 
 def _player(id_: int, username: str) -> dto.Player:
@@ -46,7 +46,7 @@ def test_left_by_self() -> None:
     assert "вышел" in (BotTeamNotifier._render(event) or "")
 
 
-def test_left_by_captain() -> None:
+def test_left_by_someone_else() -> None:
     harry = _player(1, "harry")
     ron = _player(2, "ron")
     event = PlayerLeftTeam(team=_team(harry), actor=harry, removed=ron)
@@ -54,6 +54,31 @@ def test_left_by_captain() -> None:
     text = BotTeamNotifier._render(event) or ""
     assert "удалён" in text
     assert "harry" in text
+    # the remover is not necessarily the captain: a teammate with the right to
+    # manage players, or an engine admin, may have done it
+    assert "капитан" not in text
+
+
+def test_leave_confirmation_in_private() -> None:
+    ron = _player(2, "ron")
+    text = render_leave_confirmation(ron, _team(), chat_id=ron.id, private=True)
+    assert text == "Ты вышел из команды Gryffindor"
+
+
+def test_leave_confirmation_in_group_names_the_player() -> None:
+    ron = _player(2, "ron")
+    text = render_leave_confirmation(ron, _team(), chat_id=-200, private=False)
+    # a plain message in a group has to say who left, «ты» tells nobody anything
+    assert text is not None
+    assert "ron" in text
+    assert "Ты" not in text
+    assert "Gryffindor" in text
+
+
+def test_no_leave_confirmation_in_team_chat() -> None:
+    ron = _player(2, "ron")
+    # BotTeamNotifier already announces the leave there, no need to say it twice
+    assert render_leave_confirmation(ron, _team(), chat_id=-100, private=False) is None
 
 
 def test_captain_changed_by_old_captain() -> None:


### PR DESCRIPTION
Closes https://github.com/bomzheg/Shvatka/issues/354

## Что было

- `/leave` в групповом чате давал обычное (не reply) сообщение «Ты вышел из команды …» — из чата непонятно, кто именно вышел.
- Уведомление об удалении игрока называло того, кто удалил, капитаном: «Игрок X удалён из команды (капитан Y)», хотя удалить может любой с правом `can_remove_player` и админ движка.

## Что стало

`shvatka/tgbot/views/team.py`:

- Новая чистая функция `render_leave_confirmation(player, team, *, chat_id, private)` — что бот отвечает в том чате, где написали `/leave`:
  - в лс — «Ты вышел из команды …» как раньше;
  - в чате самой команды — ничего: `BotTeamNotifier` уже пишет туда «Игрок X вышел из команды», второе сообщение было бы дублем;
  - в любом другом групповом чате — «Игрок X вышел из команды …» с ником вместо «ты».
- В `BotTeamNotifier._render` для `PlayerLeftTeam` не по своей воле: «(капитан Y)» → «(удалил Y)» — сообщение больше не приписывает роль, а называет действие (по аналогии с «(пригласил Y)» при добавлении).

`shvatka/tgbot/handlers/player.py`:

- `leave_handler` формирует ответ через `render_leave_confirmation` и молчит, когда рендер вернул `None`.
- Ответ «Ты не состоишь в команде» стал `reply` — в группе «ты» однозначно только в ответе на сообщение.

## Тесты

`tests/unit/services/team_notifier_test.py`: три теста на `render_leave_confirmation` (лс / чужой групповой чат / чат команды), а `test_left_by_captain` переименован в `test_left_by_someone_else` и проверяет, что слова «капитан» в тексте больше нет.

`pytest tests/unit` — 539 passed. `ruff check`, `ruff format --check`, `mypy` по затронутым файлам — чисто.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7qRkSSdA7Dt36xgnuiFYx)_