### PR TITLE
feat(admin): purge a false start's run, and edit waivers from the panel

### DIFF
--- a/context.md
+++ b/context.md
@@ -97,6 +97,7 @@ the edge-specific twist.
 | **Game** | Игра | The aggregate root of the engine: an author, a name, an ordered list of levels, a status, a start time, and results. | `dto.Game`, `dto.FullGame`, `dto.PreviewGame` |
 | **Game status** | Статус игры | Where the game is in its lifecycle — see the table below. Nearly every permission check reads it. | `enums.GameStatus` |
 | **Game number** | Номер игры | The game's place in the archive. Assigned as `max + 1` at completion, so only played games have one. | `Game.number`, `game.complete_game` |
+| **Game run** | Ход игры | Everything playing a game produced: the **level times**, the typed **keys**, the **events** and the **timers**. Not part of the game — the game is what the author wrote — but what a *second* run of the same game would collide with, which is why undoing a false start sweeps it. Four tables, and only these four. | `levels_times`, `log_keys`, `event_log`, `timers_log`; `GameRuntimePurger` |
 | **Organizer (org)** | Организатор (орг) | A player who runs a game rather than playing it. The author is the **primary organizer** and holds every right; anyone else invited is a **secondary organizer** with explicit permissions. | `dto.Organizer`, `dto.PrimaryOrganizer`, `dto.SecondaryOrganizer` |
 | **Org permission** | Полномочие орга | What a secondary organizer may do: spy, see the key log, validate waivers, view the scenario. **Nothing is granted by default.** | `enums.OrgPermission` |
 | **Manage token** | — | The game's secret, checked when someone acts on the game through an invite link. | `Game.manage_token`, `organizers.check_game_token` |
@@ -126,6 +127,15 @@ back out of waivers opened too early) but never read its content while it is not
 complete. A game in `underconstruction` or `ready` is its author's alone and is
 reported as not found there — including the game an admin has just moved back,
 which is the point: the fix hands the game over and ends the admin's part in it.
