### PR TITLE
fix(teams): retag every member when the team is renamed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,6 +544,14 @@ with a curated ignore list, mypy overrides) lives in `pyproject.toml`.
   (`FromDishka[...]` on an `@inject`-decorated handler) rather than reaching
   into `manager.middleware_data` / event middleware data. That includes
   `dao: FromDishka[HolderDao]`.
+- **Every change to a team goes through `TeamNotifier`.** Joining, leaving,
+  handing over the captaincy and renaming all raise a `TeamEvent`
+  (`core/views/team.py`), because both edges hang behavior off it: the bot
+  announces the change in the team chat and keeps the players' member tags in
+  public chats in sync (the tag *is* the team name, so a rename has to retag
+  every member), and the web persists a notification and sends a push. A new
+  kind of change means a new event class plus a branch in `BotTeamNotifier` and
+  `WebTeamNotifier` — never a silent write to the teams table.
 - **Superuser rights resolve through `SuperusersResolver`**
   (`core/interfaces/superusers.py`) — the single source for who the configured
   admins are. `IdentityProvider` derives `get_superuser` / `is_superuser` from

--- a/shvatka/api/app/utils/web_input.py
+++ b/shvatka/api/app/utils/web_input.py
@@ -39,6 +39,7 @@ from shvatka.core.views.team import (
     PlayerLeftTeam,
     TeamEvent,
     TeamNotifier,
+    TeamRenamed,
 )
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,8 @@ class WebTeamNotifier(TeamNotifier):
                 await self._notify(event, self._left_spec(event))
             case CaptainChanged():
                 await self._notify(event, self._captain_changed_spec(event))
+            case TeamRenamed():
+                await self._notify(event, self._renamed_spec(event))
             case _:
                 logger.warning("unknown team event %s, no notification persisted", type(event))
 
@@ -397,6 +400,28 @@ class WebTeamNotifier(TeamNotifier):
                 url="/team",
                 tag=f"team-captain-{event.team.id}",
                 data={"kind": "team_captain_changed", "team_id": event.team.id},
+            ),
+        )
+
+    @staticmethod
+    def _renamed_spec(event: TeamRenamed) -> "_TeamNotificationSpec":
+        payload = {
+            "team_id": event.team.id,
+            "team_name": event.new_name,
+            "old_team_name": event.old_name,
+            "player_id": event.actor.id,
+            "player_name": event.actor.name_mention,
+        }
+        return _TeamNotificationSpec(
+            type=NotificationType.team_renamed,
+            severity=NotificationSeverity.normal,
+            payload=payload,
+            push=PushMessage(
+                title=f"{event.new_name}: новое название",
+                body=f"Команда {event.old_name} теперь называется {event.new_name}",
+                url="/team",
+                tag=f"team-renamed-{event.team.id}",
+                data={"kind": "team_renamed", "team_id": event.team.id},
             ),
         )
 

--- a/shvatka/core/interfaces/dal/team.py
+++ b/shvatka/core/interfaces/dal/team.py
@@ -19,7 +19,14 @@ class TeamCreator(TeamJoiner, Protocol):
         raise NotImplementedError
 
 
-class TeamRenamer(Committer, Protocol):
+class TeamByIdGetter(Protocol):
+    async def get_by_id(self, id_: int) -> dto.Team:
+        raise NotImplementedError
+
+
+class TeamRenamer(Committer, TeamByIdGetter, Protocol):
+    """Rename a team and read it back — the new name is what a notifier shows."""
+
     async def rename_team(self, team: dto.Team, new_name: str) -> None:
         raise NotImplementedError
 
@@ -33,11 +40,6 @@ class TeamsGetter(Protocol):
     async def get_teams(
         self, active: bool = True, archive: bool = False, name: str | None = None
     ) -> list[dto.Team]:
-        raise NotImplementedError
-
-
-class TeamByIdGetter(Protocol):
-    async def get_by_id(self, id_: int) -> dto.Team:
         raise NotImplementedError
 
 

