### PR TITLE
feat(push): deliver in-game pushes now, keep team news for a day

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,14 @@ overrides) lives in `pyproject.toml`.
   answers the user and restarts them in the main menu. Use
   `get_actual_team_player(identity)` / `get_actual_teammate`, or better, resolve
   the state in the getter on every render (see `my_team_getter`). SHEP-0005.
+- **A web push says how urgently it wants to be delivered, and for how long.**
+  `PushMessage` carries `urgency` and `ttl`; below `PushUrgency.high` a push
+  service is free to hold the message until the device wakes up on its own,
+  which is minutes on a backgrounded android. In-game pushes (`WebGameView`) are
+  `high` and die in ten minutes — late is worse than never for a hint. Team news
+  (`WebTeamNotifier`) keeps for a day at `normal`. Orgs have not been looked at
+  yet and take the defaults. Severity does **not** drive urgency: the audience
+  does.
 - **Every change to a team goes through `TeamNotifier`.** Joining, leaving,
   handing over the captaincy and renaming all raise a `TeamEvent`
   (`core/views/team.py`); both edges hang behavior off it (chat announcement and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,14 +332,6 @@ overrides) lives in `pyproject.toml`.
   answers the user and restarts them in the main menu. Use
   `get_actual_team_player(identity)` / `get_actual_teammate`, or better, resolve
   the state in the getter on every render (see `my_team_getter`). SHEP-0005.