+
+Two more groups name the two halves of a **rewind** — an admin declaring that a
+run never happened. `PLAYED_STATUSES` = `started`, `finished`, `complete` (the
+ones a game only reaches by being played) and `REWOUND_STATUSES` =
+`getting_waivers`, `ready`, `underconstruction` (the ones before a run). Moving
+from the first group into the second is the only time the **game run** may be
+swept along with the status (`purge_runtime`), because it is the only time the
+run is being disowned rather than made history. The waivers are never part of
+it: who signed up survives a false start. See SHEP-0013.
 
 A game's **release** follows the statuses on its own schedule, wider than
 `EDITABLE_STATUSES`: it may be rewritten up to and including `finished` (it is

--- a/docs/modules/shep/nav.adoc
+++ b/docs/modules/shep/nav.adoc
@@ -11,4 +11,5 @@
 ** xref:shep-0010-message-outbox.adoc[SHEP-0010 Message outbox]
 ** xref:shep-0011-player-identity-loading.adoc[SHEP-0011 Player identity loading]
 ** xref:shep-0012-team-captain-by-id.adoc[SHEP-0012 Team captain by id]
+** xref:shep-0013-undoing-a-false-start.adoc[SHEP-0013 Undoing a false start]
 ** xref:template.adoc[SHEP template]

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -74,6 +74,10 @@ came out of it*.
 | xref:shep-0012-team-captain-by-id.adoc[SHEP-0012]
 | Carrying the team captain by id
 | Draft
+
+| xref:shep-0013-undoing-a-false-start.adoc[SHEP-0013]
+| Undoing a false start
+| Accepted, implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0013-undoing-a-false-start.adoc
+++ b/docs/modules/shep/pages/shep-0013-undoing-a-false-start.adoc
@@ -1,0 +1,167 @@
+= SHEP-0013 — Undoing a false start
+:navtitle: SHEP-0013 Undoing a false start
+
+[cols="1,4"]
+|===
+| SHEP | 0013
+| Title | Undoing a false start
+| Status | `Accepted, implemented`
+| Created | 2026-09-01
+| Updated | 2026-09-01
+| Related | xref:shep-0009-key-submission-latency.adoc[SHEP-0009]
+|===
+
+== Summary
+
+A game that was started by mistake cannot be given back. The admin panel can
+already walk its status back to `getting_waivers`, but the run stays in the
+database: the level times say every team is where the false start left it, and
+the keys they typed are already accepted. Replaying the game then starts each
+team halfway through it. This adds a checkbox to the status change — sweep the
+four tables a run writes into — and, next to it, the ability to add and remove a
+single waiver, because a repaired game usually needs its roster repaired too.
+
+== Context
+
+Playing a game writes into exactly four tables:
+
+[cols="2,3,3",options="header"]
+|===
+| table | rows per game | references
+
+| `levels_times` | one per team per level entered | `games`, `teams`
+| `log_keys` | one per key typed, right or wrong | `games`, `teams`, `levels_times`, `event_log`
+| `event_log` | one per effect (bonus, penalty, timer) | `games`, `teams`, `levels_times`
+| `timers_log` | one per timer started | `levels_times`, `event_log`
+|===
+
+Nothing else a run touches is per-run: the waivers are the roster, the scenario
+is the author's, the files are the game's.
+
+`AdminChangeGameStatusInteractor`
+(`shvatka/core/games/admin_interactors.py`) already moves a game between
+statuses and, leaving the active statuses, cancels its planned start — because
+otherwise the scheduler would start it again minutes later and undo the repair.
+The run is the same class of leftover, one step deeper: the status says the
+game has not been played, and the tables say it has.
+
+Today the only way out is `psql`. That is a poor place to remember that
+`log_keys` and `timers_log` both point at `event_log` and at `levels_times`,
+that `timers_log` has no `game_id` of its own, and that deleting in the wrong
+order fails on a foreign key halfway through — leaving the game in a state worse
+than the one being repaired.
+
+== Decision
+
+=== The purge rides on the status change, not on an endpoint of its own
+
+`PUT /admin/games/{id}/status` takes `purge_runtime: bool = false`. One request,
+one transaction: the new status and the deletes commit together, or neither
+does.
+
+A separate `DELETE /admin/games/{id}/runtime` was the obvious alternative and
+loses on exactly that. Two requests can half-succeed, and the half that fails is
+never the harmless one — a game whose rows are gone but whose status still says
+`finished` is unplayable *and* looks fine in the panel. Riding on the status
+change also puts the checkbox where the admin already is, which is the whole
+user-facing point.
+
+=== Only on the way back, and never on the way forward
+
+`check_can_purge_game_runtime` (`shvatka/core/rules/game.py`) allows the purge
+only from `PLAYED_STATUSES` (`started`, `finished`, `complete`) into
+`REWOUND_STATUSES` (`getting_waivers`, `ready`, `underconstruction`). Any other
+combination is refused before anything is written.
+
+The rule is a rule and not a UI decision because the alternatives are all worse.
+Silently ignoring the flag on a move that keeps the run teaches an admin that
+the checkbox sometimes does nothing. Honouring it on a *forward* move — a game
+being completed — would let the panel erase the history of a game that is going
+on, which nothing about the panel should be able to do. Refusing is the only
+option that leaves the admin knowing what happened.
+
+`complete` is in the "played" set rather than only `started` and `finished`,
+because the mistake worth undoing is sometimes discovered after the game was
+closed. Nothing else about `complete` changes: a game rewound out of it keeps
+its number (see `complete_game`), so the archive is not renumbered by a repair.
+
+=== The waivers are deliberately not swept
+
+Rewinding to `getting_waivers` is the common case, and its whole point is that
+the teams who signed up stay signed up. A false start costs the orgs an evening;
+making every team re-submit its roster would cost them one too.
+
+That is also why the roster gets an editing pair rather than a reset:
+`POST /admin/waivers/game/{id}/teams/{team_id}/players` and
+`DELETE …/players/{player_id}` (`AdminAddWaiverInteractor`,
+`AdminRemoveWaiverInteractor`). The panel could already *read* a game's waivers
+and remove a poll vote; what it could not do is fix a roster when the captain is
+gone, unreachable, or missed the deadline.
+
+Two details of that pair are decisions rather than defaults:
+
+* the player must currently play in the team. A waiver for somebody who plays
+  elsewhere would not appear in the roster anyway — `WaiverDao.get_played` reads
+  it through the live membership — so writing one would produce a row that
+  cannot be seen and cannot be removed from the panel. The admin already has
+  `POST /admin/teams/{id}/players` for the other half of that repair.
+* removing a waiver deletes the row rather than setting `played = revoked`. The
+  captain's own revoke marks a player as barred from re-signing
+  (`WaiverDao.is_excluded`); an admin undoing a mistake means the opposite, and
+  the team must be free to sign the player up again.
+
+=== The deletes are per-table; the order is the use case's
+
+Following the DAO rules in `AGENTS.md`: each table is deleted through its own
+dao (`LevelTimeDao`, `KeyTimeDao`, `GameEventDao`, `TimersDAO`), and the
+interactor walks them in the order the foreign keys allow — `timers_log` and
+`log_keys` first, then `event_log`, then `levels_times`. `timers_log` has no
+game of its own, so the interactor reads the game's level time ids first and
+hands them over.
+
+They are composed behind `GameRuntimePurger` and folded into the existing
+`AdminGameStatusChanger`, so the interactor keeps a single dao. That protocol was
+until now "the games table and nothing else"; it is now "the games table, plus
+the deletes that undo a run". The line it was drawn on still holds — the purge
+reads no key, no event and no team's position, it only deletes — but it is worth
+saying out loud, because the next thing added to that protocol will be tempted
+to be a `SELECT`.
+
+== Consequences
+
+* The purge is irreversible and has no dry run. The panel confirms twice (the
+  status change already confirms once) and the interactor logs the acting
+  admin's id and the number of level times it dropped, which is the only trace
+  left afterwards.
+* The four tables are now enumerated in three places: this document, the
+  `GameRuntimePurger` protocol, and its implementation. A fifth table written
+  during a run would have to be added to all three — there is no cascade and no
+  reflection doing it automatically. That is deliberate: a `DELETE` that
+  discovers its own scope is not something to have.
+* `achievements` is not swept, and is not a mistake: an achievement is a
+  player's, not a run's, and nothing about replaying a game invalidates one.
+* Waivers stay editable one player at a time. Replacing a whole team's roster
+  from the panel would need the captain-side `replace_team_waivers` semantics
+  (which delete the players not listed), and no one has asked for it.
+
+== Phases and status
+
+[cols="1,4,2",options="header"]
+|===
+| Phase | Content | Status
+
+| 1 | `purge_runtime` on the status change; per-table deletes; the rewind rule | ✅ done
+| 2 | Admin add/remove of a single waiver | ✅ done
+| 3 | `shvatka-ui`: the checkbox on the status form, add/remove on the waivers page | ✅ done
+|===
+
+== Deviations from the plan
+
+None so far.
+
+== Open questions
+
+Whether a rewound game should also lose its `results` (`published_chanel_id`,
+`results_picture_file_id`, `keys_url`) — they describe a run that is being
+declared not to have happened. Nothing breaks while they stay, and a game
+rewound out of `complete` is rare enough that no one has hit it yet.

--- a/shvatka/api/admin/requests.py
+++ b/shvatka/api/admin/requests.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from shvatka.api.shared.requests import MergeRequest, TimelineItem
 from shvatka.core.models.enums import GameStatus
+from shvatka.core.models.enums.played import Played
 from shvatka.core.players.dto import TimelineItem as CoreTimelineItem
 
 
@@ -18,11 +19,25 @@ class AdminGameStatusChange:
     status: GameStatus
     """the status to move the game to; the game keeps everything else"""
 
+    purge_runtime: bool = False
+    """also erase what playing the game produced — level times, typed keys,
+    events and timers. Only when a played game (``started``, ``finished``,
+    ``complete``) is rewound to ``getting_waivers``, ``ready`` or
+    ``underconstruction``; any other move is refused rather than half-obeyed.
+    Waivers are never touched."""
+
 
 @dataclass
 class AdminResendLevel:
     team_id: int | None = None
     """the single team to resend to; ``null`` means every team of the game"""
+
+
+@dataclass
+class AdminAddWaiver:
+    player_id: int
+    played: Played = Played.yes
+    """how the player takes part; ``yes`` is the roster, the rest are the ways out"""
 
 
 @dataclass

--- a/shvatka/api/admin/routes.py
+++ b/shvatka/api/admin/routes.py
@@ -45,9 +45,11 @@ from shvatka.core.teams.admin_interactors import (
 )
 from shvatka.core.utils import exceptions
 from shvatka.core.waiver.admin_interactors import (
+    AdminAddWaiverInteractor,
     AdminGameWaiversReaderInteractor,
     AdminPollReaderInteractor,
     AdminRemovePollVoteInteractor,
+    AdminRemoveWaiverInteractor,
 )
 from shvatka.infrastructure.db.dao.holder import HolderDao
 
@@ -265,6 +267,46 @@ async def get_waivers_by_game(
 
 
 @inject
+async def add_waiver(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[AdminAddWaiverInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    team_id: Annotated[int, Path()],
+    body: Annotated[requests.AdminAddWaiver, Body()],
+) -> waivers_responses.TeamWaivers:
+    """Sign a player up for the game over the captain's head.
+
+    The player must play in the team right now. A player who already has a
+    waiver here gets it rewritten, so this is also how ``played`` is changed.
+    Answers with the team's waivers as they now are.
+    """
+    result = await interactor(
+        identity=identity,
+        game_id=id_,
+        team_id=team_id,
+        player_id=body.player_id,
+        played=body.played,
+    )
+    return waivers_responses.TeamWaivers.from_core(result.team, result.waivers)
+
+
+@inject
+async def remove_waiver(
+    identity: FromDishka[ApiIdentityProvider],
+    interactor: FromDishka[AdminRemoveWaiverInteractor],
+    id_: Annotated[int, Path(alias="id")],
+    team_id: Annotated[int, Path()],
+    player_id: Annotated[int, Path()],
+) -> None:
+    """Take the player back out of the game's roster.
+
+    The row goes rather than becoming a ``revoked`` one — the team may sign the
+    player up again afterwards.
+    """
+    await interactor(identity=identity, game_id=id_, team_id=team_id, player_id=player_id)
+
+
+@inject
 async def list_games(
     identity: FromDishka[ApiIdentityProvider],
     interactor: FromDishka[AdminGamesListInteractor],
@@ -290,8 +332,19 @@ async def change_game_status(
     Answers with the game as it now is. Moving it to a status an admin may not
     see (``underconstruction``, ``ready``) is allowed and final: the game is
     its author's again, and this endpoint answers 404 for it afterwards.
+
+    With ``purge_runtime`` the move also erases the run — level times, typed
+    keys, events and timers — so a game whose start was a mistake can be played
+    again from the beginning. It is allowed only when a played game is rewound;
+    on any other move the request is refused and nothing changes. The waivers
+    stay: who signed up survives a false start.
     """
-    game = await interactor(game_id=id_, status=body.status, identity=identity)
+    game = await interactor(
+        game_id=id_,
+        status=body.status,
+        identity=identity,
+        purge_runtime=body.purge_runtime,
+    )
     return shared.Game.from_core(game)
 
 
@@ -395,6 +448,17 @@ def setup() -> APIRouter:
         status_code=204,
     )
     router.add_api_route("/waivers/game/{id}", get_waivers_by_game, methods=["GET"])
+    router.add_api_route(
+        "/waivers/game/{id}/teams/{team_id}/players",
+        add_waiver,
+        methods=["POST"],
+    )
+    router.add_api_route(
+        "/waivers/game/{id}/teams/{team_id}/players/{player_id}",
+        remove_waiver,
+        methods=["DELETE"],
+        status_code=204,
+    )
     router.add_api_route("/games", list_games, methods=["GET"])
     router.add_api_route("/games/{id}/status", change_game_status, methods=["PUT"])
     router.add_api_route("/games/{id}/scenario", change_game_scenario, methods=["PUT"])

--- a/shvatka/api/app/error_handler.py
+++ b/shvatka/api/app/error_handler.py
@@ -51,6 +51,7 @@ def sh_exception_handler(
         exceptions.FileNotFound
         | exceptions.GameNotFound
         | exceptions.PlayerNotFoundError
+        | exceptions.TeamNotFound
         | exceptions.UserNotFoundError,
     ):
         status_code = 404

--- a/shvatka/api/waivers/routes.py
+++ b/shvatka/api/waivers/routes.py
@@ -1,12 +1,10 @@
-import logging
 from collections.abc import Iterable
 from typing import Annotated
 
 from dishka import FromDishka
 from dishka.integrations.fastapi import inject
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Body
 from fastapi.params import Path
-from sqlalchemy.exc import NoResultFound
 
 from shvatka.api.app.dependencies.auth import ApiIdentityProvider
 from shvatka.api.waivers import requests, responses
@@ -18,8 +16,6 @@ from shvatka.core.waiver.interactors import (
     WaiverCompleteReaderInteractor,
 )
 from shvatka.infrastructure.db.dao.holder import HolderDao
-
-logger = logging.getLogger(__name__)
 
 
 @inject
@@ -54,11 +50,9 @@ async def get_waivers_by_game(
     dao: FromDishka[HolderDao],
     id_: Annotated[int, Path(alias="id")],
 ) -> responses.WaiversDto:
-    try:
-        game = await get_game(id_, dao=dao.game)
-    except NoResultFound as e:
-        logger.info("game %s not found", id_, exc_info=e)
-        raise HTTPException(status_code=404, detail={"text": "game not found"}) from e
+    # a game that is not there raises GameNotFound from the dao, which the
+    # error handler already answers with a 404
+    game = await get_game(id_, dao=dao.game)
     waivers: dict[dto.Team, Iterable[dto.VotedPlayer]] = await interactor(game)
     return responses.WaiversDto.from_core(waivers)
 

--- a/shvatka/core/games/adapters.py
+++ b/shvatka/core/games/adapters.py
@@ -59,7 +59,36 @@ class AdminGameScenarioEditor(GameScenarioEditor, GameAuthorTransferer, Protocol
         raise NotImplementedError
 
 
-class AdminGameStatusChanger(GameByIdGetter, GameCompleter, GameStartPlanner, Protocol):
+class GameRuntimePurger(Protocol):
+    """The per-table deletes that undo a game's run.
+
+    Four tables hold what playing a game produces — ``levels_times``,
+    ``log_keys``, ``event_log`` and ``timers_log`` — and each is dropped
+    through its own table's dao. Nothing here decides *when*: the order the
+    foreign keys demand (timers and keys, then events, then level times) is
+    the use case's to walk, and ``timers_log`` has no game of its own, so its
+    level time ids are resolved first and handed over.
+    """
+
+    async def get_level_time_ids(self, game: dto.Game) -> list[int]:
+        raise NotImplementedError
+
+    async def delete_timers(self, level_time_ids: Collection[int]) -> None:
+        raise NotImplementedError
+
+    async def delete_typed_keys(self, game: dto.Game) -> None:
+        raise NotImplementedError
+
+    async def delete_events(self, game: dto.Game) -> None:
+        raise NotImplementedError
+
+    async def delete_level_times(self, game: dto.Game) -> None:
+        raise NotImplementedError
+
+
+class AdminGameStatusChanger(
+    GameByIdGetter, GameCompleter, GameStartPlanner, GameRuntimePurger, Protocol
+):
     """Move a game between statuses on behalf of an admin, and list the ones
     the admin may act on.
 
@@ -67,6 +96,10 @@ class AdminGameStatusChanger(GameByIdGetter, GameCompleter, GameStartPlanner, Pr
     completing one needs — the number — and what leaving the active statuses
     needs — cancelling the planned start). Nothing here reaches a level, a
     hint or a file, so the admin panel cannot read a game's content through it.
+
+    The purge (``GameRuntimePurger``) is the one thing it reaches past the
+    games table for, and it only *deletes*: sweeping the run of a game the
+    admin is rewinding never reads a key, an event or where a team got to.
     """
 
     async def set_status(self, game: dto.Game, status: GameStatus) -> None:

--- a/shvatka/core/games/admin_interactors.py
+++ b/shvatka/core/games/admin_interactors.py
@@ -15,6 +15,8 @@ A game's *status* is a different matter: the panel may walk a game that
 collects waivers, runs, is finished or is complete to another status (see
 :class:`AdminChangeGameStatusInteractor`), without ever reading a level, a
 hint or a file of it. Games still being written stay invisible even to that.
+Rewinding a played game may take the run with it — the level times, keys,
+events and timers of a false start — which is a delete and never a read.
 
 The same line runs through the one thing the panel may do to a game that is
 being *played* — resending a level's messages to a team that lost them (see
@@ -44,7 +46,7 @@ from shvatka.core.models import dto
 from shvatka.core.models.dto import hints, scn
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.game_status import ACTIVE_STATUSES, ADMIN_MANAGEABLE_STATUSES
-from shvatka.core.rules.game import check_admin_can_manage_game
+from shvatka.core.rules.game import check_admin_can_manage_game, check_can_purge_game_runtime
 from shvatka.core.services.game import check_no_other_game_active, complete_game
 from shvatka.core.services.scenario.files import save_file, sync_files_for_level
 from shvatka.core.services.scenario.game_ops import parse_uploaded_game
@@ -201,17 +203,37 @@ class AdminChangeGameStatusInteractor:
     A game the admin may not see (``underconstruction``, ``ready``) is reported
     as not found — including the game the admin has just moved there, which is
     exactly the point: the fix hands the game back to its author.
+
+    Rewinding a game that was *played* leaves the run behind, and that is the
+    one thing the status alone cannot repair: the level times, keys, events and
+    timers of the false start are still there, and the game replayed on the
+    right evening would start with every team already on the level it reached.
+    So the move may take them with it — ``purge_runtime``, the panel's
+    checkbox — and only on that move: see
+    :func:`~shvatka.core.rules.game.check_can_purge_game_runtime`. Nothing of
+    the run is read on the way out; it is four deletes, in the order the
+    foreign keys allow, in the transaction that writes the new status. The
+    waivers are deliberately not among them — who signed up survives a false
+    start, and that is the whole point of rewinding to ``getting_waivers``.
     """
 
     dao: AdminGameStatusChanger
     scheduler: Scheduler
 
     async def __call__(
-        self, game_id: int, status: GameStatus, identity: IdentityProvider
+        self,
+        game_id: int,
+        status: GameStatus,
+        identity: IdentityProvider,
+        purge_runtime: bool = False,
     ) -> dto.Game:
         admin = await identity.get_superuser()
         game = await self.dao.get_by_id(id_=game_id)
         check_admin_can_manage_game(game)
+        if purge_runtime:
+            # refuse before anything is written: an admin who ticked the box on
+            # a move that keeps the run must be told, not quietly obeyed by half
+            check_can_purge_game_runtime(game, status)
         if status == game.status:
             return game
         if status in ACTIVE_STATUSES:
@@ -224,9 +246,31 @@ class AdminChangeGameStatusInteractor:
             await self.dao.set_status(game, status)
             if status not in ACTIVE_STATUSES:
                 await self._cancel_planned_start(game)
+            if purge_runtime:
+                await self._purge_runtime(game, admin)
             await self.dao.commit()
         logger.warning("admin %s changed status of game %s to %s", admin.id, game.id, status.name)
         return game
+
+    async def _purge_runtime(self, game: dto.Game, admin: dto.Player) -> None:
+        """Erase what playing the game produced, deepest reference first.
+
+        ``log_keys`` and ``timers_log`` point at both ``event_log`` and
+        ``levels_times``, and ``event_log`` points at ``levels_times`` — so the
+        order is fixed, and ``timers_log`` (which has no game of its own) is
+        addressed through the level time ids read before anything is dropped.
+        """
+        level_time_ids = await self.dao.get_level_time_ids(game)
+        await self.dao.delete_timers(level_time_ids)
+        await self.dao.delete_typed_keys(game)
+        await self.dao.delete_events(game)
+        await self.dao.delete_level_times(game)
+        logger.warning(
+            "admin %s purged the run of game %s (%s level times)",
+            admin.id,
+            game.id,
+            len(level_time_ids),
+        )
 
     async def _cancel_planned_start(self, game: dto.Game) -> None:
         if game.start_at is None:

--- a/shvatka/core/models/enums/game_status.py
+++ b/shvatka/core/models/enums/game_status.py
@@ -30,3 +30,15 @@ EDITABLE_STATUSES = (
     GameStatus.ready,
     GameStatus.getting_waivers,
 )
+PLAYED_STATUSES = (GameStatus.started, GameStatus.finished, GameStatus.complete)
+"""Statuses a game only reaches by having been played. Everything a run
+produces — level times, typed keys, events, timers — exists exactly for the
+games that got this far."""
+REWOUND_STATUSES = (
+    GameStatus.getting_waivers,
+    GameStatus.ready,
+    GameStatus.underconstruction,
+)
+"""Statuses that put a game back *before* its run. Moving a played game into
+one of them is the admin undoing a start, and the only moment the run's data
+may be swept (see ``AdminChangeGameStatusInteractor``)."""

--- a/shvatka/core/rules/game.py
+++ b/shvatka/core/rules/game.py
@@ -1,8 +1,18 @@
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
-from shvatka.core.models.enums.game_status import ADMIN_MANAGEABLE_STATUSES
+from shvatka.core.models.enums.game_status import (
+    ADMIN_MANAGEABLE_STATUSES,
+    PLAYED_STATUSES,
+    REWOUND_STATUSES,
+    GameStatus,
+)
 from shvatka.core.models.enums.org_permission import OrgPermission
-from shvatka.core.utils.exceptions import CantEditGame, GameNotFound, NotAuthorizedForEdit
+from shvatka.core.utils.exceptions import (
+    CantEditGame,
+    GameNotFound,
+    GameStatusError,
+    NotAuthorizedForEdit,
+)
 
 
 def check_can_read(game: dto.Game, player: dto.Player):
@@ -54,6 +64,34 @@ def check_admin_can_manage_game(game: dto.Game) -> None:
     """
     if game.status not in ADMIN_MANAGEABLE_STATUSES:
         raise GameNotFound(game=game)
+
+
+def check_can_purge_game_runtime(game: dto.Game, status: GameStatus) -> None:
+    """Whether the run of ``game`` may be swept as it moves to ``status``.
+
+    Only on the way back: a game that was played (``started``, ``finished``,
+    ``complete``) moving to a status before its run (``getting_waivers``,
+    ``ready``, ``underconstruction``). That move is the admin declaring the run
+    never happened — a false start, a game opened on the wrong evening — and
+    the level times, keys, events and timers it left behind are what would
+    otherwise make the game unplayable a second time.
+
+    Any other move keeps them: a game that is merely being renumbered or
+    completed still owns its history, and nothing about the panel should be
+    able to erase the history of a game that is going on.
+    """
+    if game.status not in PLAYED_STATUSES or status not in REWOUND_STATUSES:
+        raise GameStatusError(
+            game_status=game.status.name,
+            game=game,
+            text=(
+                f"cant purge the run of a game moving from " f"{game.status.name} to {status.name}"
+            ),
+            notify_user=(
+                "Очистить ход игры можно только возвращая сыгранную игру "
+                "к сбору вейверов или в черновики"
+            ),
+        )
 
 
 def check_game_editable(game: dto.Game):

--- a/shvatka/core/utils/exceptions.py
+++ b/shvatka/core/utils/exceptions.py
@@ -278,6 +278,10 @@ class TeamError(SHError):
     doc_page = DocPage.CREATE_TEAM
 
 
+class TeamNotFound(TeamError):
+    notify_user = "Команда не найдена"
+
+
 class PlayerNotFoundError(SHError):
     notify_user = "Игрок не найден"
 

--- a/shvatka/core/waiver/adapters.py
+++ b/shvatka/core/waiver/adapters.py
@@ -54,6 +54,43 @@ class AdminPollReader(PollTeamsGetter, WaiverVoteGetter, TeamByIdGetter, Protoco
     pass
 
 
+class AdminWaiverEditor(Protocol):
+    """Add and remove single waivers on behalf of an admin.
+
+    Everything is addressed by id, and the getters are named apart on purpose:
+    a game, a team and a player all answer to ``get_by_id`` in their own dao,
+    so composing the narrow protocols here would collide on the name.
+
+    Only the ``waivers`` table is written. The poll draft is a different thing
+    with its own button in the panel, and a waiver of a game long over has no
+    poll to speak of — so removing one leaves any vote alone.
+    """
+
+    async def get_game_by_id(self, id_: int) -> dto.Game:
+        raise NotImplementedError
+
+    async def get_team_by_id(self, id_: int) -> dto.Team:
+        raise NotImplementedError
+
+    async def get_player_by_id(self, id_: int) -> dto.Player:
+        raise NotImplementedError
+
+    async def get_team_player(self, player: dto.Player) -> dto.TeamPlayer:
+        raise NotImplementedError
+
+    async def get_team_waivers(self, game: dto.Game, team: dto.Team) -> list[dto.Waiver]:
+        raise NotImplementedError
+
+    async def upsert(self, waiver: dto.Waiver) -> None:
+        raise NotImplementedError
+
+    async def delete(self, waiver: dto.WaiverQuery) -> None:
+        raise NotImplementedError
+
+    async def commit(self) -> None:
+        raise NotImplementedError
+
+
 class AdminGameWaiversReader(Protocol):
     """Load a game by id and read its approved waivers, for the admin panel."""
 

--- a/shvatka/core/waiver/admin_interactors.py
+++ b/shvatka/core/waiver/admin_interactors.py
@@ -11,9 +11,12 @@ from dataclasses import dataclass
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.models.enums import Played
+from shvatka.core.players.player import get_checked_player_on_team
+from shvatka.core.waiver import dto as waiver_dto
 from shvatka.core.waiver.adapters import (
     AdminGameWaiversReader,
     AdminPollReader,
+    AdminWaiverEditor,
     PollVoteRemover,
 )
 from shvatka.core.waiver.services import get_all_played, get_vote_to_voted
@@ -60,3 +63,76 @@ class AdminGameWaiversReaderInteractor:
         logger.warning("admin %s read waivers of game %s", admin.id, game_id)
         game = await self.dao.get_by_id(game_id)  # raises GameNotFound if absent
         return await get_all_played(game, self.dao)
+
+
+@dataclass
+class AdminAddWaiverInteractor:
+    """Sign a player up for a game over the captain's head.
+
+    The way in when the captain is gone, missed the deadline, or simply left
+    somebody out: the panel writes the waiver the team would have written. The
+    player has to be *in* the team right now — a waiver for somebody who plays
+    elsewhere would never show up in the game's roster anyway, since that is
+    read through the current membership.
+
+    Re-signing a player who already has a waiver rewrites it, which is how the
+    panel changes a ``no`` into a ``yes`` without a second endpoint.
+    """
+
+    dao: AdminWaiverEditor
+
+    async def __call__(
+        self,
+        identity: IdentityProvider,
+        game_id: int,
+        team_id: int,
+        player_id: int,
+        played: Played = Played.yes,
+    ) -> waiver_dto.TeamWaivers:
+        admin = await identity.get_superuser()
+        game = await self.dao.get_game_by_id(game_id)
+        team = await self.dao.get_team_by_id(team_id)
+        player = await self.dao.get_player_by_id(player_id)
+        await get_checked_player_on_team(player, team, self.dao)
+        await self.dao.upsert(dto.Waiver(player=player, team=team, game=game, played=played))
+        await self.dao.commit()
+        logger.warning(
+            "admin %s set waiver of player %s in team %s for game %s to %s",
+            admin.id,
+            player.id,
+            team.id,
+            game.id,
+            played.name,
+        )
+        return waiver_dto.TeamWaivers(
+            team=team, waivers=await self.dao.get_team_waivers(game, team)
+        )
+
+
+@dataclass
+class AdminRemoveWaiverInteractor:
+    """Take a player back out of a game's roster.
+
+    The row goes rather than turning into a ``revoked`` one: the captain's own
+    revoke marks a player as barred from re-signing, and an admin undoing a
+    mistake means the opposite — the team may sign them up again.
+    """
+
+    dao: AdminWaiverEditor
+
+    async def __call__(
+        self, identity: IdentityProvider, game_id: int, team_id: int, player_id: int
+    ) -> None:
+        admin = await identity.get_superuser()
+        game = await self.dao.get_game_by_id(game_id)
+        team = await self.dao.get_team_by_id(team_id)
+        player = await self.dao.get_player_by_id(player_id)
+        await self.dao.delete(dto.WaiverQuery(player=player, team=team, game=game))
+        await self.dao.commit()
+        logger.warning(
+            "admin %s removed waiver of player %s in team %s for game %s",
+            admin.id,
+            player.id,
+            team.id,
+            game.id,
+        )

--- a/shvatka/core/waiver/dto.py
+++ b/shvatka/core/waiver/dto.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from shvatka.core.models import dto
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class TeamWaivers:
+    """One team's waivers for one game, with the team they belong to.
+
+    The team travels next to the list rather than being read off the first
+    waiver, so a team whose last waiver was just removed is still answered for.
+    """
+
+    team: dto.Team
+    waivers: list[dto.Waiver]

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -147,9 +147,11 @@ class AdminGameScenarioEditorImpl(GameScenarioEditorImpl):
 class AdminGameStatusChangerImpl(AdminGameStatusChanger):
     """Status-only view of a game for the admin panel.
 
-    Everything it can reach is the games table: read one by id, list them by
-    status, write a status, a number, a planned start. No level, no hint, no
-    file — an admin has no way to a game's content through here.
+    What it reads is the games table alone: one by id, or the list by status.
+    What it writes is a status, a number, a planned start — and, when the admin
+    rewinds a played game, the deletes that undo its run (level times, typed
+    keys, events, timers), each through that table's own dao. No level, no
+    hint, no file — an admin has no way to a game's content through here.
     """
 
     dao: "HolderDao"
@@ -186,6 +188,21 @@ class AdminGameStatusChangerImpl(AdminGameStatusChanger):
 
     async def cancel_start(self, game: dto.Game) -> None:
         await self.dao.game.cancel_start(game)
+
+    async def get_level_time_ids(self, game: dto.Game) -> list[int]:
+        return await self.dao.level_time.get_ids_by_game(game)
+
+    async def delete_timers(self, level_time_ids: Collection[int]) -> None:
+        await self.dao.timers.delete_by_level_times(level_time_ids)
+
+    async def delete_typed_keys(self, game: dto.Game) -> None:
+        await self.dao.key_time.delete_by_game(game)
+
+    async def delete_events(self, game: dto.Game) -> None:
+        await self.dao.events.delete_by_game(game)
+
+    async def delete_level_times(self, game: dto.Game) -> None:
+        await self.dao.level_time.delete_by_game(game)
 
     async def commit(self) -> None:
         await self.dao.commit()

--- a/shvatka/infrastructure/db/dao/complex2/waiver.py
+++ b/shvatka/infrastructure/db/dao/complex2/waiver.py
@@ -1,11 +1,8 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from sqlalchemy.exc import NoResultFound
-
 from shvatka.core.models import dto
 from shvatka.core.models.enums import Played
-from shvatka.core.utils import exceptions
 from shvatka.core.waiver.adapters import (
     AdminGameWaiversReader,
     AdminPollReader,
@@ -103,10 +100,7 @@ class AdminGameWaiversReaderImpl(AdminGameWaiversReader):
     dao: HolderDao
 
     async def get_by_id(self, id_: int) -> dto.Game:
-        try:
-            return await self.dao.game.get_by_id(id_)
-        except NoResultFound as e:
-            raise exceptions.GameNotFound(game_id=id_) from e
+        return await self.dao.game.get_by_id(id_)
 
     async def get_played_teams(self, game: dto.Game) -> Iterable[dto.Team]:
         return await self.dao.waiver.get_played_teams(game)
@@ -122,30 +116,22 @@ class AdminGameWaiversReaderImpl(AdminGameWaiversReader):
 class AdminWaiverEditorImpl(AdminWaiverEditor):
     """Writes one waiver row, with the three entities it needs to name it.
 
-    Each getter goes to its own dao, and a missing row becomes the domain's own
-    "not found" — an admin fixing a roster gets 404 for a game or a player that
-    is not there, not a database error.
+    Each getter goes to its own dao, and each of those already answers a missing
+    row with the domain's own "not found" — so an admin fixing a roster gets a
+    404 for a game, a team or a player that is not there, and nothing has to be
+    translated here.
     """
 
     dao: HolderDao
 
     async def get_game_by_id(self, id_: int) -> dto.Game:
-        try:
-            return await self.dao.game.get_by_id(id_)
-        except NoResultFound as e:
-            raise exceptions.GameNotFound(game_id=id_) from e
+        return await self.dao.game.get_by_id(id_)
 
     async def get_team_by_id(self, id_: int) -> dto.Team:
-        try:
-            return await self.dao.team.get_by_id(id_)
-        except NoResultFound as e:
-            raise exceptions.TeamError(team_id=id_, text=f"team {id_} not found") from e
+        return await self.dao.team.get_by_id(id_)
 
     async def get_player_by_id(self, id_: int) -> dto.Player:
-        try:
-            return await self.dao.player.get_by_id(id_)
-        except NoResultFound as e:
-            raise exceptions.PlayerNotFoundError(player_id=id_) from e
+        return await self.dao.player.get_by_id(id_)
 
     async def get_team_player(self, player: dto.Player) -> dto.TeamPlayer:
         return await self.dao.team_player.get_team_player(player)

--- a/shvatka/infrastructure/db/dao/complex2/waiver.py
+++ b/shvatka/infrastructure/db/dao/complex2/waiver.py
@@ -9,6 +9,7 @@ from shvatka.core.utils import exceptions
 from shvatka.core.waiver.adapters import (
     AdminGameWaiversReader,
     AdminPollReader,
+    AdminWaiverEditor,
     PollDraftsReader,
     PollVoteRemover,
     WaiverVoteAdder,
@@ -115,3 +116,48 @@ class AdminGameWaiversReaderImpl(AdminGameWaiversReader):
 
     async def get_all_by_game(self, game: dto.Game) -> list[dto.Waiver]:
         return await self.dao.waiver.get_all_by_game(game)
+
+
+@dataclass
+class AdminWaiverEditorImpl(AdminWaiverEditor):
+    """Writes one waiver row, with the three entities it needs to name it.
+
+    Each getter goes to its own dao, and a missing row becomes the domain's own
+    "not found" — an admin fixing a roster gets 404 for a game or a player that
+    is not there, not a database error.
+    """
+
+    dao: HolderDao
+
+    async def get_game_by_id(self, id_: int) -> dto.Game:
+        try:
+            return await self.dao.game.get_by_id(id_)
+        except NoResultFound as e:
+            raise exceptions.GameNotFound(game_id=id_) from e
+
+    async def get_team_by_id(self, id_: int) -> dto.Team:
+        try:
+            return await self.dao.team.get_by_id(id_)
+        except NoResultFound as e:
+            raise exceptions.TeamError(team_id=id_, text=f"team {id_} not found") from e
+
+    async def get_player_by_id(self, id_: int) -> dto.Player:
+        try:
+            return await self.dao.player.get_by_id(id_)
+        except NoResultFound as e:
+            raise exceptions.PlayerNotFoundError(player_id=id_) from e
+
+    async def get_team_player(self, player: dto.Player) -> dto.TeamPlayer:
+        return await self.dao.team_player.get_team_player(player)
+
+    async def get_team_waivers(self, game: dto.Game, team: dto.Team) -> list[dto.Waiver]:
+        return await self.dao.waiver.get_all_by_team(game, team)
+
+    async def upsert(self, waiver: dto.Waiver) -> None:
+        await self.dao.waiver.upsert(waiver)
+
+    async def delete(self, waiver: dto.WaiverQuery) -> None:
+        await self.dao.waiver.delete(waiver)
+
+    async def commit(self) -> None:
+        await self.dao.commit()

--- a/shvatka/infrastructure/db/dao/rdb/events.py
+++ b/shvatka/infrastructure/db/dao/rdb/events.py
@@ -1,7 +1,7 @@
 import typing
 from datetime import datetime, tzinfo
 
-from sqlalchemy import ScalarResult, select
+from sqlalchemy import ScalarResult, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -19,6 +19,12 @@ class GameEventDao(BaseDAO[models.GameEvent]):
         self, session: AsyncSession, clock: typing.Callable[[tzinfo], datetime] = datetime.now
     ) -> None:
         super().__init__(models.GameEvent, session, clock=clock)
+
+    async def delete_by_game(self, game: dto.Game) -> None:
+        """Drop the game's events. Keys and timers pointing at them must go first."""
+        await self.session.execute(
+            delete(models.GameEvent).where(models.GameEvent.game_id == game.id)
+        )
 
     async def get_team_level_events(
         self,

--- a/shvatka/infrastructure/db/dao/rdb/game.py
+++ b/shvatka/infrastructure/db/dao/rdb/game.py
@@ -14,7 +14,7 @@ from shvatka.core.models.dto.scn.game import GameScenario
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.game_status import ACTIVE_STATUSES
 from shvatka.core.utils.datetime_utils import tz_utc
-from shvatka.core.utils.exceptions import GameHasAnotherAuthor
+from shvatka.core.utils.exceptions import GameHasAnotherAuthor, GameNotFound
 from shvatka.infrastructure.db import models
 
 from .base import ILIKE_ESCAPE, BaseDAO, ilike_pattern
@@ -78,18 +78,26 @@ class GameDao(BaseDAO[models.Game]):
         return game.to_full_game(levels=levels)
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
-        if not author:
-            options = (
-                joinedload(models.Game.author).options(
-                    joinedload(models.Player.user),
-                ),
-            )
-            game = await self._get_by_id(id_, options)
-            author = game.author.to_dto_user_prefetched()
-        else:
-            game = await self._get_by_id(id_)
-            if author and game.author_id != author.id:
-                raise GameHasAnotherAuthor(game_id=game.id, player=author)
+        """The game, or ``GameNotFound`` — never a bare ``NoResultFound``.
+
+        The domain word for a missing row belongs with the query that can fail
+        to find one, so every caller gets it without wrapping the call.
+        """
+        try:
+            if not author:
+                options = (
+                    joinedload(models.Game.author).options(
+                        joinedload(models.Player.user),
+                    ),
+                )
+                game = await self._get_by_id(id_, options)
+                author = game.author.to_dto_user_prefetched()
+            else:
+                game = await self._get_by_id(id_)
+        except NoResultFound as e:
+            raise GameNotFound(game_id=id_) from e
+        if author and game.author_id != author.id:
+            raise GameHasAnotherAuthor(game_id=game.id, player=author)
         return game.to_dto(author)
 
     async def get_preview(self, id_: int, author: dto.Player | None = None) -> dto.PreviewGame:

--- a/shvatka/infrastructure/db/dao/rdb/level_times.py
+++ b/shvatka/infrastructure/db/dao/rdb/level_times.py
@@ -1,7 +1,7 @@
 import typing
 from datetime import datetime, tzinfo
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -22,6 +22,19 @@ class LevelTimeDao(BaseDAO[models.LevelTime]):
     async def get_by_id(self, id_: int, team: dto.Team, game: dto.Game) -> dto.LevelTime:
         model = await self._get_by_id(id_)
         return model.to_dto(game=game, team=team)
+
+    async def get_ids_by_game(self, game: dto.Game) -> list[int]:
+        """Ids of every level time of the game — what the run hangs off."""
+        result = await self.session.scalars(
+            select(models.LevelTime.id).where(models.LevelTime.game_id == game.id)
+        )
+        return list(result.all())
+
+    async def delete_by_game(self, game: dto.Game) -> None:
+        """Drop the game's level times. Everything referencing them must go first."""
+        await self.session.execute(
+            delete(models.LevelTime).where(models.LevelTime.game_id == game.id)
+        )
 
     async def set_to_level(
         self,

--- a/shvatka/infrastructure/db/dao/rdb/log_keys.py
+++ b/shvatka/infrastructure/db/dao/rdb/log_keys.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import datetime, tzinfo
 
-from sqlalchemy import ScalarResult, select, update
+from sqlalchemy import ScalarResult, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -20,6 +20,10 @@ class KeyTimeDao(BaseDAO[models.KeyTime]):
         self, session: AsyncSession, clock: typing.Callable[[tzinfo], datetime] = datetime.now
     ) -> None:
         super().__init__(models.KeyTime, session, clock=clock)
+
+    async def delete_by_game(self, game: dto.Game) -> None:
+        """Drop every key typed in the game."""
+        await self.session.execute(delete(models.KeyTime).where(models.KeyTime.game_id == game.id))
 
     async def get_correct_typed_keys(
         self,

--- a/shvatka/infrastructure/db/dao/rdb/player.py
+++ b/shvatka/infrastructure/db/dao/rdb/player.py
@@ -30,11 +30,16 @@ class PlayerDao(BaseDAO[models.Player]):
             return await self.create_for_user(user)
 
     async def get_by_id(self, id_: int) -> dto.Player:
-        player = await self._get_by_id(
-            id_,
-            (joinedload(models.Player.user),),
-            populate_existing=True,
-        )
+        """The player, or ``PlayerNotFoundError`` — never a bare ``NoResultFound``,
+        the same way :meth:`get_by_user_id` already answers."""
+        try:
+            player = await self._get_by_id(
+                id_,
+                (joinedload(models.Player.user),),
+                populate_existing=True,
+            )
+        except NoResultFound as e:
+            raise exceptions.PlayerNotFoundError(player_id=id_) from e
         return player.to_dto_user_prefetched()
 
     async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:

--- a/shvatka/infrastructure/db/dao/rdb/team.py
+++ b/shvatka/infrastructure/db/dao/rdb/team.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.interfaces import ORMOption
 
 from shvatka.core.models import dto
-from shvatka.core.utils.exceptions import AnotherTeamInChat, TeamError
+from shvatka.core.utils.exceptions import AnotherTeamInChat, TeamError, TeamNotFound
 from shvatka.infrastructure.db import models
 
 from .base import ILIKE_ESCAPE, BaseDAO, ilike_pattern
@@ -118,11 +118,15 @@ class TeamDao(BaseDAO[models.Team]):
             )
 
     async def get_by_id(self, id_: int) -> dto.Team:
-        team = await self._get_by_id(
-            id_,
-            get_team_options(),
-            populate_existing=True,
-        )
+        """The team, or ``TeamNotFound`` — never a bare ``NoResultFound``."""
+        try:
+            team = await self._get_by_id(
+                id_,
+                get_team_options(),
+                populate_existing=True,
+            )
+        except NoResultFound as e:
+            raise TeamNotFound(team_id=id_) from e
         return team.to_dto_chat_prefetched()
 
     async def get_captained_teams(self, captain: dto.Player) -> list[dto.Team]:

--- a/shvatka/infrastructure/db/dao/rdb/timers.py
+++ b/shvatka/infrastructure/db/dao/rdb/timers.py
@@ -1,6 +1,8 @@
 import typing
+from collections.abc import Collection
 from datetime import datetime, tzinfo
 
+from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shvatka.core.models import dto
@@ -14,6 +16,18 @@ from .base import BaseDAO
 class TimersDAO(BaseDAO[TimerAction]):
     def __init__(self, session: AsyncSession, clock: typing.Callable[[tzinfo], datetime]) -> None:
         super().__init__(TimerAction, session, clock=clock)
+
+    async def delete_by_level_times(self, level_time_ids: Collection[int]) -> None:
+        """Drop the timers of the given level times.
+
+        ``timers_log`` has no game of its own — it hangs off ``levels_times`` —
+        so the caller resolves the ids there and hands them over.
+        """
+        if not level_time_ids:
+            return
+        await self.session.execute(
+            delete(TimerAction).where(TimerAction.level_time_id.in_(level_time_ids))
+        )
 
     async def save_timer(
         self,

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -163,15 +163,18 @@ from shvatka.core.views.team import TeamNotifier
 from shvatka.core.waiver.adapters import (
     AdminGameWaiversReader,
     AdminPollReader,
+    AdminWaiverEditor,
     PollDraftsReader,
     PollVoteRemover,
     WaiverVoteAdder,
     WaiverVoteGetter,
 )
 from shvatka.core.waiver.admin_interactors import (
+    AdminAddWaiverInteractor,
     AdminGameWaiversReaderInteractor,
     AdminPollReaderInteractor,
     AdminRemovePollVoteInteractor,
+    AdminRemoveWaiverInteractor,
 )
 from shvatka.core.waiver.interactors import (
     AddWaiverVoteInteractor,
@@ -218,6 +221,7 @@ from shvatka.infrastructure.db.dao.complex.team import (
 from shvatka.infrastructure.db.dao.complex2.waiver import (
     AdminGameWaiversReaderImpl,
     AdminPollReaderImpl,
+    AdminWaiverEditorImpl,
     PollDraftsReaderImpl,
     PollVoteRemoverImpl,
     WaiverVoteAdderImpl,
@@ -556,6 +560,7 @@ class AdminProvider(Provider):
     admin_poll_reader_dao = provide(AdminPollReaderImpl, provides=AdminPollReader)
     poll_vote_remover_dao = provide(PollVoteRemoverImpl, provides=PollVoteRemover)
     admin_waivers_reader_dao = provide(AdminGameWaiversReaderImpl, provides=AdminGameWaiversReader)
+    admin_waiver_editor_dao = provide(AdminWaiverEditorImpl, provides=AdminWaiverEditor)
 
     @provide
     def admin_email_setter(self, dao: HolderDao) -> AdminEmailSetter:
@@ -614,6 +619,8 @@ class AdminProvider(Provider):
         )
 
     admin_waivers_reader = provide(AdminGameWaiversReaderInteractor)
+    admin_add_waiver = provide(AdminAddWaiverInteractor)
+    admin_remove_waiver = provide(AdminRemoveWaiverInteractor)
 
     @provide
     def admin_search_players(self, dao: HolderDao) -> AdminSearchPlayersInteractor:

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -1445,3 +1445,234 @@ async def test_admin_resend_forbidden_for_non_superuser(
         follow_redirects=True,
     )
     assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Purging a false start. Rewinding a played game leaves its run behind, and the
+# game replayed on the right evening would start with every team already on the
+# level it reached — so the move may take the run with it.
+# ---------------------------------------------------------------------------
+
+
+async def count_runtime(dao: HolderDao) -> tuple[int, int, int, int]:
+    """The four tables a game's run writes into."""
+    return (
+        await dao.level_time.count(),
+        await dao.key_time.count(),
+        await dao.events.count(),
+        await dao.timers.count(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_purges_the_run_when_rewinding_a_played_game(
+    client: AsyncClient,
+    admin_token: Token,
+    finished_game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    level_times, keys, events, _ = await count_runtime(check_dao)
+    assert level_times > 0
+    assert keys > 0
+    assert events > 0
+
+    resp = await client.put(
+        f"/admin/games/{finished_game.id}/status",
+        json={"status": GameStatus.getting_waivers.value, "purge_runtime": True},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success, resp.text
+    assert resp.json()["status"] == GameStatus.getting_waivers.value
+    assert await count_runtime(check_dao) == (0, 0, 0, 0)
+    stored = await check_dao.game.get_by_id(finished_game.id)
+    assert stored.status == GameStatus.getting_waivers
+
+
+@pytest.mark.asyncio
+async def test_the_purge_keeps_the_waivers(
+    client: AsyncClient,
+    admin_token: Token,
+    finished_game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    """Who signed up survives a false start — that is the point of rewinding to
+    ``getting_waivers`` rather than to a draft."""
+    before = await check_dao.waiver.get_all_by_game(finished_game)
+    assert before
+
+    resp = await client.put(
+        f"/admin/games/{finished_game.id}/status",
+        json={"status": GameStatus.getting_waivers.value, "purge_runtime": True},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success, resp.text
+    after = await check_dao.waiver.get_all_by_game(finished_game)
+    assert {(w.player.id, w.team.id, w.played) for w in after} == {
+        (w.player.id, w.team.id, w.played) for w in before
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_status_change_without_the_box_keeps_the_run(
+    client: AsyncClient,
+    admin_token: Token,
+    finished_game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    before = await count_runtime(check_dao)
+    resp = await client.put(
+        f"/admin/games/{finished_game.id}/status",
+        json={"status": GameStatus.getting_waivers.value},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success, resp.text
+    assert await count_runtime(check_dao) == before
+
+
+@pytest.mark.asyncio
+async def test_the_purge_is_refused_on_a_move_that_is_not_a_rewind(
+    client: AsyncClient,
+    admin_token: Token,
+    finished_game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    """Completing a game is not undoing it — the run is its history."""
+    before = await count_runtime(check_dao)
+    resp = await client.put(
+        f"/admin/games/{finished_game.id}/status",
+        json={"status": GameStatus.complete.value, "purge_runtime": True},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "GameStatusError"
+    assert await count_runtime(check_dao) == before
+    stored = await check_dao.game.get_by_id(finished_game.id)
+    assert stored.status == GameStatus.finished
+
+
+@pytest.mark.asyncio
+async def test_purge_forbidden_for_non_superuser(
+    client: AsyncClient,
+    hermione_token: Token,
+    finished_game: dto.FullGame,
+    check_dao: HolderDao,
+):
+    before = await count_runtime(check_dao)
+    resp = await client.put(
+        f"/admin/games/{finished_game.id}/status",
+        json={"status": GameStatus.getting_waivers.value, "purge_runtime": True},
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 403, resp.text
+    assert await count_runtime(check_dao) == before
+
+
+# ---------------------------------------------------------------------------
+# Editing a game's roster from the panel: the way in when the captain is gone,
+# missed the deadline, or simply left somebody out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_adds_a_waiver(
+    client: AsyncClient,
+    admin_token: Token,
+    game_with_waivers: dto.FullGame,
+    gryffindor: dto.Team,
+    ron: dto.Player,
+    check_dao: HolderDao,
+):
+    # ron voted `no` and is not in the roster
+    assert ron.id not in {
+        p.player.id for p in await check_dao.waiver.get_played(game_with_waivers, gryffindor)
+    }
+
+    resp = await client.post(
+        f"/admin/waivers/game/{game_with_waivers.id}/teams/{gryffindor.id}/players",
+        json={"player_id": ron.id},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.is_success, resp.text
+    body = resp.json()
+    assert body["team"]["id"] == gryffindor.id
+    assert body["players"]
+    stored = await check_dao.waiver.get_player_waiver(game_with_waivers, ron, gryffindor)
+    assert stored is not None
+    assert stored.played == Played.yes
+
+
+@pytest.mark.asyncio
+async def test_admin_removes_a_waiver(
+    client: AsyncClient,
+    admin_token: Token,
+    game_with_waivers: dto.FullGame,
+    gryffindor: dto.Team,
+    harry: dto.Player,
+    check_dao: HolderDao,
+):
+    assert await check_dao.waiver.get_player_waiver(game_with_waivers, harry, gryffindor)
+
+    resp = await client.request(
+        "DELETE",
+        f"/admin/waivers/game/{game_with_waivers.id}" f"/teams/{gryffindor.id}/players/{harry.id}",
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 204, resp.text
+    # the row goes rather than becoming `revoked` — the team may sign the
+    # player up again afterwards
+    assert await check_dao.waiver.get_player_waiver(game_with_waivers, harry, gryffindor) is None
+
+
+@pytest.mark.asyncio
+async def test_admin_cant_sign_up_a_player_of_another_team(
+    client: AsyncClient,
+    admin_token: Token,
+    game_with_waivers: dto.FullGame,
+    gryffindor: dto.Team,
+    draco: dto.Player,
+    check_dao: HolderDao,
+):
+    resp = await client.post(
+        f"/admin/waivers/game/{game_with_waivers.id}/teams/{gryffindor.id}/players",
+        json={"player_id": draco.id},
+        cookies=auth_cookies(admin_token),
+        follow_redirects=True,
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["type"] == "PlayerNotInTeam"
+    assert await check_dao.waiver.get_player_waiver(game_with_waivers, draco, gryffindor) is None
+
+
+@pytest.mark.asyncio
+async def test_admin_waiver_edit_forbidden_for_non_superuser(
+    client: AsyncClient,
+    hermione_token: Token,
+    game_with_waivers: dto.FullGame,
+    gryffindor: dto.Team,
+    harry: dto.Player,
+    ron: dto.Player,
+    check_dao: HolderDao,
+):
+    added = await client.post(
+        f"/admin/waivers/game/{game_with_waivers.id}/teams/{gryffindor.id}/players",
+        json={"player_id": ron.id},
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert added.status_code == 403, added.text
+
+    removed = await client.request(
+        "DELETE",
+        f"/admin/waivers/game/{game_with_waivers.id}" f"/teams/{gryffindor.id}/players/{harry.id}",
+        cookies=auth_cookies(hermione_token),
+        follow_redirects=True,
+    )
+    assert removed.status_code == 403, removed.text
+    assert await check_dao.waiver.get_player_waiver(game_with_waivers, harry, gryffindor)

--- a/tests/integration/api_full/test_admin.py
+++ b/tests/integration/api_full/test_admin.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime, timedelta
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy.exc import NoResultFound
 
 from shvatka.api.app.dependencies.auth import AuthProperties
 from shvatka.api.auth.responses import Token
@@ -12,6 +11,7 @@ from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.played import Played
 from shvatka.core.players.player import upsert_player
 from shvatka.core.services.user import upsert_user
+from shvatka.core.utils import exceptions
 from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
@@ -361,7 +361,7 @@ async def test_merge_players(
     assert resp.is_success, resp.text
     assert resp.json()["id"] == primary.id
     assert (await check_dao.player.get_by_id(primary.id)).id == primary.id
-    with pytest.raises(NoResultFound):
+    with pytest.raises(exceptions.PlayerNotFoundError):
         await check_dao.player.get_by_id(secondary.id)
 
 
@@ -505,7 +505,7 @@ async def test_merge_players_with_timeline(
     )
     assert resp.is_success, resp.text
     assert resp.json()["id"] == primary.id
-    with pytest.raises(NoResultFound):
+    with pytest.raises(exceptions.PlayerNotFoundError):
         await check_dao.player.get_by_id(secondary.id)
     history = await check_dao.team_player.get_history(primary)
     assert [tp.team_id for tp in history] == [slytherin.id, gryffindor.id]
@@ -636,7 +636,7 @@ async def test_merge_teams(
     assert resp.is_success, resp.text
     assert resp.json()["id"] == primary.id
     assert (await check_dao.team.get_by_id(primary.id)).id == primary.id
-    with pytest.raises(NoResultFound):
+    with pytest.raises(exceptions.TeamNotFound):
         await check_dao.team.get_by_id(secondary.id)
 
 

--- a/tests/unit/services/admin_game_status_test.py
+++ b/tests/unit/services/admin_game_status_test.py
@@ -55,6 +55,9 @@ class FakeGameDao:
     cancelled: bool = False
     committed: int = 0
     max_number: int = 7
+    level_time_ids: list[int] = field(default_factory=list)
+    purged: list[str] = field(default_factory=list)
+    purged_timers_for: list[int] | None = None
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return self.game
@@ -80,6 +83,22 @@ class FakeGameDao:
 
     async def cancel_start(self, game: dto.Game) -> None:
         self.cancelled = True
+
+    async def get_level_time_ids(self, game: dto.Game) -> list[int]:
+        return list(self.level_time_ids)
+
+    async def delete_timers(self, level_time_ids) -> None:
+        self.purged.append("timers")
+        self.purged_timers_for = list(level_time_ids)
+
+    async def delete_typed_keys(self, game: dto.Game) -> None:
+        self.purged.append("keys")
+
+    async def delete_events(self, game: dto.Game) -> None:
+        self.purged.append("events")
+
+    async def delete_level_times(self, game: dto.Game) -> None:
+        self.purged.append("level_times")
 
     async def commit(self) -> None:
         self.committed += 1
@@ -250,3 +269,90 @@ async def test_only_a_superuser_may_list_the_games():
 
     with pytest.raises(exceptions.NotAuthorizedForAdmin):
         await interactor(MockIdentityProvider(player=make_player(2)))
+
+
+@pytest.mark.asyncio
+async def test_rewinding_a_played_game_can_take_its_run_with_it():
+    """The false start: the game is handed back, and so is every row it wrote.
+
+    Without this the game replayed on the right evening would start with each
+    team already on the level it reached the first time.
+    """
+    game = make_game(GameStatus.started)
+    dao = FakeGameDao(game=game, level_time_ids=[4, 5, 6])
+    interactor = AdminChangeGameStatusInteractor(dao=dao, scheduler=FakeScheduler())
+
+    await interactor(
+        game_id=game.id,
+        status=GameStatus.getting_waivers,
+        identity=admin_identity(),
+        purge_runtime=True,
+    )
+
+    # the order is the one the foreign keys allow, and timers are addressed by
+    # the level time ids read before anything was dropped
+    assert dao.purged == ["timers", "keys", "events", "level_times"]
+    assert dao.purged_timers_for == [4, 5, 6]
+    assert dao.committed == 1
+
+
+@pytest.mark.asyncio
+async def test_a_status_change_leaves_the_run_alone_by_default():
+    game = make_game(GameStatus.finished)
+    dao = FakeGameDao(game=game, level_time_ids=[1])
+    interactor = AdminChangeGameStatusInteractor(dao=dao, scheduler=FakeScheduler())
+
+    await interactor(
+        game_id=game.id,
+        status=GameStatus.getting_waivers,
+        identity=admin_identity(),
+    )
+
+    assert dao.purged == []
+
+
+@pytest.mark.parametrize(
+    ("from_", "to"),
+    [
+        # forward, not back: the game is going on, its history is not the panel's
+        (GameStatus.getting_waivers, GameStatus.started),
+        (GameStatus.started, GameStatus.finished),
+        (GameStatus.finished, GameStatus.complete),
+        # a game that never ran has nothing to sweep, and asking is a mistake
+        (GameStatus.getting_waivers, GameStatus.underconstruction),
+    ],
+)
+@pytest.mark.asyncio
+async def test_the_purge_is_refused_on_a_move_that_is_not_a_rewind(from_, to):
+    game = make_game(from_)
+    dao = FakeGameDao(game=game, level_time_ids=[1])
+    interactor = AdminChangeGameStatusInteractor(dao=dao, scheduler=FakeScheduler())
+
+    with pytest.raises(exceptions.GameStatusError):
+        await interactor(
+            game_id=game.id,
+            status=to,
+            identity=admin_identity(),
+            purge_runtime=True,
+        )
+
+    # refused before anything was written — not the status, not a single row
+    assert game.status == from_
+    assert dao.purged == []
+    assert dao.committed == 0
+
+
+@pytest.mark.asyncio
+async def test_only_a_superuser_may_purge_a_run():
+    game = make_game(GameStatus.finished)
+    dao = FakeGameDao(game=game, level_time_ids=[1])
+    interactor = AdminChangeGameStatusInteractor(dao=dao, scheduler=FakeScheduler())
+
+    with pytest.raises(exceptions.NotAuthorizedForAdmin):
+        await interactor(
+            game_id=game.id,
+            status=GameStatus.getting_waivers,
+            identity=MockIdentityProvider(player=make_player(2)),
+            purge_runtime=True,
+        )
+    assert dao.purged == []

--- a/tests/unit/services/admin_waiver_edit_test.py
+++ b/tests/unit/services/admin_waiver_edit_test.py
@@ -1,0 +1,219 @@
+"""Adding and removing one waiver from the admin panel.
+
+The captain is gone, or missed the deadline, and a team's roster is wrong on
+the evening of the game. These pin down the two ways the panel puts it right —
+and the one thing it refuses: signing up somebody who does not play in the team.
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+
+from shvatka.core.models import dto
+from shvatka.core.models.dto import GameResults
+from shvatka.core.models.enums import GameStatus, Played
+from shvatka.core.utils import exceptions
+from shvatka.core.utils.defaults_constants import DEFAULT_ROLE
+from shvatka.core.waiver.admin_interactors import (
+    AdminAddWaiverInteractor,
+    AdminRemoveWaiverInteractor,
+)
+from tests.fixtures.identity import MockIdentityProvider
+
+
+def make_player(id_: int) -> dto.Player:
+    return dto.Player(id=id_, can_be_author=True, is_dummy=False, username=f"player{id_}")
+
+
+def make_team(id_: int) -> dto.Team:
+    return dto.Team(
+        id=id_,
+        name=f"team{id_}",
+        captain=make_player(1),
+        description=None,
+        is_dummy=False,
+    )
+
+
+def make_game(id_: int = 10) -> dto.Game:
+    return dto.Game(
+        id=id_,
+        author=make_player(1),
+        name="my game",
+        status=GameStatus.getting_waivers,
+        manage_token="token",
+        start_at=None,
+        number=None,
+        results=GameResults(published_chanel_id=None, results_picture_file_id=None, keys_url=None),
+    )
+
+
+@dataclass
+class FakeWaiverDao:
+    """In-memory stand-in for ``AdminWaiverEditor``."""
+
+    game: dto.Game
+    team: dto.Team
+    players: dict[int, dto.Player] = field(default_factory=dict)
+    """every player the panel may name"""
+    team_of: dict[int, int] = field(default_factory=dict)
+    """player id -> the team they currently play in"""
+    waivers: list[dto.Waiver] = field(default_factory=list)
+    committed: int = 0
+
+    async def get_game_by_id(self, id_: int) -> dto.Game:
+        if id_ != self.game.id:
+            raise exceptions.GameNotFound(game_id=id_)
+        return self.game
+
+    async def get_team_by_id(self, id_: int) -> dto.Team:
+        if id_ != self.team.id:
+            raise exceptions.TeamError(team_id=id_)
+        return self.team
+
+    async def get_player_by_id(self, id_: int) -> dto.Player:
+        try:
+            return self.players[id_]
+        except KeyError as e:
+            raise exceptions.PlayerNotFoundError(player_id=id_) from e
+
+    async def get_team_player(self, player: dto.Player) -> dto.TeamPlayer:
+        return dto.TeamPlayer(
+            id=player.id,
+            player_id=player.id,
+            team_id=self.team_of.get(player.id, 0),
+            date_joined=datetime(2025, 4, 1, tzinfo=UTC),
+            date_left=None,
+            role=DEFAULT_ROLE,
+            emoji=None,
+            _can_manage_waivers=False,
+            _can_manage_players=False,
+            _can_change_team_name=False,
+            _can_add_players=False,
+            _can_remove_players=False,
+        )
+
+    async def get_team_waivers(self, game: dto.Game, team: dto.Team) -> list[dto.Waiver]:
+        return [w for w in self.waivers if w.team.id == team.id and w.game.id == game.id]
+
+    async def upsert(self, waiver: dto.Waiver) -> None:
+        for i, existing in enumerate(self.waivers):
+            if existing.player.id == waiver.player.id and existing.team.id == waiver.team.id:
+                self.waivers[i] = waiver
+                return
+        self.waivers.append(waiver)
+
+    async def delete(self, waiver: dto.WaiverQuery) -> None:
+        self.waivers = [
+            w
+            for w in self.waivers
+            if not (w.player.id == waiver.player.id and w.team.id == waiver.team.id)
+        ]
+
+    async def commit(self) -> None:
+        self.committed += 1
+
+
+def admin_identity() -> MockIdentityProvider:
+    admin = make_player(99)
+    return MockIdentityProvider(player=admin, superuser=admin)
+
+
+def make_dao() -> FakeWaiverDao:
+    team = make_team(2)
+    harry = make_player(3)
+    draco = make_player(4)
+    return FakeWaiverDao(
+        game=make_game(),
+        team=team,
+        players={harry.id: harry, draco.id: draco},
+        team_of={harry.id: team.id},
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_signs_a_player_up():
+    dao = make_dao()
+    interactor = AdminAddWaiverInteractor(dao=dao)
+
+    result = await interactor(
+        identity=admin_identity(), game_id=dao.game.id, team_id=dao.team.id, player_id=3
+    )
+
+    assert result.team.id == dao.team.id
+    assert [(w.player.id, w.played) for w in result.waivers] == [(3, Played.yes)]
+    assert dao.committed == 1
+
+
+@pytest.mark.asyncio
+async def test_signing_a_player_up_twice_rewrites_the_waiver():
+    """How the panel turns a `no` into a `yes` without a second endpoint."""
+    dao = make_dao()
+    interactor = AdminAddWaiverInteractor(dao=dao)
+
+    await interactor(
+        identity=admin_identity(),
+        game_id=dao.game.id,
+        team_id=dao.team.id,
+        player_id=3,
+        played=Played.no,
+    )
+    result = await interactor(
+        identity=admin_identity(),
+        game_id=dao.game.id,
+        team_id=dao.team.id,
+        player_id=3,
+        played=Played.yes,
+    )
+
+    assert [(w.player.id, w.played) for w in result.waivers] == [(3, Played.yes)]
+
+
+@pytest.mark.asyncio
+async def test_a_player_of_another_team_cant_be_signed_up():
+    """A waiver for somebody who plays elsewhere would never show in the roster
+    anyway — it is read through the current membership."""
+    dao = make_dao()
+    interactor = AdminAddWaiverInteractor(dao=dao)
+
+    with pytest.raises(exceptions.PlayerNotInTeam):
+        await interactor(
+            identity=admin_identity(), game_id=dao.game.id, team_id=dao.team.id, player_id=4
+        )
+
+    assert dao.waivers == []
+    assert dao.committed == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_removes_a_waiver():
+    dao = make_dao()
+    await AdminAddWaiverInteractor(dao=dao)(
+        identity=admin_identity(), game_id=dao.game.id, team_id=dao.team.id, player_id=3
+    )
+
+    await AdminRemoveWaiverInteractor(dao=dao)(
+        identity=admin_identity(), game_id=dao.game.id, team_id=dao.team.id, player_id=3
+    )
+
+    # the row goes rather than turning into a `revoked` one: unlike the
+    # captain's revoke, an admin undoing a mistake leaves the player free to
+    # be signed up again
+    assert dao.waivers == []
+
+
+@pytest.mark.asyncio
+async def test_only_a_superuser_may_edit_waivers():
+    dao = make_dao()
+    stranger = MockIdentityProvider(player=make_player(2))
+
+    with pytest.raises(exceptions.NotAuthorizedForAdmin):
+        await AdminAddWaiverInteractor(dao=dao)(
+            identity=stranger, game_id=dao.game.id, team_id=dao.team.id, player_id=3
+        )
+    with pytest.raises(exceptions.NotAuthorizedForAdmin):
+        await AdminRemoveWaiverInteractor(dao=dao)(
+            identity=stranger, game_id=dao.game.id, team_id=dao.team.id, player_id=3
+        )
+    assert dao.waivers == []

--- a/tests/unit/services/admin_waiver_edit_test.py
+++ b/tests/unit/services/admin_waiver_edit_test.py
@@ -69,7 +69,7 @@ class FakeWaiverDao:
 
     async def get_team_by_id(self, id_: int) -> dto.Team:
         if id_ != self.team.id:
-            raise exceptions.TeamError(team_id=id_)
+            raise exceptions.TeamNotFound(team_id=id_)
         return self.team
 
     async def get_player_by_id(self, id_: int) -> dto.Player:


### PR DESCRIPTION
## Что это

Игру, начатую по ошибке, админка уже умела вернуть в `getting_waivers` — но ход игры при этом оставался в базе: `levels_times` говорит, что каждая команда стоит там, где её застал ложный старт, а введённые ключи уже зачтены. При повторной игре команды продолжат с середины.

Две вещи, обе про один и тот же вечер:

1. **Чекбокс «очистить ход игры»** на смене статуса — сметает `levels_times`, `log_keys`, `event_log`, `timers_log`.
2. **Добавление и удаление вейверов** из админки — потому что у починенной игры обычно и состав нужно чинить.

Решение описано в SHEP-0013 (`docs/modules/shep/pages/shep-0013-undoing-a-false-start.adoc`).

## Очистка хода игры

`PUT /admin/games/{id}/status` принимает `purge_runtime: bool = false`. Один запрос, одна транзакция: новый статус и удаления коммитятся вместе или не коммитятся вовсе.

Разрешено **только на откате** — сыгранная игра (`started`, `finished`, `complete`) уходит в статус до своего хода (`getting_waivers`, `ready`, `underconstruction`). Проверка — `check_can_purge_game_runtime` в `core/rules/game.py`, и она отказывает **до** любой записи, а не молча игнорирует галочку: на движении вперёд админка не должна уметь стирать историю идущей игры.

Вейверы не трогаются намеренно — в этом весь смысл отката именно в `getting_waivers`.

Удаления идут по одному на таблицу, каждое через DAO своей таблицы (`LevelTimeDao`, `KeyTimeDao`, `GameEventDao`, `TimersDAO`); порядок, который требуют внешние ключи, — дело use case'а. У `timers_log` нет своего `game_id`, поэтому id'шники `levels_times` читаются первыми и передаются в него. Всё это собрано за `GameRuntimePurger` и вложено в существующий `AdminGameStatusChanger`, чтобы у интерактора остался один DAO.

## Вейверы

```
POST   /admin/waivers/game/{id}/teams/{team_id}/players           {player_id, played}
DELETE /admin/waivers/game/{id}/teams/{team_id}/players/{player_id}
```

- Игрок должен быть **в команде прямо сейчас**: ростер читается через живое членство (`WaiverDao.get_played`), так что вейвер для кого-то ещё был бы невидим и неудаляем из панели. Завести игрока в команду — соседняя ручка `POST /admin/teams/{id}/players`.
- Повторная подача переписывает вейвер — так же меняется `played`.
- Удаление сносит строку, а не ставит `revoked`: капитанский отзыв означает «не допущен» (`WaiverDao.is_excluded`), а админ, исправляющий ошибку, имеет в виду обратное.

## Тесты

- `tests/unit/services/admin_game_status_test.py` — порядок удалений, id'шники, отказ на не-откате, отказ не-суперюзеру, и что без флага ход остаётся.
- `tests/unit/services/admin_waiver_edit_test.py` — новый файл: добавление, перезапись, отказ для игрока чужой команды, удаление, права.
- `tests/integration/api_full/test_admin.py` — очистка на `finished_game` (все четыре таблицы в ноль), сохранность вейверов, отказ на `complete`, отказ не-суперюзеру; add/remove вейверов.

Локально: `ruff format`, `ruff check`, `mypy` — чисто; `pytest tests/unit` — 569 passed. Интеграционные не гонял (в контейнере нет docker для testcontainers), их проверит CI.

## Чего здесь нет

- `achievements` не сметается: достижение принадлежит игроку, а не прогону.
- `games.results` тоже остаются — открытый вопрос в конце SHEP.

Фронт: bomzheg/shvatka-ui#... (ветка `claude/admin-panel-status-waivers-hi46ly`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZRiD36HSe5FvBYFRMD16N)_