--- a/shvatka/core/services/team.py
+++ b/shvatka/core/services/team.py
@@ -27,7 +27,7 @@ from shvatka.core.utils.defaults_constants import CAPTAIN_ROLE, DEFAULT_ROLE
 from shvatka.core.utils.doc_pages import DocPage
 from shvatka.core.utils.exceptions import PermissionsError, SHDataBreach
 from shvatka.core.views.game import GameLogEvent, GameLogType, GameLogWriter
-from shvatka.core.views.team import CaptainChanged, TeamNotifier
+from shvatka.core.views.team import CaptainChanged, TeamNotifier, TeamRenamed
 
 
 async def create_team(
@@ -72,11 +72,20 @@ async def get_by_chat(chat: dto.Chat, dao: TeamGetter) -> dto.Team | None:
 
 
 async def rename_team(
-    team: dto.Team, captain: dto.FullTeamPlayer, new_name: str, dao: TeamRenamer
-):
+    team: dto.Team,
+    captain: dto.FullTeamPlayer,
+    new_name: str,
+    dao: TeamRenamer,
+    notifier: TeamNotifier,
+) -> dto.Team:
     assert_can_change_name(team=team, captain=captain)
+    if new_name == team.name:
+        return team
     await dao.rename_team(team=team, new_name=new_name)
     await dao.commit()
+    renamed = await dao.get_by_id(team.id)
+    await notifier.notify(TeamRenamed(team=renamed, actor=captain.player, old_name=team.name))
+    return renamed
 
 
 async def change_team_desc(

--- a/shvatka/core/teams/interactors.py
+++ b/shvatka/core/teams/interactors.py
@@ -59,7 +59,7 @@ from shvatka.core.utils.exceptions import (
     TeamError,
 )
 from shvatka.core.views.game import GameLogEvent, GameLogType, GameLogWriter
-from shvatka.core.views.team import TeamNotifier
+from shvatka.core.views.team import TeamNotifier, TeamRenamed
 
 
 @dataclass
@@ -324,6 +324,7 @@ class ChangeCaptainInteractor:
 class EditTeamInteractor:
     dao: TeamEditor
     team_player_dao: TeamPlayerGetter
+    notifier: TeamNotifier
 
     async def __call__(
         self,
@@ -335,9 +336,15 @@ class EditTeamInteractor:
         manager = await identity.get_required_player()
         team = await get_team_by_id(team_id, self.dao)
         await check_can_change_name(manager, team, self.team_player_dao)
+        renamed = name is not None and name != team.name
         if name is not None:
             await self.dao.rename_team(team, name)
         if description is not None:
             await self.dao.change_team_desc(team, description)
         await self.dao.commit()
-        return await get_team_by_id(team_id, self.dao)
+        updated = await get_team_by_id(team_id, self.dao)
+        if renamed:
+            await self.notifier.notify(
+                TeamRenamed(team=updated, actor=manager, old_name=team.name)
+            )
+        return updated

--- a/shvatka/core/views/team.py
+++ b/shvatka/core/views/team.py
@@ -54,3 +54,18 @@ class CaptainChanged(TeamEvent):
     @property
     def by_old_captain(self) -> bool:
         return self.old_captain is not None and self.actor.id == self.old_captain.id
+
+
+@dataclass
+class TeamRenamed(TeamEvent):
+    """The team changed its name.
+
+    ``team`` already carries the new name — ``old_name`` is the one it had
+    before, so a notifier can tell what exactly changed.
+    """
+
+    old_name: str
+
+    @property
+    def new_name(self) -> str:
+        return self.team.name

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -508,8 +508,8 @@ class TeamProvider(Provider):
         )
 
     @provide
-    def edit_team(self, dao: HolderDao) -> EditTeamInteractor:
-        return EditTeamInteractor(dao=dao.team, team_player_dao=dao.team_player)
+    def edit_team(self, dao: HolderDao, notifier: TeamNotifier) -> EditTeamInteractor:
+        return EditTeamInteractor(dao=dao.team, team_player_dao=dao.team_player, notifier=notifier)
 
     @provide
     def captained_teams_reader(self, dao: HolderDao) -> CaptainedTeamsReader:

--- a/shvatka/tgbot/dialogs/team_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/team_manage/handlers.py
@@ -47,9 +47,16 @@ async def rename_team_handler(
     new_name: str,
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
+    team_notifier: FromDishka[TeamNotifier],
 ):
     team_player = await get_actual_team_player(identity)
-    await rename_team(team=team_player.team, captain=team_player, new_name=new_name, dao=dao.team)
+    await rename_team(
+        team=team_player.team,
+        captain=team_player,
+        new_name=new_name,
+        dao=dao.team,
+        notifier=team_notifier,
+    )
 
 
 @inject

--- a/shvatka/tgbot/main_factory.py
+++ b/shvatka/tgbot/main_factory.py
@@ -223,6 +223,12 @@ class GameToolsProvider(Provider):
     ) -> HintContentResolver:
         return HintContentResolver(dao=dao.file_info, file_storage=file_storage)
 
