### PR TITLE
feat(api): tell the web which hint is the level's last

### DIFF
--- a/shvatka/api/app/utils/web_input.py
+++ b/shvatka/api/app/utils/web_input.py
@@ -98,11 +98,16 @@ class WebGameView(GameView):
         )
 
     async def send_hint(self, team: dto.Team, hint_number: int, level: dto.Level) -> None:
+        is_last = level.is_last_hint(hint_number)
         await self._send_to_played(
             team,
             PushMessage(
-                title="Новая подсказка",
-                body=f"{team.name}: подсказка #{hint_number}",
+                title="Последняя подсказка" if is_last else "Новая подсказка",
+                body=(
+                    f"{team.name}: последняя подсказка уровня {self._level_label(level)}"
+                    if is_last
+                    else f"{team.name}: подсказка #{hint_number}"
+                ),
                 url="/games/running",
                 tag=f"hint-{team.id}-{level.db_id}-{hint_number}",
                 data={

--- a/shvatka/api/games/responses.py
+++ b/shvatka/api/games/responses.py
@@ -383,6 +383,8 @@ class CurrentHintResponse:
     level_time_id: int
     started_at: datetime
     is_finished: bool
+    is_last_hint_shown: bool
+    """Whether the last of ``hints`` is the level's last — the client says so."""
 
     @classmethod
     def from_core(cls, core: CurrentHintsAndKeys) -> Self:
@@ -398,6 +400,7 @@ class CurrentHintResponse:
             started_at=core.started_at,
             level_time_id=core.level_time_id,
             is_finished=core.is_finished,
+            is_last_hint_shown=core.is_last_hint_shown,
         )
 
 
@@ -408,6 +411,8 @@ class PassedLevel:
     started_at: datetime
     finished_at: datetime
     hints: list[hints.TimeHint]
+    is_last_hint_shown: bool
+    """Whether the last of ``hints`` is the level's last — the client says so."""
 
     @classmethod
     def from_core(cls, core: PassedLevelHints) -> "PassedLevel":
@@ -417,6 +422,7 @@ class PassedLevel:
             started_at=core.started_at,
             finished_at=core.finished_at,
             hints=core.hints,
+            is_last_hint_shown=core.is_last_hint_shown,
         )
 
 

--- a/shvatka/core/games/dto.py
+++ b/shvatka/core/games/dto.py
@@ -86,6 +86,8 @@ class CurrentHintsAndKeys:
     started_at: datetime
     game_id: int
     is_finished: bool
+    is_last_hint_shown: bool
+    """Whether the last of ``hints`` is the last time hint the level has."""
     level_numbers_by_name_id: dict[str, int]
     """Mapping of level name_id to its number_in_game, used to resolve effects' next_level."""
 
@@ -98,6 +100,8 @@ class CurrentHintsOnly:
     started_at: datetime
     game_id: int
     is_finished: bool
+    is_last_hint_shown: bool
+    """Whether the last of ``hints`` is the last time hint the level has."""
 
     def get_guids(self) -> list[str]:
         return [g for h in self.hints for g in h.get_guids()]
@@ -118,6 +122,8 @@ class PassedLevelHints:
     started_at: datetime
     finished_at: datetime
     hints: list[hints.TimeHint]
+    is_last_hint_shown: bool
+    """Whether the last of ``hints`` is the last time hint the level has."""
 
     @property
     def duration(self) -> timedelta:

--- a/shvatka/core/games/interactors.py
+++ b/shvatka/core/games/interactors.py
@@ -240,6 +240,7 @@ class GamePlayReaderInteractor:
             level_time_id=hints_.level_time_id,
             events=events,
             is_finished=hints_.is_finished,
+            is_last_hint_shown=hints_.is_last_hint_shown,
             level_numbers_by_name_id=level_numbers_by_name_id,
         )
 

--- a/shvatka/core/models/dto/level.py
+++ b/shvatka/core/models/dto/level.py
@@ -26,6 +26,9 @@ class Level:
     def is_last_hint(self, hint_number: int) -> bool:
         return self.scenario.is_last_hint(hint_number)
 
+    def is_last_hint_shown(self, shown_hints_count: int) -> bool:
+        return self.scenario.is_last_hint_shown(shown_hints_count)
+
     def get_keys(self) -> set[str]:
         return self.scenario.get_keys()
 

--- a/shvatka/core/models/dto/scn/level.py
+++ b/shvatka/core/models/dto/scn/level.py
@@ -344,6 +344,14 @@ class LevelScenario:
     def is_last_hint(self, hint_number: int) -> bool:
         return len(self.time_hints) == hint_number + 1
 
+    def is_last_hint_shown(self, shown_hints_count: int) -> bool:
+        """Whether the first ``shown_hints_count`` hints already include the last one.
+
+        Hints are published in order, so the count is enough: a team that has
+        seen them all has nothing more to wait for on this level.
+        """
+        return shown_hints_count > 0 and self.is_last_hint(shown_hints_count - 1)
+
     def check(self, action_: action.Action, state: action.StateHolder) -> action.Decision:
         decisions = action.Decisions([cond.check(action_, state) for cond in self.conditions])
         implemented = decisions.get_implemented()

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -427,11 +427,13 @@ class GamePlayDaoImpl(GamePlayDao):
         if level_time.has_finished(game):
             is_finished = True
             hints_ = []
