### PR TITLE
fix(push): keep only the last level up and hint in the tray

### DIFF
--- a/shvatka/api/app/utils/web_input.py
+++ b/shvatka/api/app/utils/web_input.py
@@ -50,6 +50,14 @@ class ApiInput(InputContainer):
 
 
 class WebGameView(GameView):
+    """A push tag is the notification's identity in the phone's tray: showing a
+    push with a tag that is already there replaces it instead of adding a line.
+    So an in-game tag names *what* happened to *which team* and never the level
+    or the hint number — the tray keeps the last level up and the last hint, not
+    the whole run. The ui closes the ones a newer push makes pointless (the
+    hints of a level the team has left), see ``push-sw.js``.
+    """
+
     def __init__(self, push_sender: WebPushSender, current_game: CurrentGameProvider) -> None:
         self.push_sender = push_sender
         self.current_game = current_game
@@ -93,7 +101,7 @@ class WebGameView(GameView):
                 title="Новый уровень",
                 body=f"{team.name}: открыт уровень {self._level_label(level)}",
                 url="/games/running",
-                tag=f"level-{team.id}-{level.db_id}",
+                tag=f"level-{team.id}",
                 data={"kind": "puzzle", "team_id": team.id, "level_id": level.db_id},
             ),
         )
@@ -110,7 +118,7 @@ class WebGameView(GameView):
                     else f"{team.name}: подсказка #{hint_number}"
                 ),
                 url="/games/running",
-                tag=f"hint-{team.id}-{level.db_id}-{hint_number}",
+                tag=f"hint-{team.id}",
                 data={
                     "kind": "hint",
                     "team_id": team.id,
@@ -151,7 +159,7 @@ class WebGameView(GameView):
                 title="Событие на уровне",
                 body=f"{team.name}: сработал эффект",
                 url="/games/running",
-                tag=f"effects-{team.id}-{effects.id}",
+                tag=f"effects-{team.id}",
                 data={"kind": "effects", "team_id": team.id, "effects_id": str(effects.id)},
             ),
         )
@@ -215,6 +223,7 @@ class WebOrgNotifier(OrgNotifier):
         )
 
     async def _notify_level_up(self, event: LevelUp) -> None:
+        # per team, not per level: an org watching a team wants where it is now
         await self._notify_orgs(
             event,
             PushMessage(
@@ -222,7 +231,7 @@ class WebOrgNotifier(OrgNotifier):
                 body=f"Команда {event.team.name} перешла на уровень "
                 f"{self._level_label(event.new_level)}",
                 url="/games/running",
-                tag=f"org-level-up-{event.team.id}-{event.new_level.db_id}",
+                tag=f"org-level-up-{event.team.id}",
                 data={
                     "kind": "org_level_up",
                     "team_id": event.team.id,

--- a/tests/unit/services/web_game_view_test.py
+++ b/tests/unit/services/web_game_view_test.py
@@ -1,0 +1,106 @@
+from collections.abc import Collection
+from types import SimpleNamespace
+
+import pytest
+
+from shvatka.api.app.utils.push import PushMessage
+from shvatka.api.app.utils.web_input import WebGameView
+from shvatka.core.views.game import SendHint, SendPuzzle
+
+
+class FakePushSender:
+    def __init__(self) -> None:
+        self.calls: list[tuple[set[int], PushMessage]] = []
+
+    async def send_to_players(self, player_ids: Collection[int], message: PushMessage) -> None:
+        self.calls.append((set(player_ids), message))
+
+
+class FakeCurrentGame:
+    def __init__(self, player_ids: Collection[int]) -> None:
+        self.player_ids = player_ids
+
+    async def get_team_waivers_by_team(self, team) -> list:
+        return [SimpleNamespace(player=SimpleNamespace(id=id_)) for id_ in self.player_ids]
+
+
+def _view(*player_ids: int) -> tuple[WebGameView, FakePushSender]:
+    sender = FakePushSender()
+    return WebGameView(sender, FakeCurrentGame(player_ids)), sender
+
+
+def _team():
+    return SimpleNamespace(id=7, name="Gryffindor")
+
+
+def _level(db_id: int, number_in_game: int | None = 0, last_hint: int = 10):
+    return SimpleNamespace(
+        db_id=db_id,
+        name_id=f"lvl-{db_id}",
+        number_in_game=number_in_game,
+        is_last_hint=lambda number: number == last_hint,
+    )
+
+
+@pytest.mark.asyncio
+async def test_puzzle_pushed_to_voted_players_only() -> None:
+    view, sender = _view(1, 2)
+
+    await view.show([SendPuzzle(team=_team(), level=_level(3))])
+
+    player_ids, message = sender.calls[0]
+    assert player_ids == {1, 2}
+    assert "Gryffindor" in message.body
+    assert message.data is not None
+    assert message.data["kind"] == "puzzle"
+
+
+@pytest.mark.asyncio
+async def test_level_up_replaces_the_previous_one() -> None:
+    """Moving to level 4 must hide the push about moving to level 3."""
+    view, sender = _view(1)
+    team = _team()
+
+    await view.show(
+        [
+            SendPuzzle(team=team, level=_level(3, number_in_game=2)),
+            SendPuzzle(team=team, level=_level(4, number_in_game=3)),
+        ]
+    )
+
+    first, second = (message.tag for _, message in sender.calls)
+    assert first == second == "level-7"
+
+
+@pytest.mark.asyncio
+async def test_every_hint_of_a_team_shares_one_tag() -> None:
+    """The tray keeps the last hint, not the whole history of them."""
+    view, sender = _view(1)
+    team = _team()
+    level = _level(3)
+
+    await view.show(
+        [
+            SendHint(team=team, hint_number=1, level=level),
+            SendHint(team=team, hint_number=2, level=level),
+            SendHint(team=team, hint_number=10, level=level),
+        ]
+    )
+
+    assert {"hint-7"} == {message.tag for _, message in sender.calls}
+    *_, (_, last) = sender.calls
+    assert last.title == "Последняя подсказка"
+
+
+@pytest.mark.asyncio
+async def test_a_hint_never_replaces_a_level_up() -> None:
+    view, sender = _view(1)
+    team = _team()
+    level = _level(3)
+
+    await view.show(
+        [SendPuzzle(team=team, level=level), SendHint(team=team, hint_number=1, level=level)]
+    )
+
+    puzzle, hint = (message.tag for _, message in sender.calls)
+    assert puzzle != hint


### PR DESCRIPTION
Closes #272.

## Что не так

Тег пуша — это его идентичность в шторке телефона: пуш с уже показанным тегом
заменяет старый, а с новым — добавляет ещё одну строку. Игровые теги несли в
себе id уровня и номер подсказки:

```
level-{team}-{level_id}      hint-{team}-{level_id}-{hint_number}
effects-{team}-{effects_id}  org-level-up-{team}-{level_id}
```

Поэтому в шторке копилась вся история игры: каждая подсказка отдельной строкой,
а пуш «переход на 3» оставался рядом с «переход на 4».

## Что сделано

Игровой тег теперь называет только *что* произошло и *с какой командой* —
`level-{team}`, `hint-{team}`, `effects-{team}`, `org-level-up-{team}`. Тексты,
`data` и адресаты не изменились: меняется только то, сколько строк остаётся в
шторке — последний переход и последняя подсказка вместо всего забега. Для орга
то же самое: он смотрит, где команда сейчас, а не как она туда шла.

Подсказки прошлого уровня закрывает уже ui — парный PR в `shvatka-ui`
(`push-sw.js` закрывает уведомления, которые новый пуш делает бессмысленными).

## Тесты

Новый `tests/unit/services/web_game_view_test.py`: переход на следующий уровень
переиспользует тег предыдущего, все подсказки команды делят один тег, подсказка
не вытесняет переход. `pytest tests/unit` — 596 passed, `ruff` и `mypy` чистые.

Локальный прогон был на 3.13: в контейнере доступен только CPython 3.14.0rc2, на
котором pydantic падает на `_eval_type(prefer_fwd_module=...)`. Зависимости те
же (`uv export`), но 3.14 проверит CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VH1Td89suxJcyU9y3haS42

---
_Generated by [Claude Code](https://claude.ai/code/session_01VH1Td89suxJcyU9y3haS42)_