+    @provide(scope=Scope.REQUEST)
+    def get_bot_team_notifier(
+        self, bot: Bot, tagger: MemberTagger, dao: HolderDao
+    ) -> BotTeamNotifier:
+        return BotTeamNotifier(bot=bot, tagger=tagger, team_players_dao=dao.team_player)
+
     @provide(scope=Scope.APP)
     def get_bot_rights(self, bot: Bot) -> BotRights:
         return BotRights(bot=bot)
@@ -267,7 +273,6 @@ class GameToolsProvider(Provider):
     message_pinner = provide(MessagePinner, scope=Scope.REQUEST)
     member_tagger = provide(MemberTagger, scope=Scope.REQUEST)
     get_bot_game_view = provide(BotView, scope=Scope.REQUEST)
-    get_bot_team_notifier = provide(BotTeamNotifier, scope=Scope.REQUEST)
     get_bot_org_notifier = provide(BotOrgNotifier, scope=Scope.REQUEST)
     level_bot_view = provide(LevelBotView, scope=Scope.REQUEST, provides=LevelView)
     hint_parser = provide(HintParser, scope=Scope.REQUEST)

--- a/shvatka/tgbot/views/team.py
+++ b/shvatka/tgbot/views/team.py
@@ -7,6 +7,7 @@ from aiogram import Bot
 from aiogram.exceptions import TelegramAPIError
 from aiogram.utils.markdown import html_decoration as hd
 