+            is_last_hint_shown = False
         else:
             is_finished = False
             level = await self.dao.level.get_by_number(game, level_time.level_number)
             td = datetime.now(tz=tz_utc) - level_time.start_at
             hints_ = level.get_hints_for_timedelta(td)
+            is_last_hint_shown = level.is_last_hint_shown(len(hints_))
         return CurrentHintsOnly(
             hints=hints_,
             level_number=level_time.level_number,
@@ -439,6 +441,7 @@ class GamePlayDaoImpl(GamePlayDao):
             started_at=level_time.start_at,
             level_time_id=level_time.id,
             is_finished=is_finished,
+            is_last_hint_shown=is_last_hint_shown,
         )
 
     async def get_passed_levels(self, identity: IdentityProvider) -> PassedLevels:
@@ -452,15 +455,15 @@ class GamePlayDaoImpl(GamePlayDao):
             if level_time.id == current.id or level_time.has_finished(game):
                 continue
             level = game.levels[level_time.level_number]
+            shown = level.get_hints_for_timedelta(next_level_time.start_at - level_time.start_at)
             passed.append(
                 PassedLevelHints(
                     level_number=level_time.level_number,
                     level_time_id=level_time.id,
                     started_at=level_time.start_at,
                     finished_at=next_level_time.start_at,
-                    hints=level.get_hints_for_timedelta(
-                        next_level_time.start_at - level_time.start_at
-                    ),
+                    hints=shown,
+                    is_last_hint_shown=level.is_last_hint_shown(len(shown)),
                 )
             )
         return PassedLevels(game_id=game.id, levels=passed)

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -271,6 +271,41 @@ async def test_game_hints(
     assert resp_json["level_number"] == 0
     assert resp_json["game_id"] == started_game.id
     assert resp_json["level_time_id"] == level_time.id
+    # the level has four hints (0, 2, 4, 6 min.), two of them are out so far
+    assert resp_json["is_last_hint_shown"] is False
+
+
+@pytest.mark.asyncio
+async def test_game_last_hint_shown(
+    client: AsyncClient,
+    auth: AuthProperties,
+    harry: dto.Player,
+    gryffindor: dto.Team,
+    started_game: dto.FullGame,
+    dao: HolderDao,
+):
+    """The last hint of the level is marked as such, like the bot does."""
+    await dao.level_time.delete_all()
+    level_time = models.LevelTime(
+        game_id=started_game.id,
+        team_id=gryffindor.id,
+        level_number=0,
+        # the level's last hint comes out at 6 minutes
+        start_at=datetime.now(tz=tz_utc) - timedelta(minutes=7),
+    )
+    dao.level_time._save(level_time)
+    await dao.commit()
+    token = auth.create_user_token(harry)
+
+    resp = await client.get(
+        "/games/running/level/current",
+        cookies={"Authorization": "Bearer " + token.access_token},
+    )
+
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert [hint["time"] for hint in resp_json["hints"]] == [0, 2, 4, 6]
+    assert resp_json["is_last_hint_shown"] is True
 
 
 @pytest.mark.asyncio
@@ -315,6 +350,7 @@ async def test_game_passed_levels(
     assert passed["level_time_id"] == first.id
     # three minutes on the level: only the hints of 0 and 2 minutes were shown
     assert [hint["time"] for hint in passed["hints"]] == [0, 2]
+    assert passed["is_last_hint_shown"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/level_test.py
+++ b/tests/unit/domain/level_test.py
@@ -216,3 +216,10 @@ def test_third_key_of_three(level_three_keys: scn.LevelScenario):
     assert decision.type == action.DecisionType.EFFECTS
     assert decision.is_level_up()
     assert not decision.duplicate
+
+
+def test_last_hint_shown(level_one_key: scn.LevelScenario):
+    """The level has two hints: only both of them shown mean the last one is out."""
+    assert not level_one_key.is_last_hint_shown(0)
+    assert not level_one_key.is_last_hint_shown(1)
+    assert level_one_key.is_last_hint_shown(2)


### PR DESCRIPTION
Closes #259 (engine half — the web ui half is bomzheg/shvatka-ui#…).

## Why

The bot signs the hint a level ends on — «Последняя подсказка уровня №N (T мин.)» — so a team knows nothing more is coming and can decide to storm the keys. The web play page had no way to say the same: `/games/running/level/current` and `/games/running/level/passed` hand out the hints published so far and nothing about what is left.

## What

- `LevelScenario.is_last_hint_shown(shown_hints_count)` (and the delegate on `dto.Level`): hints come out in order, so the count of published ones is enough to tell whether the last is among them.
- Both play endpoints carry `is_last_hint_shown` — whether the last of the `hints` they return is the last one the level has. It says nothing about hints the team has not reached, so a level in progress keeps its remaining hints, and their count, secret. A finished level reports `false` along with its empty hint list.
- The web push announcing a hint is signed the same way: «Последняя подсказка» / «{team}: последняя подсказка уровня N» instead of «Новая подсказка» / «подсказка #N».

## Tests

- `tests/unit/domain/level_test.py` — the new domain helper, on a two-hint level.
- `tests/integration/api_full/test_game.py` — a level three minutes in (two of four hints out) reports `false`; seven minutes in, with all four out, `true`; a passed level reports it too.

Ran locally: `ruff format --check .`, `ruff check .`, `mypy .` clean; `pytest tests/unit` 558 passed. The testcontainer integration suite is left to CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_011hth7sns6X2nGnCpreX9hF)_