-- **A web push says how urgently it wants to be delivered, and for how long.**
-  `PushMessage` carries `urgency` and `ttl`; below `PushUrgency.high` a push
-  service is free to hold the message until the device wakes up on its own,
-  which is minutes on a backgrounded android. In-game pushes (`WebGameView`) are
-  `high` and die in ten minutes — late is worse than never for a hint. Team news
-  (`WebTeamNotifier`) keeps for a day at `normal`. Orgs have not been looked at
-  yet and take the defaults. Severity does **not** drive urgency: the audience
-  does.
 - **Every change to a team goes through `TeamNotifier`.** Joining, leaving,
   handing over the captaincy and renaming all raise a `TeamEvent`
   (`core/views/team.py`); both edges hang behavior off it (chat announcement and

--- a/context.md
+++ b/context.md
@@ -216,8 +216,6 @@ game and only then fall back to author or organizer rights.
 | **Notification** | Уведомление | One inbox item for exactly one recipient — the record that something happened. A request produces notifications; a notification is not itself actionable. | `notifications.dto.Notification`, `enums.NotificationType` |
 | **Severity** | Важность | How much a notification matters (`low` / `normal` / `important`); drives UI emphasis in the feed. | `enums.NotificationSeverity` |
 | **Push subscription** | Подписка на пуши | A browser endpoint registered for web push. | `push_subscriptions` table |
-| **Push urgency** | Срочность пуша | RFC 8030 delivery priority. Anything below `high` lets the push service hold the message until the device wakes on its own; in-game pushes are `high`, everything else `normal`. | `PushUrgency` |
-| **Push TTL** | Время жизни пуша | How long the push service may keep trying before dropping the message. In-game news dies in ten minutes, team news keeps for a day. | `IN_GAME_TTL`, `TEAM_TTL` |
 
 ## Search
 

--- a/context.md
+++ b/context.md
@@ -214,8 +214,10 @@ game and only then fall back to author or organizer rights.
 | **Action request** | Заявка | A user-to-user request that needs someone's decision, with a lifecycle: `pending` → `accepted` / `declined` / `cancelled` / `expired`. *Заявка* is the term — plain *запрос* is too generic, though it reads fine mid-sentence ("ваш запрос на вступление в команду"). | `notifications.dto.ActionRequest`, `enums.RequestStatus` |
 | **Request type** | Тип запроса | `team_join_invite`, `team_join_request`, `org_invite`, `team_merge`, `player_merge`, `promotion`. | `enums.RequestType` |
 | **Notification** | Уведомление | One inbox item for exactly one recipient — the record that something happened. A request produces notifications; a notification is not itself actionable. | `notifications.dto.Notification`, `enums.NotificationType` |
-| **Severity** | Важность | How much a notification matters (`low` / `normal` / `important`); drives UI emphasis and push urgency. | `enums.NotificationSeverity` |
+| **Severity** | Важность | How much a notification matters (`low` / `normal` / `important`); drives UI emphasis in the feed. | `enums.NotificationSeverity` |
 | **Push subscription** | Подписка на пуши | A browser endpoint registered for web push. | `push_subscriptions` table |
+| **Push urgency** | Срочность пуша | RFC 8030 delivery priority. Anything below `high` lets the push service hold the message until the device wakes on its own; in-game pushes are `high`, everything else `normal`. | `PushUrgency` |
+| **Push TTL** | Время жизни пуша | How long the push service may keep trying before dropping the message. In-game news dies in ten minutes, team news keeps for a day. | `IN_GAME_TTL`, `TEAM_TTL` |
 
 ## Search
 

--- a/shvatka/api/app/utils/push.py
+++ b/shvatka/api/app/utils/push.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import enum
 import json
 import logging
 import typing
@@ -17,6 +18,29 @@ from shvatka.infrastructure.db.models.push_subscription import PushSubscription
 logger = logging.getLogger(__name__)
 
 
+class PushUrgency(enum.StrEnum):
+    """RFC 8030 urgency: how much battery the push is worth to the receiver.
+
+    Anything below ``high`` is the sender's permission to hold the message until
+    the device wakes up on its own, which android does readily — a backgrounded
+    browser in doze gets its pushes at the next maintenance window, minutes to
+    tens of minutes later. Only ``high`` asks for delivery now.
+    """
+
+    very_low = "very-low"
+    low = "low"
+    normal = "normal"
+    high = "high"
+
+
+# In-game news goes stale in minutes: a hint delivered after the level is over is
+# noise, so let the push service drop it rather than wake the phone for it.
+IN_GAME_TTL = 10 * 60
+# Team news keeps: whoever joined is still on the team tomorrow. A phone that was
+# off all evening should get it when it comes back.
+TEAM_TTL = 24 * 60 * 60
+
+
 @dataclass(frozen=True, slots=True)
 class PushMessage:
     title: str
@@ -24,6 +48,10 @@ class PushMessage:
     url: str = "/"
     tag: str | None = None
     data: dict[str, Any] | None = None
+    # How hard the push service should try, as opposed to what the push says.
+    # Never part of ``to_json``: the browser is not told any of this.
+    urgency: PushUrgency = PushUrgency.normal
+    ttl: int = IN_GAME_TTL
 
     def to_json(self) -> str:
         payload: dict[str, Any] = {
@@ -130,5 +158,6 @@ class WebPushSender:
             data=message.to_json(),
             vapid_private_key=self.config.vapid_private_key,
             vapid_claims={"sub": self.config.vapid_claims_sub},
-            ttl=10 * 60,
+            ttl=message.ttl,
+            headers={"Urgency": message.urgency.value},
         )

--- a/shvatka/api/app/utils/web_input.py
+++ b/shvatka/api/app/utils/web_input.py
@@ -3,7 +3,7 @@ import typing
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
-from shvatka.api.app.utils.push import PushMessage, WebPushSender
+from shvatka.api.app.utils.push import TEAM_TTL, PushMessage, PushUrgency, WebPushSender
 from shvatka.core.interfaces.current_game import CurrentGameProvider
 from shvatka.core.interfaces.dal.game_play import GamePreparer
 from shvatka.core.interfaces.dal.player import TeamPlayersGetter
@@ -56,6 +56,11 @@ class WebGameView(GameView):
     or the hint number — the tray keeps the last level up and the last hint, not
     the whole run. The ui closes the ones a newer push makes pointless (the
     hints of a level the team has left), see ``push-sw.js``.
+
+    Every push here is ``high`` urgency. A game is played with the phone in a
+    pocket and the browser in the background, which is exactly the state android
+    holds normal-urgency pushes in until it wakes up on its own; a hint that
+    arrives at the next doze maintenance window arrives after the level.
     """
 
     def __init__(self, push_sender: WebPushSender, current_game: CurrentGameProvider) -> None:
@@ -103,6 +108,7 @@ class WebGameView(GameView):
                 url="/games/running",
                 tag=f"level-{team.id}",
                 data={"kind": "puzzle", "team_id": team.id, "level_id": level.db_id},
+                urgency=PushUrgency.high,
             ),
         )
 
@@ -125,6 +131,7 @@ class WebGameView(GameView):
                     "level_id": level.db_id,
                     "hint_number": hint_number,
                 },
+                urgency=PushUrgency.high,
             ),
         )
 
@@ -137,6 +144,7 @@ class WebGameView(GameView):
                 url="/games/running",
                 tag=f"finish-{team.id}",
                 data={"kind": "team_finished", "team_id": team.id},
+                urgency=PushUrgency.high,
             ),
         )
 
@@ -149,6 +157,7 @@ class WebGameView(GameView):
                 url="/games/running",
                 tag="game-finished",
                 data={"kind": "game_finished", "team_id": team.id},
+                urgency=PushUrgency.high,
             ),
         )
 
@@ -161,6 +170,7 @@ class WebGameView(GameView):
                 url="/games/running",
                 tag=f"effects-{team.id}",
                 data={"kind": "effects", "team_id": team.id, "effects_id": str(effects.id)},
+                urgency=PushUrgency.high,
             ),
         )
 
@@ -300,6 +310,12 @@ class WebOrgNotifier(OrgNotifier):
 
 
 class WebTeamNotifier(TeamNotifier):
+    """Team news keeps, so its pushes get a day of ttl instead of the in-game ten
+    minutes: who joined, who left and who is captain now is still true tomorrow,
+    and a phone that spent the evening off should be told when it comes back.
+    Urgency stays ``normal`` — none of this is worth waking a sleeping device.
+    """
+
     def __init__(
         self,
         notification_dao: NotificationWriter,
@@ -363,6 +379,7 @@ class WebTeamNotifier(TeamNotifier):
                 url="/teams",
                 tag=f"team-join-{event.team.id}-{event.invited.id}",
                 data={"kind": "player_joined_team", "team_id": event.team.id},
+                ttl=TEAM_TTL,
             ),
         )
 
@@ -385,6 +402,7 @@ class WebTeamNotifier(TeamNotifier):
                 url="/teams",
                 tag=f"team-leave-{event.team.id}-{event.removed.id}",
                 data={"kind": "player_left_team", "team_id": event.team.id},
+                ttl=TEAM_TTL,
             ),
         )
 
@@ -409,6 +427,7 @@ class WebTeamNotifier(TeamNotifier):
                 url="/team",
                 tag=f"team-captain-{event.team.id}",
                 data={"kind": "team_captain_changed", "team_id": event.team.id},
+                ttl=TEAM_TTL,
             ),
         )
 
@@ -431,6 +450,7 @@ class WebTeamNotifier(TeamNotifier):
                 url="/team",
                 tag=f"team-renamed-{event.team.id}",
                 data={"kind": "team_renamed", "team_id": event.team.id},
+                ttl=TEAM_TTL,
             ),
         )
 

--- a/shvatka/core/models/enums/notification.py
+++ b/shvatka/core/models/enums/notification.py
@@ -22,7 +22,7 @@ class NotificationType(enum.Enum):
 
 
 class NotificationSeverity(enum.Enum):
-    """How much a notification matters. Drives UI emphasis and push urgency."""
+    """How much a notification matters. Drives UI emphasis in the feed."""
 
     low = enum.auto()
     normal = enum.auto()

--- a/tests/unit/services/web_game_view_test.py
+++ b/tests/unit/services/web_game_view_test.py
@@ -3,9 +3,15 @@ from types import SimpleNamespace
 
 import pytest
 
-from shvatka.api.app.utils.push import PushMessage
-from shvatka.api.app.utils.web_input import WebGameView
-from shvatka.core.views.game import SendHint, SendPuzzle
+from shvatka.api.app.utils.push import PushMessage, PushUrgency
+from shvatka.api.app.utils.web_input import ApiInput, WebGameView
+from shvatka.core.views.game import (
+    GameFinished,
+    GameFinishedByAll,
+    SendHint,
+    SendPuzzle,
+    ShowEffects,
+)
 
 
 class FakePushSender:
@@ -104,3 +110,37 @@ async def test_a_hint_never_replaces_a_level_up() -> None:
 
     puzzle, hint = (message.tag for _, message in sender.calls)
     assert puzzle != hint
+
+
+@pytest.mark.asyncio
+async def test_every_in_game_push_is_high_urgency() -> None:
+    """A phone in a pocket holds normal-urgency pushes until it wakes up, and a
+    hint delivered at the next doze window is delivered after the level.
+    """
+    view, sender = _view(1)
+    team = _team()
+    level = _level(3)
+
+    await view.show(
+        [
+            SendPuzzle(team=team, level=level),
+            SendHint(team=team, hint_number=1, level=level),
+            ShowEffects(team=team, effects=SimpleNamespace(id="e1"), input_container=ApiInput()),
+            GameFinished(team=team, input_container=ApiInput()),
+            GameFinishedByAll(team=team),
+        ]
+    )
+
+    assert len(sender.calls) == 5
+    assert {message.urgency for _, message in sender.calls} == {PushUrgency.high}
+
+
+@pytest.mark.asyncio
+async def test_an_in_game_push_still_dies_in_ten_minutes() -> None:
+    """Urgency asks for it now; ttl says a hint an hour late is noise, not news."""
+    view, sender = _view(1)
+
+    await view.show([SendPuzzle(team=_team(), level=_level(3))])
+
+    _, message = sender.calls[0]
+    assert message.ttl == 10 * 60

--- a/tests/unit/services/web_org_notifier_test.py
+++ b/tests/unit/services/web_org_notifier_test.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from shvatka.api.app.utils.push import PushMessage
+from shvatka.api.app.utils.push import PushMessage, PushUrgency
 from shvatka.api.app.utils.web_input import WebOrgNotifier
 from shvatka.core.views.game import LevelTestCompleted, LevelUp, NewOrg
 
@@ -111,3 +111,21 @@ async def test_level_test_completed_pushes_to_all_orgs() -> None:
     assert "tester" in message.body
     assert "2 минут 5 с" in message.body
     assert _data(message)["kind"] == "level_test_completed"
+
+
+@pytest.mark.asyncio
+async def test_org_pushes_keep_the_in_game_defaults() -> None:
+    """Orgs are watching from a laptop, not playing with a phone in a pocket: the
+    urgency their pushes deserve has not been looked at yet.
+    """
+    sender = FakePushSender()
+    notifier = WebOrgNotifier(sender, FakeNotificationDao())
+    team = SimpleNamespace(id=7, name="Gryffindor")
+    level = SimpleNamespace(db_id=3, name_id="lvl-1", number_in_game=0)
+    event = LevelUp(orgs_list=[_org(1)], team=team, new_level=level)
+
+    await notifier.notify(event)
+
+    _, message = sender.calls[0]
+    assert message.urgency == PushUrgency.normal
+    assert message.ttl == 10 * 60

--- a/tests/unit/services/web_push_sender_test.py
+++ b/tests/unit/services/web_push_sender_test.py
@@ -6,7 +6,7 @@ from pywebpush import WebPushException
 
 from shvatka.api.app.config.models.push import PushConfig
 from shvatka.api.app.utils import push as push_module
-from shvatka.api.app.utils.push import PushMessage, WebPushSender
+from shvatka.api.app.utils.push import TEAM_TTL, PushMessage, PushUrgency, WebPushSender
 
 CONFIG = PushConfig(
     vapid_public_key="public",
@@ -125,3 +125,44 @@ async def test_nothing_sent_when_push_is_not_configured(monkeypatch) -> None:
     sender = WebPushSender(config=PushConfig(), dao=FakeDao())
 
     await sender.send_to_players([1, 2], MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_urgency_and_ttl_reach_the_push_service(monkeypatch) -> None:
+    """They are the whole point of the fields: nothing else carries them."""
+    sent: list[dict] = []
+    monkeypatch.setattr(push_module, "webpush", lambda **kwargs: sent.append(kwargs))
+    sender = WebPushSender(config=CONFIG, dao=FakeDao())
+    message = PushMessage(
+        title="Новая подсказка",
+        body="подсказка #1",
+        urgency=PushUrgency.high,
+        ttl=TEAM_TTL,
+    )
+
+    await sender.send_many([subscription(1)], message)
+
+    assert sent[0]["headers"] == {"Urgency": "high"}
+    assert sent[0]["ttl"] == 24 * 60 * 60
+
+
+@pytest.mark.asyncio
+async def test_a_push_is_normal_urgency_and_dies_in_ten_minutes_by_default(monkeypatch) -> None:
+    sent: list[dict] = []
+    monkeypatch.setattr(push_module, "webpush", lambda **kwargs: sent.append(kwargs))
+    sender = WebPushSender(config=CONFIG, dao=FakeDao())
+
+    await sender.send_many([subscription(1)], MESSAGE)
+
+    assert sent[0]["headers"] == {"Urgency": "normal"}
+    assert sent[0]["ttl"] == 10 * 60
+
+
+def test_delivery_is_not_told_to_the_browser() -> None:
+    """``to_json`` is the payload the service worker sees; urgency is between us
+    and the push service.
+    """
+    message = PushMessage(title="t", body="b", urgency=PushUrgency.high, ttl=TEAM_TTL)
+
+    assert "urgency" not in message.to_json()
+    assert "ttl" not in message.to_json()

--- a/tests/unit/services/web_team_notifier_test.py
+++ b/tests/unit/services/web_team_notifier_test.py
@@ -3,9 +3,14 @@ from types import SimpleNamespace
 
 import pytest
 
-from shvatka.api.app.utils.push import PushMessage
+from shvatka.api.app.utils.push import PushMessage, PushUrgency
 from shvatka.api.app.utils.web_input import WebTeamNotifier
-from shvatka.core.views.team import CaptainChanged, PlayerJoinedTeam, PlayerLeftTeam
+from shvatka.core.views.team import (
+    CaptainChanged,
+    PlayerJoinedTeam,
+    PlayerLeftTeam,
+    TeamRenamed,
+)
 
 
 class FakePushSender:
@@ -122,3 +127,37 @@ async def test_no_recipients_no_calls() -> None:
     assert notification_dao.created == []
     assert notification_dao.commits == 0
     assert sender.calls == []
+
+
+@pytest.mark.asyncio
+async def test_team_pushes_keep_for_a_day() -> None:
+    """Who joined the team is still true tomorrow, so a phone that was off all
+    evening should be told when it comes back on.
+    """
+    sender = FakePushSender()
+    notifier = WebTeamNotifier(FakeNotificationDao(), FakeTeamPlayersDao([10, 42]), sender)
+    team = _team()
+
+    for event in (
+        PlayerJoinedTeam(team=team, actor=_player(10), invited=_player(42)),
+        PlayerLeftTeam(team=team, actor=_player(10), removed=_player(42)),
+        CaptainChanged(
+            team=team, actor=_player(10), new_captain=_player(42), old_captain=_player(10)
+        ),
+        TeamRenamed(team=team, actor=_player(10), old_name="Ravenclaw"),
+    ):
+        await notifier.notify(event)
+
+    assert len(sender.calls) == 4
+    assert {message.ttl for _, message in sender.calls} == {24 * 60 * 60}
+
+
+@pytest.mark.asyncio
+async def test_team_news_is_not_worth_waking_a_sleeping_phone() -> None:
+    sender = FakePushSender()
+    notifier = WebTeamNotifier(FakeNotificationDao(), FakeTeamPlayersDao([10]), sender)
+
+    await notifier.notify(PlayerJoinedTeam(team=_team(), actor=_player(10), invited=_player(42)))
+
+    _, message = sender.calls[0]
+    assert message.urgency == PushUrgency.normal


### PR DESCRIPTION
## Зачем

Пуши доходят не всегда — даже при разблокированном экране, если браузер не на переднем плане. Часть причины снаружи (android doze, App Standby, вендорские «оптимизаторы» батареи), и кодом её не починить. Но две наши собственные настройки делали ситуацию заметно хуже:

1. **Заголовок `Urgency` не отправлялся вообще.** По RFC 8030 дефолт — `normal`, а это прямое разрешение push-сервису придержать сообщение до того, как устройство проснётся само. На забэкграундленном андроиде это минуты, в глубоком doze — десятки минут.
2. **`ttl=10 * 60` на всём.** Если задержка вылезла за десять минут, сообщение выбрасывается насовсем, ретрая нет.

Вместе получалось «просим подождать и тут же запрещаем ждать».

## Что изменилось

`PushMessage` теперь несёт `urgency` и `ttl`, и выбирает их аудитория:

| Кто | Urgency | TTL | Почему |
| --- | --- | --- | --- |
| Ход игры (`WebGameView`) | **`high`** (было `normal`) | 10 мин (без изменений) | В игру играют с телефоном в кармане — ровно то состояние, в котором android держит `normal`-пуши до следующего окна обслуживания. Подсказка, доехавшая к тому моменту, доезжает уже после уровня. TTL оставлен: тут поздно хуже, чем никогда. |
| Команда (`WebTeamNotifier`) | `normal` (без изменений) | **24 ч** (было 10 мин) | Кто вступил — всё ещё правда завтра. Телефон, весь вечер пролежавший выключенным, должен узнать, когда включится. Будить спящее устройство ради этого не нужно. |
| Оргам (`WebOrgNotifier`) | `normal` | 10 мин | Не трогал, как договаривались — берут дефолты. |

Оба поля не попадают в `to_json()`: это разговор с push-сервисом, браузеру о них знать нечего.

Попутно: `NotificationSeverity` в двух местах (docstring и `context.md`) обещал, что «drives push urgency». Он этого никогда не делал, а теперь, когда urgency стал реальной вещью, ею управляет аудитория, а не важность — так что формулировка исправлена, а не реализована.

## Файлы

- `shvatka/api/app/utils/push.py` — `PushUrgency` (RFC 8030), константы `IN_GAME_TTL` / `TEAM_TTL`, два поля на `PushMessage`, передача `headers={"Urgency": ...}` и `ttl` в `webpush()`.
- `shvatka/api/app/utils/web_input.py` — `urgency=high` на пяти игровых пушах, `ttl=TEAM_TTL` на четырёх командных, docstring'и с обоснованием.
- `AGENTS.md`, `context.md` — правило и два термина глоссария.

## Проверки

- `ruff format --check .` — чисто, `ruff check .` — чисто (ruff 0.2.2 из локфайла).
- `mypy .` — `Success: no issues found in 836 source files`.
- Новые unit-тесты (8 штук): urgency и ttl доезжают до `webpush()`; дефолты остались `normal` / 10 мин; ни то ни другое не утекает в `to_json()`; **все пять** игровых пушей `high`; **все четыре** командных живут сутки; оргам ничего не изменилось.

Оговорка про запуск тестов: в контейнере доступен только python 3.14.0rc2 (проект пинит 3.14.7), а залоченный pydantic на rc2 падает на `_eval_type(prefer_fwd_module=...)` при импорте aiogram. Свои четыре файла я прогнал с локальной заглушкой aiogram — **26 passed**. Полный `tests/unit` под той же заглушкой даёт одинаковые «27 failed, 21 errors» и до, и после моих правок (все они — следствие заглушки и rc2), при этом passed растёт с 438 до 446. Настоящий прогон — за CI.

## Что осталось за скобками

- **Оргам** urgency/ttl не трогал по договорённости — отдельный разговор.
- **`pushsubscriptionchange`** в `shvatka-ui/src/push-sw.js` не обрабатывается: после ротации подписки браузером пуши какое-то время летят на мёртвый endpoint, бэк ловит 410 и выключает подписку, устройство молчит до следующего открытия сайта (там `init()` → `refresh()` чинит). Это уже фронтовая задача, отдельным PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzFdVu1gL4ahefYcEnhQ86

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzFdVu1gL4ahefYcEnhQ86)_