+from shvatka.core.interfaces.dal.player import TeamPlayersGetter
 from shvatka.core.models import dto
 from shvatka.core.views.team import (
     CaptainChanged,
@@ -14,6 +15,7 @@ from shvatka.core.views.team import (
     PlayerLeftTeam,
     TeamEvent,
     TeamNotifier,
+    TeamRenamed,
 )
 from shvatka.tgbot.services.member_tags import MemberTagger
 from shvatka.tgbot.views.player import get_emoji
@@ -62,6 +64,7 @@ def render_leave_confirmation(
 class BotTeamNotifier(TeamNotifier):
     bot: Bot
     tagger: MemberTagger
+    team_players_dao: TeamPlayersGetter
 
     async def notify(self, event: TeamEvent) -> None:
         await self._retag(event)
@@ -74,6 +77,11 @@ class BotTeamNotifier(TeamNotifier):
                 await self.tagger.sync(event.invited, event.team)
             case PlayerLeftTeam():
                 await self.tagger.sync(event.removed, None)
+            case TeamRenamed():
+                # the tag is the team name, so every member of the team carries
+                # the old one until it is set again
+                for team_player in await self.team_players_dao.get_players(event.team):
+                    await self.tagger.sync(team_player.player, event.team)
 
     async def _send_to_team_chat(self, event: TeamEvent) -> None:
         if not event.team.has_chat():
@@ -109,5 +117,10 @@ class BotTeamNotifier(TeamNotifier):
                 if not event.by_old_captain:
                     text += f" Капитанство передал {hd.quote(event.actor.name_mention)}."
                 return text
+            case TeamRenamed():
+                return (
+                    f"🚩Команда {hd.quote(event.old_name)} теперь называется "
+                    f"{hd.quote(event.new_name)}."
+                )
             case _:
                 return None

--- a/tests/integration/api_full/test_notifications.py
+++ b/tests/integration/api_full/test_notifications.py
@@ -10,9 +10,11 @@ from httpx import AsyncClient
 from shvatka.api.app.dependencies.auth import AuthProperties
 from shvatka.api.auth.responses import Token
 from shvatka.core.models import dto
+from shvatka.core.players.player import join_team
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.chat_constants import create_tg_chat
+from tests.mocks.team_notifier import TeamNotifierMock
 
 
 def auth_cookies(token: Token) -> dict[str, str]:
@@ -27,6 +29,38 @@ def harry_token(harry: dto.Player, auth: AuthProperties) -> Token:
 @pytest.fixture
 def hermione_token(hermione: dto.Player, auth: AuthProperties) -> Token:
     return auth.create_user_token(hermione)
+
+
+@pytest.mark.asyncio
+async def test_feed_after_team_rename(
+    client: AsyncClient,
+    harry: dto.Player,
+    hermione: dto.Player,
+    gryffindor: dto.Team,
+    harry_token: Token,
+    hermione_token: Token,
+    dao: HolderDao,
+):
+    await join_team(hermione, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
+    old_name = gryffindor.name
+
+    edit = await client.put(
+        f"/teams/{gryffindor.id}",
+        cookies=auth_cookies(harry_token),
+        json={"name": "New Gryffindor"},
+        follow_redirects=True,
+    )
+    assert edit.is_success
+
+    resp = await client.get(
+        "/notifications", cookies=auth_cookies(hermione_token), follow_redirects=True
+    )
+    assert resp.is_success
+    resp.read()
+    items = resp.json()["items"]
+    renamed = next(n for n in items if n["type"] == "team_renamed")
+    assert renamed["payload"]["old_team_name"] == old_name
+    assert renamed["payload"]["team_name"] == "New Gryffindor"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/bot_full/test_member_tags.py
+++ b/tests/integration/bot_full/test_member_tags.py
@@ -9,7 +9,8 @@ from aiogram.client.session.base import BaseSession
 from dishka import AsyncContainer
 
 from shvatka.core.models import dto
-from shvatka.core.players.player import join_team, leave
+from shvatka.core.players.player import get_full_team_player, join_team, leave
+from shvatka.core.services.team import rename_team
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.services.bot_rights import BotRights, ChatRights
@@ -30,7 +31,7 @@ def tags(bot_session: BaseSession) -> list:
 
 
 @pytest_asyncio.fixture
-async def notifier(dishka: AsyncContainer, bot: Bot):
+async def notifier(dishka: AsyncContainer, bot: Bot, dao: HolderDao):
     config = await dishka.get(BotConfig)
     rights = await dishka.get(BotRights)
     # rights are cached, so the tagger doesn't ask telegram about them
@@ -43,6 +44,7 @@ async def notifier(dishka: AsyncContainer, bot: Bot):
             config=dataclasses.replace(config, public_chats=[PUBLIC_CHAT]),
             bot_rights=rights,
         ),
+        team_players_dao=dao.team_player,
     )
 
 
@@ -68,3 +70,22 @@ async def test_tag_set_and_cleared_on_team_ops(
     _, cleared = tags(bot_session)
     assert hermione.get_chat_id() == cleared.user_id
     assert cleared.tag is None
+
+
+@pytest.mark.asyncio
+async def test_tags_follow_team_rename(
+    harry: dto.Player,
+    hermione: dto.Player,
+    gryffindor: dto.Team,
+    dao: HolderDao,
+    notifier: BotTeamNotifier,
+    bot_session: BaseSession,
+):
+    await join_team(hermione, gryffindor, harry, dao.team_player, notifier=notifier)
+    captain = await get_full_team_player(harry, gryffindor, dao.team_player)
+
+    await rename_team(gryffindor, captain, "Гриффиндор", dao.team, notifier)
+
+    _, *retagged = tags(bot_session)
+    assert {harry.get_chat_id(), hermione.get_chat_id()} == {tag.user_id for tag in retagged}
+    assert {render_tag("Гриффиндор")} == {tag.tag for tag in retagged}

--- a/tests/integration/test_team.py
+++ b/tests/integration/test_team.py
@@ -4,8 +4,10 @@ from shvatka.core.models import dto
 from shvatka.core.players.player import get_full_team_player
 from shvatka.core.services.game import complete_game
 from shvatka.core.services.team import change_team_desc, get_played_games, get_teams, rename_team
+from shvatka.core.views.team import TeamRenamed
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.chat_constants import GRYFFINDOR_CHAT_DTO
+from tests.mocks.team_notifier import TeamNotifierMock
 
 
 @pytest.mark.asyncio
@@ -14,9 +16,15 @@ async def test_rename(
 ):
     assert GRYFFINDOR_CHAT_DTO.title == gryffindor.name
     team_player = await get_full_team_player(player=harry, team=gryffindor, dao=dao.team_player)
-    await rename_team(gryffindor, team_player, "Гриффиндор", dao.team)
+    notifier = TeamNotifierMock()
+    renamed = await rename_team(gryffindor, team_player, "Гриффиндор", dao.team, notifier)
+    assert renamed.name == "Гриффиндор"
     actual_team = await check_dao.team.get_by_id(id_=gryffindor.id)
     assert actual_team.name == "Гриффиндор"
+    (event,) = notifier.events
+    assert isinstance(event, TeamRenamed)
+    assert event.old_name == GRYFFINDOR_CHAT_DTO.title
+    assert event.new_name == "Гриффиндор"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/team_notifier_test.py
+++ b/tests/unit/services/team_notifier_test.py
@@ -1,8 +1,15 @@
+from datetime import UTC, datetime
+
 import pytest
 
 from shvatka.core.models import dto
 from shvatka.core.models.enums.chat_type import ChatType
-from shvatka.core.views.team import CaptainChanged, PlayerJoinedTeam, PlayerLeftTeam
+from shvatka.core.views.team import (
+    CaptainChanged,
+    PlayerJoinedTeam,
+    PlayerLeftTeam,
+    TeamRenamed,
+)
 from shvatka.tgbot.views.team import BotTeamNotifier, render_leave_confirmation
 
 
@@ -112,6 +119,33 @@ def test_captain_changed_for_team_without_captain() -> None:
     assert "ron" in (BotTeamNotifier._render(event) or "")
 
 
+def _team_player(player: dto.Player, team: dto.Team) -> dto.FullTeamPlayer:
+    return dto.FullTeamPlayer(
+        id=player.id * 10,
+        player_id=player.id,
+        team_id=team.id,
+        date_joined=datetime(2025, 4, 12, 16, 0, tzinfo=UTC),
+        date_left=None,
+        role="боец",
+        emoji=None,
+        _can_manage_waivers=False,
+        _can_manage_players=False,
+        _can_change_team_name=False,
+        _can_add_players=False,
+        _can_remove_players=False,
+        player=player,
+        team=team,
+    )
+
+
+class _PlayersDao:
+    def __init__(self, players: list[dto.FullTeamPlayer]) -> None:
+        self.players = players
+
+    async def get_players(self, team: dto.Team) -> list[dto.FullTeamPlayer]:
+        return self.players
+
+
 class _Tagger:
     def __init__(self) -> None:
         self.synced: list = []
@@ -129,7 +163,7 @@ async def test_no_notify_without_chat() -> None:
             sent.append(kwargs)
 
     ron = _player(2, "ron")
-    notifier = BotTeamNotifier(bot=_Bot(), tagger=_Tagger())
+    notifier = BotTeamNotifier(bot=_Bot(), tagger=_Tagger(), team_players_dao=_PlayersDao([]))
     await notifier.notify(PlayerLeftTeam(team=_team(with_chat=False), actor=ron, removed=ron))
     assert sent == []
 
@@ -139,10 +173,36 @@ async def test_tag_synced_even_without_team_chat() -> None:
     # the tag lives in a public chat, the team chat has nothing to do with it
     ron = _player(2, "ron")
     tagger = _Tagger()
-    notifier = BotTeamNotifier(bot=None, tagger=tagger)
+    notifier = BotTeamNotifier(bot=None, tagger=tagger, team_players_dao=_PlayersDao([]))
     team = _team(with_chat=False)
 
     await notifier.notify(PlayerJoinedTeam(team=team, actor=ron, invited=ron))
     await notifier.notify(PlayerLeftTeam(team=team, actor=ron, removed=ron))
 
     assert [(ron, team), (ron, None)] == tagger.synced
+
+
+@pytest.mark.asyncio
+async def test_rename_retags_every_member() -> None:
+    # the tag is the team name, so a rename leaves the whole team mistagged
+    harry = _player(1, "harry")
+    ron = _player(2, "ron")
+    team = _team(harry, with_chat=False)
+    tagger = _Tagger()
+    notifier = BotTeamNotifier(
+        bot=None,
+        tagger=tagger,
+        team_players_dao=_PlayersDao([_team_player(harry, team), _team_player(ron, team)]),
+    )
+
+    await notifier.notify(TeamRenamed(team=team, actor=harry, old_name="Gryffindor old"))
+
+    assert [(harry, team), (ron, team)] == tagger.synced
+
+
+def test_rename_announced_in_team_chat() -> None:
+    harry = _player(1, "harry")
+    event = TeamRenamed(team=_team(harry), actor=harry, old_name="Gryffindor old")
+    text = BotTeamNotifier._render(event) or ""
+    assert "Gryffindor old" in text
+    assert "Gryffindor" in text


### PR DESCRIPTION
Fixes #385.

## What was wrong

A member tag in a public chat *is* the team name (`MemberTagger.sync` renders it
from `team.name`). Tags were set on join and cleared on leave, but nothing
touched them when the team itself was renamed — so the whole team kept wearing
the old name until each player happened to re-join a chat.

## What changed

Renaming now raises a `TeamRenamed` event through `TeamNotifier`, the way joins,
leaves and captaincy handovers already do:

- `core/views/team.py` — new `TeamRenamed(TeamEvent)` carrying `old_name`; the
  event's `team` already has the new name.
- `core/services/team.rename_team` and `EditTeamInteractor` read the team back
  after the commit and notify. A rename to the same name changes nothing and
  raises nothing.
- `BotTeamNotifier` retags every current member of the team, and announces the
  new name in the team chat.
- `WebTeamNotifier` persists the `team_renamed` notification (the enum member
  existed but nothing produced it) and sends the matching push, so the event no
  longer falls into the "unknown team event" branch.
- `TeamRenamer` gained `get_by_id` so the service can read the renamed team back
  (same pattern as `change_captain`); `BotTeamNotifier` gained a
  `TeamPlayersGetter` to list who to retag, like `WebTeamNotifier` already has.

Both rename paths emit it: the captain's bridge dialog in the bot and
`PUT /teams/{id}` in the api.

`AGENTS.md` records the rule: a change to a team goes through `TeamNotifier`,
because both edges hang behavior off it.

## Tests

- unit: rename retags every member; the rename is announced in the team chat.
- integration (bot): `test_tags_follow_team_rename` asserts `setChatMemberTag`
  for both members with the new name.
- integration (api): a rename via `PUT /teams/{id}` shows up as a
  `team_renamed` notification in a teammate's feed, with both names in the
  payload.
- Existing `test_rename` now also asserts the emitted event.

Ran locally: `ruff format`, `ruff check`, `mypy .`, `pytest tests/unit` (572
passed). Integration tests need Docker, which this environment lacks — left to
CI.

## Not covered

Merging one team into another moves players between teams and leaves their tags
stale in the same way; that path still has no event. Worth a follow-up issue.

Bot behavior changed, so it wants a manual pass from the **Bot regression pass**
template (rename in the captain's bridge, then check the tag in a public chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZFG2VSdTNEYfpf6KVb2sd

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZFG2VSdTNEYfpf6KVb2sd)_