### PR TITLE
refactor: complex daos reach their consumers through DI, not HolderDao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ Telegram bot.
 
 - **Write new code as `Interactor` classes** (callable, DI-wired), not as free
   service functions. The project is mid-migration — see below.
-- **Don't add new HolderDAO properties** and **don't add new middleware data
-  keys** — prefer DI.
+- **`HolderDao` holds per-table daos only** — a complex dao is never a property
+  on it; register it in `ComplexDaoProvider` and take it from DI. **Don't add new
+  middleware data keys** either — prefer DI.
 - **Don't rewrite existing code** unless the task requires it. Leave working
   service functions alone; only new functionality should adopt the new style.
 - **Capture review feedback as rules.** When a code-review comment states a
@@ -94,12 +95,14 @@ onto its Protocol:
 class GamePlayProvider(Provider):
     scope = Scope.REQUEST
 
-    @provide
-    def get_game_state(self, dao: HolderDao) -> GameStatReader:
-        return GameStatReaderImpl(dao)
-
+    game_stat_reader_dao = provide(GameStatReaderImpl, provides=GameStatReader)
     get_game_state_interactor = provide(GameStatReaderInteractor)
 ```
+
+A `dao/complex/*` impl takes `HolderDao` as its only constructor argument, so the
+class-provide shorthand is enough — write an explicit `@provide` factory only
+when the impl needs something dishka can't build (`GamePlayDaoImpl`'s per-request
+`cache`, say).
 
 Consume them at the edges via `FromDishka[...]` on an `@inject`-decorated
 route/handler.
@@ -201,6 +204,11 @@ await self.sender.show_later(tasks)
   those methods behind one Protocol, but it should not drive the sequence.
 - **At most one DAO per interactor.** Compose what it needs behind a single
   Protocol and a single `dao/complex/*` adapter.
+- **A complex dao reaches its consumer through DI**, never as a `HolderDao`
+  attribute. Cross-table adapters live in `dao/complex/*` (or `dao/complex2/*`),
+  import `HolderDao` directly, and are registered once in `ComplexDaoProvider`
+  (`infrastructure/di/db.py`) so both edges see them. Handlers, interactors and
+  scheduler wrappers take the Protocol, not `HolderDao`.
 - **Generic SQLAlchemy by default.** Dialect-specific helpers (e.g.
   `postgresql.insert(...).on_conflict_do_nothing()`) are fine when they make a
   query meaningfully better or faster — not by reflex.

--- a/shvatka/api/admin/routes.py
+++ b/shvatka/api/admin/routes.py
@@ -25,6 +25,7 @@ from shvatka.core.games.admin_interactors import (
     AdminUpdateGameScenarioInteractor,
     AdminUploadGameFileInteractor,
 )
+from shvatka.core.interfaces.dal.complex import GamePackager
 from shvatka.core.models import dto
 from shvatka.core.players.admin_interactors import (
     AdminChangePlayerTgInteractor,
@@ -354,6 +355,7 @@ async def change_game_scenario(
     interactor: FromDishka[AdminUpdateGameScenarioInteractor],
     dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
+    game_packager: FromDishka[GamePackager],
     id_: Annotated[int, Path(alias="id")],
     body: Annotated[requests.AdminGameScenarioEdit, Body()],
 ) -> games_responses.FullGame:
@@ -363,7 +365,7 @@ async def change_game_scenario(
         new_author_id=body.author_id,
         identity=identity,
     )
-    files = await get_file_metas(game, identity, dao.game_packager)
+    files = await get_file_metas(game, identity, game_packager)
     return games_responses.FullGame.from_core(retort, game, files)
 
 

--- a/shvatka/api/games/routes.py
+++ b/shvatka/api/games/routes.py
@@ -45,6 +45,7 @@ from shvatka.core.games.release_interactors import (
     SaveGameReleaseInteractor,
 )
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.complex import GamePackager
 from shvatka.core.models import enums
 from shvatka.core.models.enums.org_permission import OrgPermission
 from shvatka.core.scenario.interactors import AllGameKeysPrintInteractor
@@ -79,10 +80,11 @@ async def get_my_game(
     interactor: FromDishka[MyGameInteractor],
     dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
+    game_packager: FromDishka[GamePackager],
     id_: Annotated[int, Path(alias="id")],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, identity=identity)
-    files = await get_file_metas(game, identity, dao.game_packager)
+    files = await get_file_metas(game, identity, game_packager)
     return responses.FullGame.from_core(retort, game, files)
 
 
@@ -118,11 +120,12 @@ async def change_my_game_scenario(
     interactor: FromDishka[ChangeGameScenarioInteractor],
     dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
+    game_packager: FromDishka[GamePackager],
     id_: Annotated[int, Path(alias="id")],
     scenario: Annotated[dict[str, Any], Body()],
 ) -> responses.FullGame:
     game = await interactor(game_id=id_, raw_scn=scenario, identity=identity)
-    files = await get_file_metas(game, identity, dao.game_packager)
+    files = await get_file_metas(game, identity, game_packager)
     return responses.FullGame.from_core(retort, game, files)
 
 
@@ -132,6 +135,7 @@ async def import_my_game_zip(
     interactor: FromDishka[ImportGameZipInteractor],
     dao: FromDishka[HolderDao],
     retort: FromDishka[Retort],
+    game_packager: FromDishka[GamePackager],
     file: Annotated[UploadFile, File()],
     overwrite: Annotated[bool, Query()] = False,
 ) -> responses.FullGame:
@@ -146,7 +150,7 @@ async def import_my_game_zip(
     game = await interactor(
         zip_file=BytesIO(await file.read()), identity=identity, overwrite=overwrite
     )
-    files = await get_file_metas(game, identity, dao.game_packager)
+    files = await get_file_metas(game, identity, game_packager)
     return responses.FullGame.from_core(retort, game, files)
 
 
@@ -219,10 +223,11 @@ async def get_game_card(
     dao: FromDishka[HolderDao],
     identity: FromDishka[ApiIdentityProvider],
     retort: FromDishka[Retort],
+    game_packager: FromDishka[GamePackager],
     id_: Annotated[int, Path(alias="id")],
 ):
     game = await get_full_game(id_, identity, dao.game)
-    files = await get_file_metas(game, identity, dao.game_packager)
+    files = await get_file_metas(game, identity, game_packager)
     return responses.FullGame.from_core(retort, game, files)
 
 

--- a/shvatka/infrastructure/crawler/game_scn/loader/load_scns.py
+++ b/shvatka/infrastructure/crawler/game_scn/loader/load_scns.py
@@ -13,6 +13,7 @@ from dishka import make_async_container
 from shvatka.common.config.parser.logging_config import setup_logging
 from shvatka.common.config.parser.paths import common_get_paths
 from shvatka.core.interfaces.clients.file_storage import FileGateway
+from shvatka.core.interfaces.dal.game import GameUpserter
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import scn  # noqa: F401
 from shvatka.core.models.dto.export_stat import (
@@ -45,12 +46,14 @@ async def main():
         config = await dishka.get(TgBotConfig)
         async with dishka() as request_dishka:
             dao = await request_dishka.get(HolderDao)
+            game_upserter = await request_dishka.get(GameUpserter)
             file_gateway = await request_dishka.get(FileGateway)
             bot_player = await dao.player.upsert_author_dummy()
             await dao.commit()
             await load_scns(
                 bot_player=bot_player,
                 dao=dao,
+                game_upserter=game_upserter,
                 file_gateway=file_gateway,
                 retort=await dishka.get(Retort),
                 path=config.file_storage_config.path.parent / "scn",
@@ -62,6 +65,7 @@ async def main():
 async def load_scns(
     bot_player: dto.Player,
     dao: HolderDao,
+    game_upserter: GameUpserter,
     file_gateway: FileGateway,
     retort: Retort,
     path: Path,
@@ -73,7 +77,7 @@ async def load_scns(
             with file.open("rb") as game_zip_scn:
                 game = await load_scn(
                     player=bot_player,
-                    dao=dao,
+                    dao=game_upserter,
                     file_gateway=file_gateway,
                     retort=retort,
                     zip_scn=game_zip_scn,
@@ -224,14 +228,14 @@ def load_results(game_zip_scn: BinaryIO, retort: Retort) -> GameStat:
 
 async def load_scn(
     player: dto.Player,
-    dao: HolderDao,
+    dao: GameUpserter,
     file_gateway: FileGateway,
     retort: Retort,
     zip_scn: BinaryIO,
 ) -> dto.FullGame | None:
     try:
         with unpack_scn(ZipPath(zip_scn)).open() as scenario:  # type: scn.RawGameScenario
-            game = await upsert_game(scenario, player, dao.game_upserter, retort, file_gateway)
+            game = await upsert_game(scenario, player, dao, retort, file_gateway)
     except exceptions.ScenarioNotCorrect as e:
         logger.exception("game scenario from player %s has problems", player.id, exc_info=e)
         return None

--- a/shvatka/infrastructure/db/dao/complex/file.py
+++ b/shvatka/infrastructure/db/dao/complex/file.py
@@ -1,4 +1,3 @@
-import typing
 from collections.abc import Collection
 from dataclasses import dataclass
 
@@ -7,14 +6,12 @@ from shvatka.core.files.dto import GameFileLink
 from shvatka.core.interfaces.dal.game import GameFileDeleter
 from shvatka.core.models import dto
 from shvatka.core.models.dto import hints
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class ReleaseGuidsMixin:
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_release_guids(self) -> dict[int, set[str]]:
         return await self.dao.game.get_release_guids()

--- a/shvatka/infrastructure/db/dao/complex/game.py
+++ b/shvatka/infrastructure/db/dao/complex/game.py
@@ -1,4 +1,3 @@
-import typing
 from collections.abc import Collection, Iterable
 from dataclasses import dataclass
 from datetime import datetime
@@ -27,14 +26,12 @@ from shvatka.core.models.dto import hints, scn
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.utils import exceptions
 from shvatka.core.utils.datetime_utils import tz_utc
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class FileLinkMixin:
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_ids_by_guids(self, guids: Collection[str]) -> list[int]:
         return await self.dao.file_info.get_ids_by_guids(guids)
@@ -47,7 +44,7 @@ class FileLinkMixin:
 
 
 class IsGameFileMixin:
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def is_game_file(self, game_id: int, guid: str) -> bool:
         file_ids = await self.dao.file_info.get_ids_by_guids([guid])
@@ -130,7 +127,7 @@ class AdminGameScenarioEditorImpl(GameScenarioEditorImpl):
 
 @dataclass
 class AdminGameStatusChangerImpl(AdminGameStatusChanger):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return await self.dao.game.get_by_id(id_, author)
@@ -201,7 +198,7 @@ class GameCreatorImpl(FileLinkMixin, GameCreator):
 
 @dataclass
 class LevelDeleterImpl(LevelDeleter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def delete_level_files(self, level_id: int) -> None:
         await self.dao.level_file.delete_for_level(level_id)
@@ -215,7 +212,7 @@ class LevelDeleterImpl(LevelDeleter):
 
 @dataclass
 class GameFileUploaderImpl(GameFileUploader):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return await self.dao.game.get_by_id(id_, author)
@@ -241,7 +238,7 @@ class GameFileUploaderImpl(GameFileUploader):
 
 @dataclass
 class GameFileRenamerImpl(IsGameFileMixin, GameFileRenamer):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return await self.dao.game.get_by_id(id_, author)
@@ -264,7 +261,7 @@ class GameFileRenamerImpl(IsGameFileMixin, GameFileRenamer):
 
 @dataclass
 class GameReleaseReaderImpl(GameReleaseReader):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int, author: dto.Player | None = None) -> dto.Game:
         return await self.dao.game.get_by_id(id_, author)
@@ -310,7 +307,7 @@ class GameReleaseEditorImpl(FileLinkMixin, GameReleaseEditor):
 
 @dataclass
 class GamePackagerImpl(GamePackager):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_played_teams(self, game: dto.Game) -> Iterable[dto.Team]:
         return await self.dao.waiver.get_played_teams(game)
@@ -351,7 +348,7 @@ class GamePackagerImpl(GamePackager):
 
 
 class GameFilesGetterImpl(IsGameFileMixin, GameFileReader):
-    def __init__(self, dao: "HolderDao") -> None:
+    def __init__(self, dao: HolderDao) -> None:
         self.dao = dao
 
     async def get_by_guid(self, guid: str) -> hints.VerifiableFileMeta:
@@ -383,7 +380,7 @@ class CacheItem:
 
 @dataclass(kw_only=True, slots=True)
 class GamePlayDaoImpl(GamePlayDao):
-    dao: "HolderDao"
+    dao: HolderDao
     current_game: CurrentGameProvider
     cache: dict[int, CacheItem]
 

--- a/shvatka/infrastructure/db/dao/complex/game_play.py
+++ b/shvatka/infrastructure/db/dao/complex/game_play.py
@@ -1,4 +1,3 @@
-import typing
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
@@ -7,14 +6,12 @@ from shvatka.core.interfaces.dal.game_play import GamePlayerDao, GamePreparer
 from shvatka.core.interfaces.dal.level_times import GameStarter
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import action
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class GamePreparerImpl(GamePreparer):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def delete_poll_data(self) -> None:
         return await self.dao.poll.delete_all()
@@ -35,7 +32,7 @@ class GamePreparerImpl(GamePreparer):
 
 @dataclass
 class GameStarterImpl(GameStarter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def set_game_started(self, game: dto.Game) -> None:
         return await self.dao.game.set_started(game)
@@ -60,7 +57,7 @@ class GameStarterImpl(GameStarter):
 
 @dataclass
 class GamePlayerDaoImpl(GamePlayerDao):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def check_waiver(self, player: dto.Player, team: dto.Team, game: dto.Game) -> bool:
         return await self.dao.waiver.check_waiver(player, team, game)

--- a/shvatka/infrastructure/db/dao/complex/key_log.py
+++ b/shvatka/infrastructure/db/dao/complex/key_log.py
@@ -1,18 +1,15 @@
-import typing
 from dataclasses import dataclass
 
 from shvatka.core.games.adapters import GameKeysReader
 from shvatka.core.interfaces.dal.complex import TypedKeyGetter
 from shvatka.core.models import dto
 from shvatka.core.models.dto import KeyTime, Team
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class TypedKeyGetterImpl(TypedKeyGetter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_typed_keys_grouped(self, game: dto.Game) -> dict[Team, list[KeyTime]]:
         return await self.dao.key_time.get_typed_key_grouped(game=game)
@@ -27,7 +24,7 @@ class TypedKeyGetterImpl(TypedKeyGetter):
 
 
 class GameKeysReaderImpl(GameKeysReader):
-    def __init__(self, dao: "HolderDao") -> None:
+    def __init__(self, dao: HolderDao) -> None:
         self.dao = dao
 
     async def get_typed_keys_grouped(self, game: dto.Game) -> dict[Team, list[KeyTime]]:

--- a/shvatka/infrastructure/db/dao/complex/level_testing.py
+++ b/shvatka/infrastructure/db/dao/complex/level_testing.py
@@ -1,17 +1,14 @@
-import typing
 from dataclasses import dataclass
 from datetime import datetime
 
 from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
 from shvatka.core.models import dto
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class LevelTestComplex(LevelTestingDao):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def save_started_level_test(self, suite: dto.LevelTestSuite, now: datetime):
         return await self.dao.level_test.save_started_level_test(suite, now)

--- a/shvatka/infrastructure/db/dao/complex/level_times.py
+++ b/shvatka/infrastructure/db/dao/complex/level_times.py
@@ -1,18 +1,15 @@
-import typing
 from dataclasses import dataclass
 
 from shvatka.core.games.adapters import GameStatReader
 from shvatka.core.games.dto import BonusEvent
 from shvatka.core.interfaces.dal.complex import GameStatDao
 from shvatka.core.models import dto
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class GameStatImpl(GameStatDao):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_game_level_times(self, game: dto.Game) -> list[dto.LevelTime]:
         return await self.dao.level_time.get_game_level_times(game)
@@ -49,7 +46,7 @@ class GameStatImpl(GameStatDao):
 
 
 class GameStatReaderImpl(GameStatReader):
-    def __init__(self, dao: "HolderDao") -> None:
+    def __init__(self, dao: HolderDao) -> None:
         self.dao = dao
 
     async def get_game_level_times(self, game: dto.Game) -> list[dto.LevelTime]:

--- a/shvatka/infrastructure/db/dao/complex/orgs.py
+++ b/shvatka/infrastructure/db/dao/complex/orgs.py
@@ -1,16 +1,13 @@
-import typing
 from dataclasses import dataclass
 
 from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.models import dto
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class OrgAdderImpl(OrgAdder):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def add_new_org(self, game: dto.Game, player: dto.Player) -> dto.SecondaryOrganizer:
         return await self.dao.organizer.add_new(game, player)

--- a/shvatka/infrastructure/db/dao/complex/player.py
+++ b/shvatka/infrastructure/db/dao/complex/player.py
@@ -1,4 +1,3 @@
-import typing
 from dataclasses import dataclass
 
 from shvatka.core.interfaces.dal.player import PlayerPromoter
@@ -12,14 +11,12 @@ from shvatka.core.players.interfaces import (
     AdminUsernameSetter,
     PlayerMerger,
 )
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class PlayerPromoterImpl(PlayerPromoter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def promote(self, actor: dto.Player, target: dto.Player) -> None:
         return await self.dao.player.promote(actor, target)
@@ -39,7 +36,7 @@ class PlayerPromoterImpl(PlayerPromoter):
 
 @dataclass
 class PlayerMergerImpl(PlayerMerger):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def replace_games_author(self, primary: dto.Player, secondary: dto.Player) -> None:
         return await self.dao.game.transfer_all(primary, secondary)
@@ -101,7 +98,7 @@ class AdminPlayerMergerImpl(PlayerMergerImpl, AdminPlayerMerger):
 
 @dataclass
 class AdminPlayerWaiverPointsReaderImpl(AdminPlayerWaiverPointsReader):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
@@ -112,7 +109,7 @@ class AdminPlayerWaiverPointsReaderImpl(AdminPlayerWaiverPointsReader):
 
 @dataclass
 class AdminPlayerReaderImpl(AdminPlayerReader):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_identities_by_id(self, id_: int) -> dto.PlayerWithForum:
         return await self.dao.player.get_identities_by_id(id_)
@@ -123,7 +120,7 @@ class AdminPlayerReaderImpl(AdminPlayerReader):
 
 @dataclass
 class AdminEmailSetterImpl(AdminEmailSetter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
@@ -142,7 +139,7 @@ class AdminEmailSetterImpl(AdminEmailSetter):
 
 @dataclass
 class AdminUsernameSetterImpl(AdminUsernameSetter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int) -> dto.Player:
         return await self.dao.player.get_by_id(id_)
@@ -165,7 +162,7 @@ class AdminUsernameSetterImpl(AdminUsernameSetter):
 
 @dataclass
 class AdminTgChangerImpl(AdminTgChanger):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def upsert_user(self, user: dto.User) -> dto.User:
         return await self.dao.user.upsert_user(user)

--- a/shvatka/infrastructure/db/dao/complex/search.py
+++ b/shvatka/infrastructure/db/dao/complex/search.py
@@ -1,17 +1,14 @@
-import typing
 from dataclasses import dataclass
 
 from shvatka.core.models import dto
 from shvatka.core.search.adapters import GlobalSearchDao
 from shvatka.core.search.dto import LevelWithGame
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class GlobalSearchDaoImpl(GlobalSearchDao):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def search_completed_games(self, text: str) -> list[dto.Game]:
         return await self.dao.game.search_completed(text)

--- a/shvatka/infrastructure/db/dao/complex/team.py
+++ b/shvatka/infrastructure/db/dao/complex/team.py
@@ -1,4 +1,3 @@
-import typing
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -13,14 +12,12 @@ from shvatka.core.teams.adapters import (
     ChatlessTeamCreator,
     TeamCaptainSetter,
 )
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class TeamCreatorImpl(TeamCreator, ChatlessTeamCreator):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def check_no_team_in_chat(self, chat: dto.Chat) -> None:
         return await self.dao.team.check_no_team_in_chat(chat)
@@ -57,7 +54,7 @@ class TeamCreatorImpl(TeamCreator, ChatlessTeamCreator):
 
 @dataclass
 class TeamLeaverImpl(TeamLeaver):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def del_player_vote(self, team_id: int, player_id: int) -> None:
         return await self.dao.poll.del_player_vote(team_id, player_id)
@@ -83,7 +80,7 @@ class TeamLeaverImpl(TeamLeaver):
 
 @dataclass
 class TeamMergerImpl(TeamMerger):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def replace_team_waiver(self, primary: dto.Team, secondary: dto.Team):
         return await self.dao.waiver.replace_team_waiver(primary, secondary)
@@ -115,7 +112,7 @@ class AdminTeamMergerImpl(TeamMergerImpl, AdminTeamMerger):
 
 @dataclass
 class TeamCaptainSetterImpl(TeamCaptainSetter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_by_id(self, id_: int) -> dto.Team:
         return await self.dao.team.get_by_id(id_)
@@ -135,7 +132,7 @@ class TeamCaptainSetterImpl(TeamCaptainSetter):
 
 @dataclass
 class CaptainedTeamsReaderImpl(CaptainedTeamsReader):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def get_captained_teams(self, captain: dto.Player) -> list[dto.Team]:
         return await self.dao.team.get_captained_teams(captain)

--- a/shvatka/infrastructure/db/dao/complex/waiver.py
+++ b/shvatka/infrastructure/db/dao/complex/waiver.py
@@ -6,14 +6,12 @@ from shvatka.core.interfaces.dal.waiver import WaiverApprover
 from shvatka.core.models import dto
 from shvatka.core.models.enums import Played
 from shvatka.core.waiver.adapters import WaiverVoteGetter
-
-if typing.TYPE_CHECKING:
-    from shvatka.infrastructure.db.dao.holder import HolderDao
+from shvatka.infrastructure.db.dao.holder import HolderDao
 
 
 @dataclass
 class WaiverApproverImpl(WaiverApprover, WaiverVoteGetter):
-    dao: "HolderDao"
+    dao: HolderDao
 
     async def upsert(self, waiver: dto.Waiver) -> None:
         return await self.dao.waiver.upsert(waiver)

--- a/shvatka/infrastructure/db/dao/holder.py
+++ b/shvatka/infrastructure/db/dao/holder.py
@@ -4,35 +4,6 @@ from datetime import datetime, tzinfo
 from redis.asyncio.client import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from shvatka.core.interfaces.dal.complex import (
-    GamePackager,
-    GameStatDao,
-    TeamMerger,
-    TypedKeyGetter,
-)
-from shvatka.core.interfaces.dal.game import GameCreator, GameUpserter
-from shvatka.core.interfaces.dal.game_play import GamePlayerDao, GamePreparer
-from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
-from shvatka.core.interfaces.dal.level_times import GameStarter
-from shvatka.core.interfaces.dal.organizer import OrgAdder
-from shvatka.core.interfaces.dal.player import PlayerPromoter, TeamLeaver
-from shvatka.core.interfaces.dal.team import TeamCreator
-from shvatka.core.interfaces.dal.waiver import WaiverApprover
-from shvatka.core.players.interfaces import PlayerMerger
-
-from .complex.game import (
-    GameCreatorImpl,
-    GamePackagerImpl,
-    GameUpserterImpl,
-)
-from .complex.game_play import GamePlayerDaoImpl, GamePreparerImpl, GameStarterImpl
-from .complex.key_log import TypedKeyGetterImpl
-from .complex.level_testing import LevelTestComplex
-from .complex.level_times import GameStatImpl
-from .complex.orgs import OrgAdderImpl
-from .complex.player import PlayerMergerImpl, PlayerPromoterImpl
-from .complex.team import TeamCreatorImpl, TeamLeaverImpl, TeamMergerImpl
-from .complex.waiver import WaiverApproverImpl
 from .memory.level_testing import LevelTestingData
 from .rdb import (
     ChatDao,
@@ -98,67 +69,3 @@ class HolderDao:
 
     async def commit(self):
         await self.session.commit()
-
-    @property
-    def waiver_approver(self) -> WaiverApprover:
-        return WaiverApproverImpl(dao=self)
-
-    @property
-    def game_upserter(self) -> GameUpserter:
-        return GameUpserterImpl(dao=self)
-
-    @property
-    def game_creator(self) -> GameCreator:
-        return GameCreatorImpl(dao=self)
-
-    @property
-    def game_packager(self) -> GamePackager:
-        return GamePackagerImpl(dao=self)
-
-    @property
-    def team_creator(self) -> TeamCreator:
-        return TeamCreatorImpl(dao=self)
-
-    @property
-    def team_leaver(self) -> TeamLeaver:
-        return TeamLeaverImpl(dao=self)
-
-    @property
-    def team_merger(self) -> TeamMerger:
-        return TeamMergerImpl(dao=self)
-
-    @property
-    def game_preparer(self) -> GamePreparer:
-        return GamePreparerImpl(dao=self)
-
-    @property
-    def game_starter(self) -> GameStarter:
-        return GameStarterImpl(dao=self)
-
-    @property
-    def game_player(self) -> GamePlayerDao:
-        return GamePlayerDaoImpl(dao=self)
-
-    @property
-    def org_adder(self) -> OrgAdder:
-        return OrgAdderImpl(dao=self)
-
-    @property
-    def player_promoter(self) -> PlayerPromoter:
-        return PlayerPromoterImpl(dao=self)
-
-    @property
-    def player_merger(self) -> PlayerMerger:
-        return PlayerMergerImpl(dao=self)
-
-    @property
-    def level_testing_complex(self) -> LevelTestingDao:
-        return LevelTestComplex(dao=self)
-
-    @property
-    def game_stat(self) -> GameStatDao:
-        return GameStatImpl(dao=self)
-
-    @property
-    def typed_keys(self) -> TypedKeyGetter:
-        return TypedKeyGetterImpl(dao=self)

--- a/shvatka/infrastructure/di/__init__.py
+++ b/shvatka/infrastructure/di/__init__.py
@@ -2,7 +2,12 @@ from shvatka.common.factory import DCFProvider, UrlProvider
 from shvatka.infrastructure.db.factory import LockProvider
 from shvatka.infrastructure.di.bot import BotProvider
 from shvatka.infrastructure.di.config import ConfigProvider, DbConfigProvider
-from shvatka.infrastructure.di.db import DAOProvider, DbProvider, RedisProvider
+from shvatka.infrastructure.di.db import (
+    ComplexDaoProvider,
+    DAOProvider,
+    DbProvider,
+    RedisProvider,
+)
 from shvatka.infrastructure.di.files import FileClientProvider
 from shvatka.infrastructure.di.interactors import (
     ContextProvider,
@@ -29,6 +34,7 @@ def get_providers(paths_env):
         UrlProvider(),
         DCFProvider(),
         DAOProvider(),
+        ComplexDaoProvider(),
         RedisProvider(),
         FileClientProvider(),
         MailProvider(),

--- a/shvatka/infrastructure/di/db.py
+++ b/shvatka/infrastructure/di/db.py
@@ -4,22 +4,56 @@ from dishka import AnyOf, Provider, Scope, provide
 from redis.asyncio.client import Redis
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from shvatka.core.interfaces.dal.complex import (
+    GamePackager,
+    GameStatDao,
+    TeamMerger,
+    TypedKeyGetter,
+)
+from shvatka.core.interfaces.dal.game import GameCreator, GameUpserter
+from shvatka.core.interfaces.dal.game_play import GamePlayerDao, GamePreparer
 from shvatka.core.interfaces.dal.level import LevelDeleter
-from shvatka.core.interfaces.dal.organizer import OrgByPlayerGetter
-from shvatka.core.interfaces.dal.player import PlayerTeamChecker
-from shvatka.core.interfaces.dal.waiver import GameWaiversGetter, WaiverGetter
+from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
+from shvatka.core.interfaces.dal.level_times import GameStarter
+from shvatka.core.interfaces.dal.organizer import OrgAdder, OrgByPlayerGetter
+from shvatka.core.interfaces.dal.player import PlayerPromoter, PlayerTeamChecker, TeamLeaver
+from shvatka.core.interfaces.dal.team import TeamCreator
+from shvatka.core.interfaces.dal.waiver import GameWaiversGetter, WaiverApprover, WaiverGetter
 from shvatka.core.notifications.adapters import (
     NotificationMarker,
     NotificationReader,
     NotificationWriter,
     RequestStorage,
 )
+from shvatka.core.players.interfaces import PlayerMerger
+from shvatka.core.teams.adapters import ChatlessTeamCreator
 from shvatka.infrastructure.db import dao
 from shvatka.infrastructure.db.config.models.db import DBConfig, RedisConfig
 from shvatka.infrastructure.db.dao import (
     WaiverDao,
 )
-from shvatka.infrastructure.db.dao.complex.game import LevelDeleterImpl
+from shvatka.infrastructure.db.dao.complex.game import (
+    GameCreatorImpl,
+    GamePackagerImpl,
+    GameUpserterImpl,
+    LevelDeleterImpl,
+)
+from shvatka.infrastructure.db.dao.complex.game_play import (
+    GamePlayerDaoImpl,
+    GamePreparerImpl,
+    GameStarterImpl,
+)
+from shvatka.infrastructure.db.dao.complex.key_log import TypedKeyGetterImpl
+from shvatka.infrastructure.db.dao.complex.level_testing import LevelTestComplex
+from shvatka.infrastructure.db.dao.complex.level_times import GameStatImpl
+from shvatka.infrastructure.db.dao.complex.orgs import OrgAdderImpl
+from shvatka.infrastructure.db.dao.complex.player import PlayerMergerImpl, PlayerPromoterImpl
+from shvatka.infrastructure.db.dao.complex.team import (
+    TeamCreatorImpl,
+    TeamLeaverImpl,
+    TeamMergerImpl,
+)
+from shvatka.infrastructure.db.dao.complex.waiver import WaiverApproverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.infrastructure.db.dao.memory.level_testing import LevelTestingData
 from shvatka.infrastructure.db.factory import create_engine, create_redis, create_session_maker
@@ -66,10 +100,6 @@ class DAOProvider(Provider):
     @provide
     async def get_game_dao(self, holder: HolderDao) -> dao.GameDao:
         return holder.game
-
-    @provide
-    def level_deleter(self, holder: HolderDao) -> LevelDeleter:
-        return LevelDeleterImpl(dao=holder)
 
     @provide
     def get_file_info_dao(self, holder: HolderDao) -> dao.FileInfoDao:
@@ -166,6 +196,30 @@ class DAOProvider(Provider):
         self, session: AsyncSession
     ) -> AnyOf[dao.ActionRequestDAO, RequestStorage]:
         return dao.ActionRequestDAO(session=session)
+
+
+class ComplexDaoProvider(Provider):
+    """Daos composed over several tables — one narrow Protocol each, built from HolderDao."""
+
+    scope = Scope.REQUEST
+
+    level_deleter = provide(LevelDeleterImpl, provides=LevelDeleter)
+    waiver_approver = provide(WaiverApproverImpl, provides=WaiverApprover)
+    game_upserter = provide(GameUpserterImpl, provides=GameUpserter)
+    game_creator = provide(GameCreatorImpl, provides=GameCreator)
+    game_packager = provide(GamePackagerImpl, provides=GamePackager)
+    game_preparer = provide(GamePreparerImpl, provides=GamePreparer)
+    game_starter = provide(GameStarterImpl, provides=GameStarter)
+    game_player = provide(GamePlayerDaoImpl, provides=GamePlayerDao)
+    game_stat = provide(GameStatImpl, provides=GameStatDao)
+    typed_keys = provide(TypedKeyGetterImpl, provides=TypedKeyGetter)
+    level_testing = provide(LevelTestComplex, provides=LevelTestingDao)
+    org_adder = provide(OrgAdderImpl, provides=OrgAdder)
+    player_promoter = provide(PlayerPromoterImpl, provides=PlayerPromoter)
+    player_merger = provide(PlayerMergerImpl, provides=PlayerMerger)
+    team_creator = provide(TeamCreatorImpl, provides=AnyOf[TeamCreator, ChatlessTeamCreator])
+    team_leaver = provide(TeamLeaverImpl, provides=TeamLeaver)
+    team_merger = provide(TeamMergerImpl, provides=TeamMerger)
 
 
 class RedisProvider(Provider):

--- a/shvatka/infrastructure/di/interactors.py
+++ b/shvatka/infrastructure/di/interactors.py
@@ -68,6 +68,7 @@ from shvatka.core.interfaces.dal.complex import (
     GamePackager,
     GameScenarioEditor,
     GameStatusChanger,
+    TeamMerger,
 )
 from shvatka.core.interfaces.dal.game import (
     GameByIdGetter,
@@ -77,7 +78,8 @@ from shvatka.core.interfaces.dal.game import (
     GameUpserter,
 )
 from shvatka.core.interfaces.dal.game_play import GamePlayerDao
-from shvatka.core.interfaces.dal.waiver import WaiverApprover
+from shvatka.core.interfaces.dal.organizer import OrgAdder
+from shvatka.core.interfaces.dal.player import PlayerPromoter, TeamLeaver
 from shvatka.core.interfaces.scheduler import Scheduler
 from shvatka.core.interfaces.superusers import SuperusersResolver
 from shvatka.core.notifications.adapters import (
@@ -124,6 +126,7 @@ from shvatka.core.players.interfaces import (
     AdminPlayerWaiverPointsReader,
     AdminTgChanger,
     AdminUsernameSetter,
+    PlayerMerger,
 )
 from shvatka.core.scenario.interactors import (
     AllGameKeysPrintInteractor,
@@ -206,7 +209,6 @@ from shvatka.infrastructure.db.dao.complex.game import (
     GameReleaseReaderImpl,
     GameScenarioEditorImpl,
 )
-from shvatka.infrastructure.db.dao.complex.game_play import GamePlayerDaoImpl
 from shvatka.infrastructure.db.dao.complex.key_log import GameKeysReaderImpl
 from shvatka.infrastructure.db.dao.complex.level_times import GameStatReaderImpl
 from shvatka.infrastructure.db.dao.complex.player import (
@@ -223,7 +225,6 @@ from shvatka.infrastructure.db.dao.complex.team import (
     CaptainedTeamsReaderImpl,
     CaptainTeamJoinerImpl,
     TeamCaptainSetterImpl,
-    TeamCreatorImpl,
 )
 from shvatka.infrastructure.db.dao.complex2.waiver import (
     AdminGameWaiversReaderImpl,
@@ -268,34 +269,22 @@ class ContextProvider(Provider):
 class GamePlayProvider(Provider):
     scope = Scope.REQUEST
 
-    @provide
-    def get_game_keys(self, dao: HolderDao) -> GameKeysReader:
-        return GameKeysReaderImpl(dao)
-
+    game_keys_reader_dao = provide(GameKeysReaderImpl, provides=GameKeysReader)
     get_game_keys_interactor = provide(GameKeysReaderInteractor)
 
-    @provide
-    def get_game_state(self, dao: HolderDao) -> GameStatReader:
-        return GameStatReaderImpl(dao)
-
+    game_stat_reader_dao = provide(GameStatReaderImpl, provides=GameStatReader)
     get_game_state_interactor = provide(GameStatReaderInteractor)
     get_game_results_file_interactor = provide(GameResultsFileInteractor)
 
-    @provide
-    def get_game_files(self, dao: HolderDao) -> GameFileReader:
-        return GameFilesGetterImpl(dao)
-
+    game_files_reader_dao = provide(GameFilesGetterImpl, provides=GameFileReader)
     file_reader = provide(GameFileReaderInteractor)
     game_play_reader_interactor = provide(GamePlayReaderInteractor)
     passed_levels_reader_interactor = provide(PassedLevelsReaderInteractor)
 
     @provide
     def game_play_dao(self, dao: HolderDao, current_game: CurrentGameProvider) -> GamePlayDao:
+        # `cache` is per-request scratch space, not a dependency dishka can build
         return GamePlayDaoImpl(dao=dao, current_game=current_game, cache={})
-
-    @provide
-    def game_player_dao(self, dao: HolderDao) -> GamePlayerDao:
-        return GamePlayerDaoImpl(dao)
 
     game_play_role_reader = provide(GamePlayRoleReader)
 
@@ -324,9 +313,7 @@ class GameEditProvider(Provider):
     def my_game(self, dao: HolderDao) -> MyGameInteractor:
         return MyGameInteractor(dao.game)
 
-    @provide
-    def create_game(self, dao: HolderDao) -> CreateGameInteractor:
-        return CreateGameInteractor(dao.game_creator)
+    create_game = provide(CreateGameInteractor)
 
     @provide
     def game_name_editor(self, dao: HolderDao) -> GameNameEditor:
@@ -334,23 +321,13 @@ class GameEditProvider(Provider):
 
     rename_game = provide(RenameGameInteractor)
 
-    @provide
-    def game_scenario_editor(self, dao: HolderDao) -> GameScenarioEditor:
-        return GameScenarioEditorImpl(dao=dao)
+    game_scenario_editor = provide(GameScenarioEditorImpl, provides=GameScenarioEditor)
 
     @provide
     def change_scenario(
         self, dao: GameScenarioEditor, retort: Retort
     ) -> ChangeGameScenarioInteractor:
         return ChangeGameScenarioInteractor(dao=dao, retort=retort)
-
-    @provide
-    def game_upserter(self, dao: HolderDao) -> GameUpserter:
-        return dao.game_upserter
-
-    @provide
-    def game_packager(self, dao: HolderDao) -> GamePackager:
-        return dao.game_packager
 
     @provide
     def import_zip(
@@ -378,9 +355,7 @@ class GameEditProvider(Provider):
 
     change_status = provide(ChangeGameStatusInteractor)
 
-    @provide
-    def game_file_uploader(self, dao: HolderDao) -> GameFileUploader:
-        return GameFileUploaderImpl(dao=dao)
+    game_file_uploader = provide(GameFileUploaderImpl, provides=GameFileUploader)
 
     @provide
     def upload_file(
@@ -388,17 +363,13 @@ class GameEditProvider(Provider):
     ) -> UploadGameFileInteractor:
         return UploadGameFileInteractor(storage=storage, dao=dao, file_gateway=file_gateway)
 
-    @provide
-    def game_file_renamer(self, dao: HolderDao) -> GameFileRenamer:
-        return GameFileRenamerImpl(dao=dao)
+    game_file_renamer = provide(GameFileRenamerImpl, provides=GameFileRenamer)
 
     @provide
     def rename_file(self, dao: GameFileRenamer) -> RenameGameFileInteractor:
         return RenameGameFileInteractor(dao=dao)
 
-    @provide
-    def game_file_deleter(self, dao: HolderDao) -> GameFileDeleter:
-        return GameFileDeleterImpl(dao=dao)
+    game_file_deleter = provide(GameFileDeleterImpl, provides=GameFileDeleter)
 
     @provide
     def delete_file(self, dao: GameFileDeleter, storage: FileStorage) -> DeleteGameFileInteractor:
@@ -409,12 +380,12 @@ class GameEditProvider(Provider):
         return ListGameOrgsInteractor(game_dao=dao.game, org_dao=dao.organizer)
 
     @provide
-    def add_org(self, dao: HolderDao) -> AddGameOrgInteractor:
+    def add_org(self, dao: HolderDao, org_adder: OrgAdder) -> AddGameOrgInteractor:
         return AddGameOrgInteractor(
             game_dao=dao.game,
             player_dao=dao.player,
             org_getter=dao.organizer,
-            org_adder=dao.org_adder,
+            org_adder=org_adder,
             org_deleted_flipper=dao.organizer,
         )
 
@@ -430,16 +401,8 @@ class GameEditProvider(Provider):
 class GameReleaseProvider(Provider):
     scope = Scope.REQUEST
 
-    # these two take a `HolderDao` the impl only imports under TYPE_CHECKING,
-    # so dishka cannot build them from the annotation — same as every other
-    # complex dao here (`game_scenario_editor`, `admin_game_scenario_editor`)
-    @provide
-    def game_release_reader(self, dao: HolderDao) -> GameReleaseReader:
-        return GameReleaseReaderImpl(dao=dao)
-
-    @provide
-    def game_release_editor(self, dao: HolderDao) -> GameReleaseEditor:
-        return GameReleaseEditorImpl(dao=dao)
+    game_release_reader = provide(GameReleaseReaderImpl, provides=GameReleaseReader)
+    game_release_editor = provide(GameReleaseEditorImpl, provides=GameReleaseEditor)
 
     get_release = provide(GetGameReleaseInteractor)
     save_release = provide(SaveGameReleaseInteractor)
@@ -458,10 +421,6 @@ class WaiverProvider(Provider):
     waiver_vote_adder_dao = provide(WaiverVoteAdderImpl, provides=WaiverVoteAdder)
     waiver_vote_getter_dao = provide(WaiverVoteGetterImpl, provides=WaiverVoteGetter)
     poll_drafts_reader_dao = provide(PollDraftsReaderImpl, provides=PollDraftsReader)
-
-    @provide
-    def waiver_approver(self, dao: HolderDao) -> WaiverApprover:
-        return dao.waiver_approver
 
 
 class PlayerProvider(Provider):
@@ -522,10 +481,10 @@ class TeamProvider(Provider):
 
     @provide
     def remove_player(
-        self, dao: HolderDao, notifier: TeamNotifier
+        self, dao: HolderDao, team_leaver: TeamLeaver, notifier: TeamNotifier
     ) -> RemovePlayerFromTeamInteractor:
         return RemovePlayerFromTeamInteractor(
-            dao=dao.team_leaver, player_dao=dao.player, notifier=notifier
+            dao=team_leaver, player_dao=dao.player, notifier=notifier
         )
 
     @provide
@@ -538,27 +497,17 @@ class TeamProvider(Provider):
     def edit_team(self, dao: HolderDao, notifier: TeamNotifier) -> EditTeamInteractor:
         return EditTeamInteractor(dao=dao.team, team_player_dao=dao.team_player, notifier=notifier)
 
-    @provide
-    def captained_teams_reader(self, dao: HolderDao) -> CaptainedTeamsReader:
-        return CaptainedTeamsReaderImpl(dao=dao)
+    captained_teams_reader = provide(CaptainedTeamsReaderImpl, provides=CaptainedTeamsReader)
 
     my_captained_teams = provide(MyCaptainedTeamsInteractor)
 
-    @provide
-    def captain_team_joiner(self, dao: HolderDao) -> CaptainTeamJoiner:
-        return CaptainTeamJoinerImpl(dao=dao)
+    captain_team_joiner = provide(CaptainTeamJoinerImpl, provides=CaptainTeamJoiner)
 
     join_captained_team = provide(JoinCaptainedTeamInteractor)
 
-    @provide
-    def team_captain_setter(self, dao: HolderDao) -> TeamCaptainSetter:
-        return TeamCaptainSetterImpl(dao=dao)
+    team_captain_setter = provide(TeamCaptainSetterImpl, provides=TeamCaptainSetter)
 
     change_captain = provide(ChangeCaptainInteractor)
-
-    @provide
-    def chatless_team_creator(self, dao: HolderDao) -> ChatlessTeamCreator:
-        return TeamCreatorImpl(dao=dao)
 
     @provide
     def create_team(
@@ -570,9 +519,7 @@ class TeamProvider(Provider):
 class SearchProvider(Provider):
     scope = Scope.REQUEST
 
-    @provide
-    def global_search_dao(self, dao: HolderDao) -> GlobalSearchDao:
-        return GlobalSearchDaoImpl(dao)
+    global_search_dao = provide(GlobalSearchDaoImpl, provides=GlobalSearchDao)
 
     global_search = provide(GlobalSearchInteractor)
 
@@ -580,42 +527,21 @@ class SearchProvider(Provider):
 class AdminProvider(Provider):
     scope = Scope.REQUEST
 
-    # DAO adapters. complex2/waiver impls import HolderDao directly, so dishka can
-    # analyse the class-provide shorthand. complex/player and complex/team impls
-    # import HolderDao under TYPE_CHECKING (to break a circular import), so they
-    # need an explicit factory instead.
+    # DAO adapters
     admin_poll_reader_dao = provide(AdminPollReaderImpl, provides=AdminPollReader)
     poll_vote_remover_dao = provide(PollVoteRemoverImpl, provides=PollVoteRemover)
     admin_waivers_reader_dao = provide(AdminGameWaiversReaderImpl, provides=AdminGameWaiversReader)
     admin_waiver_editor_dao = provide(AdminWaiverEditorImpl, provides=AdminWaiverEditor)
 
-    @provide
-    def admin_email_setter(self, dao: HolderDao) -> AdminEmailSetter:
-        return AdminEmailSetterImpl(dao)
-
-    @provide
-    def admin_tg_changer(self, dao: HolderDao) -> AdminTgChanger:
-        return AdminTgChangerImpl(dao)
-
-    @provide
-    def admin_username_setter(self, dao: HolderDao) -> AdminUsernameSetter:
-        return AdminUsernameSetterImpl(dao)
-
-    @provide
-    def admin_player_reader(self, dao: HolderDao) -> AdminPlayerReader:
-        return AdminPlayerReaderImpl(dao)
-
-    @provide
-    def admin_player_merger_dao(self, dao: HolderDao) -> AdminPlayerMerger:
-        return AdminPlayerMergerImpl(dao)
-
-    @provide
-    def admin_player_waiver_points_dao(self, dao: HolderDao) -> AdminPlayerWaiverPointsReader:
-        return AdminPlayerWaiverPointsReaderImpl(dao)
-
-    @provide
-    def admin_team_merger_dao(self, dao: HolderDao) -> AdminTeamMerger:
-        return AdminTeamMergerImpl(dao)
+    admin_email_setter = provide(AdminEmailSetterImpl, provides=AdminEmailSetter)
+    admin_tg_changer = provide(AdminTgChangerImpl, provides=AdminTgChanger)
+    admin_username_setter = provide(AdminUsernameSetterImpl, provides=AdminUsernameSetter)
+    admin_player_reader = provide(AdminPlayerReaderImpl, provides=AdminPlayerReader)
+    admin_player_merger_dao = provide(AdminPlayerMergerImpl, provides=AdminPlayerMerger)
+    admin_player_waiver_points_dao = provide(
+        AdminPlayerWaiverPointsReaderImpl, provides=AdminPlayerWaiverPointsReader
+    )
+    admin_team_merger_dao = provide(AdminTeamMergerImpl, provides=AdminTeamMerger)
 
     # Interactors
     admin_set_email = provide(AdminSetPlayerEmailInteractor)
@@ -639,10 +565,10 @@ class AdminProvider(Provider):
 
     @provide
     def admin_remove_player_from_team(
-        self, dao: HolderDao, notifier: TeamNotifier
+        self, dao: HolderDao, team_leaver: TeamLeaver, notifier: TeamNotifier
     ) -> AdminRemovePlayerFromTeamInteractor:
         return AdminRemovePlayerFromTeamInteractor(
-            dao=dao.team_leaver, player_dao=dao.player, notifier=notifier
+            dao=team_leaver, player_dao=dao.player, notifier=notifier
         )
 
     admin_waivers_reader = provide(AdminGameWaiversReaderInteractor)
@@ -656,9 +582,9 @@ class AdminProvider(Provider):
     admin_update_scenario = provide(AdminUpdateGameScenarioInteractor)
     admin_upload_file = provide(AdminUploadGameFileInteractor)
 
-    @provide
-    def file_garbage_collector_dao(self, dao: HolderDao) -> FileGarbageCollectorDao:
-        return FileGarbageCollectorImpl(dao=dao)
+    file_garbage_collector_dao = provide(
+        FileGarbageCollectorImpl, provides=FileGarbageCollectorDao
+    )
 
     @provide
     def collect_file_garbage(
@@ -666,13 +592,12 @@ class AdminProvider(Provider):
     ) -> CollectFileGarbageInteractor:
         return CollectFileGarbageInteractor(dao=dao, storage=storage)
 
-    @provide
-    def admin_game_scenario_editor(self, dao: HolderDao) -> AdminGameScenarioEditor:
-        return AdminGameScenarioEditorImpl(dao=dao)
-
-    @provide
-    def admin_game_status_changer(self, dao: HolderDao) -> AdminGameStatusChanger:
-        return AdminGameStatusChangerImpl(dao=dao)
+    admin_game_scenario_editor = provide(
+        AdminGameScenarioEditorImpl, provides=AdminGameScenarioEditor
+    )
+    admin_game_status_changer = provide(
+        AdminGameStatusChangerImpl, provides=AdminGameStatusChanger
+    )
 
     @provide
     def admin_level_resender(self, dao: GamePlayerDao) -> AdminLevelResender:
@@ -745,13 +670,14 @@ class RequestProvider(Provider):
         dao: HolderDao,
         requests: RequestStorage,
         notifications: NotificationWriter,
+        org_adder: OrgAdder,
         notifier: RequestNotifier,
     ) -> CreateOrgInviteInteractor:
         return CreateOrgInviteInteractor(
             requests=requests,
             notifications=notifications,
             player_dao=dao.player,
-            org_adder=dao.org_adder,
+            org_adder=org_adder,
             notifier=notifier,
         )
 
@@ -810,6 +736,10 @@ class RequestProvider(Provider):
         dao: HolderDao,
         requests: RequestStorage,
         notifications: NotificationWriter,
+        org_adder: OrgAdder,
+        team_merger: TeamMerger,
+        player_merger: PlayerMerger,
+        player_promoter: PlayerPromoter,
         team_notifier: TeamNotifier,
         org_notifier: OrgNotifier,
         game_log: GameLogWriter,
@@ -822,10 +752,10 @@ class RequestProvider(Provider):
             team_dao=dao.team,
             team_player_dao=dao.team_player,
             player_dao=dao.player,
-            org_adder=dao.org_adder,
-            team_merger=dao.team_merger,
-            player_merger=dao.player_merger,
-            player_promoter=dao.player_promoter,
+            org_adder=org_adder,
+            team_merger=team_merger,
+            player_merger=player_merger,
+            player_promoter=player_promoter,
             game_log=game_log,
             team_notifier=team_notifier,
             org_notifier=org_notifier,

--- a/shvatka/infrastructure/picture/results_painter.py
+++ b/shvatka/infrastructure/picture/results_painter.py
@@ -1,6 +1,7 @@
 from aiogram import Bot
 from aiogram.types import BufferedInputFile
 
+from shvatka.core.interfaces.dal.complex import GameStatDao
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.services.game import get_full_game
@@ -11,9 +12,12 @@ from shvatka.tgbot.config.models.bot import BotConfig
 
 
 class ResultsPainter:
-    def __init__(self, bot: Bot, dao: HolderDao, config: BotConfig) -> None:
+    def __init__(
+        self, bot: Bot, dao: HolderDao, game_stat: GameStatDao, config: BotConfig
+    ) -> None:
         self.bot = bot
         self.dao = dao
+        self.game_stat = game_stat
         self.chat_id = config.log_chat
 
     async def get_game_results(self, game: dto.Game, identity: IdentityProvider) -> str:
@@ -24,7 +28,7 @@ class ResultsPainter:
             identity=identity,
             dao=self.dao.game,
         )
-        game_stat = await get_game_stat(current_game, identity, self.dao.game_stat)
+        game_stat = await get_game_stat(current_game, identity, self.game_stat)
         return await self.paint_game_results(current_game, game_stat)
 
     async def paint_game_results(self, game: dto.FullGame, game_stat: dto.GameStat) -> str:

--- a/shvatka/infrastructure/scheduler/wrappers.py
+++ b/shvatka/infrastructure/scheduler/wrappers.py
@@ -6,6 +6,9 @@ from dishka.integrations.base import FromDishka
 from shvatka.core.games.game_play import prepare_game, send_hint, start_game
 from shvatka.core.games.interactors import GamePlayTimerInteractor
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.game_play import GamePreparer
+from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
+from shvatka.core.interfaces.dal.level_times import GameStarter
 from shvatka.core.interfaces.scheduler import LevelTestScheduler, Scheduler
 from shvatka.core.models import dto
 from shvatka.core.services.level_testing import send_testing_level_hint
@@ -27,12 +30,13 @@ async def prepare_game_wrapper(
     author_id: int,
     dao: FromDishka[HolderDao],
     view_preparer: FromDishka[GameViewPreparer],
+    game_preparer: FromDishka[GamePreparer],
 ) -> None:
     author = await dao.player.get_by_id(author_id)
     game = await dao.game.get_by_id(game_id, author)
     await prepare_game(
         game=game,
-        game_preparer=dao.game_preparer,
+        game_preparer=game_preparer,
         view_preparer=view_preparer,
     )
 
@@ -45,13 +49,14 @@ async def start_game_wrapper(
     scheduler: FromDishka[Scheduler],
     sender: FromDishka[ViewSender],
     alerter: FromDishka[BotAlert],
+    game_starter: FromDishka[GameStarter],
 ):
     try:
         game = await dao.game.get_full(game_id)
         assert author_id == game.author.id
         await start_game(
             game=game,
-            dao=dao.game_starter,
+            dao=game_starter,
             sender=sender,
             scheduler=scheduler,
         )
@@ -110,6 +115,7 @@ async def send_hint_for_testing_wrapper(
     dao: FromDishka[HolderDao],
     level_view: FromDishka[LevelView],
     scheduler: FromDishka[LevelTestScheduler],
+    level_testing: FromDishka[LevelTestingDao],
 ):
     level = await dao.level.get_by_id(level_id)
     game = await dao.game.get_by_id(game_id)
@@ -121,7 +127,7 @@ async def send_hint_for_testing_wrapper(
         hint_number=hint_number,
         view=level_view,
         scheduler=scheduler,
-        dao=dao.level_testing_complex,
+        dao=level_testing,
     )
 
 

--- a/shvatka/tgbot/dialogs/game_manage/getters.py
+++ b/shvatka/tgbot/dialogs/game_manage/getters.py
@@ -11,6 +11,7 @@ from telegraph.aio import Telegraph
 
 from shvatka.common.config.models.main import FeaturesConfig
 from shvatka.common.url_factory import UrlFactory
+from shvatka.core.interfaces.dal.complex import TypedKeyGetter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.services import game
@@ -70,6 +71,7 @@ async def get_game_keys(
     dialog_manager: DialogManager,
     telegraph: FromDishka[Telegraph],
     identity: FromDishka[IdentityProvider],
+    typed_keys: FromDishka[TypedKeyGetter],
     **_,
 ):
     data: dict[str, Any] = dialog_manager.start_data  # type: ignore[assignment]
@@ -81,7 +83,11 @@ async def get_game_keys(
     return {
         "game": current_game,
         "key_link": await get_or_create_keys_page(
-            game=current_game, telegraph=telegraph, dao=dao, identity=identity
+            game=current_game,
+            telegraph=telegraph,
+            dao=dao,
+            typed_keys=typed_keys,
+            identity=identity,
         ),
     }
 

--- a/shvatka/tgbot/dialogs/game_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/game_manage/handlers.py
@@ -13,6 +13,7 @@ from shvatka.core.games.editor_interactors import (
     ExportGameZipInteractor,
     PlanGameStartInteractor,
 )
+from shvatka.core.interfaces.dal.complex import GameStatDao
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.nursery import Nursery
 from shvatka.core.models import enums
@@ -271,10 +272,11 @@ async def show_results(
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
     results_sender: FromDishka[ResultsRichSender],
+    game_stat_dao: FromDishka[GameStatDao],
 ):
     game_id = manager.dialog_data["game_id"]
     full_game = await get_full_game(id_=game_id, identity=identity, dao=dao.game)
-    game_stat = await get_game_stat(game=full_game, identity=identity, dao=dao.game_stat)
+    game_stat = await get_game_stat(game=full_game, identity=identity, dao=game_stat_dao)
     assert isinstance(c.message, Message)
     await results_sender.send_results(
         chat_id=c.message.chat.id,
@@ -291,10 +293,11 @@ async def get_excel_results_handler(
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
+    game_stat_dao: FromDishka[GameStatDao],
 ):
     game_id = manager.dialog_data["game_id"]
     full_game = await get_full_game(id_=game_id, identity=identity, dao=dao.game)
-    game_stat = await get_game_stat(game=full_game, identity=identity, dao=dao.game_stat)
+    game_stat = await get_game_stat(game=full_game, identity=identity, dao=game_stat_dao)
     file = BytesIO()
     export_results(game=full_game, game_stat=game_stat, file=file)
     file.seek(0)

--- a/shvatka/tgbot/dialogs/game_publish/handlers.py
+++ b/shvatka/tgbot/dialogs/game_publish/handlers.py
@@ -7,6 +7,7 @@ from aiogram_dialog import DialogManager
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
+from shvatka.core.interfaces.dal.complex import GameStatDao, TypedKeyGetter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.nursery import Nursery
 from shvatka.core.services.game import get_full_game
@@ -25,6 +26,8 @@ async def process_publish_message(
     dao: FromDishka[HolderDao],
     idp: FromDishka[IdentityProvider],
     nursery: FromDishka[Nursery],
+    game_stat_dao: FromDishka[GameStatDao],
+    typed_keys: FromDishka[TypedKeyGetter],
 ):
     if not message.forward_from_chat or message.forward_from_chat.type != "channel":
         return await message.reply("Это не пересланное из канала сообщение.")
@@ -48,8 +51,8 @@ async def process_publish_message(
     data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
     game_id: int = data["game_id"]
     game = await get_full_game(id_=game_id, identity=idp, dao=dao.game)
-    game_stat = await get_game_stat(game=game, identity=idp, dao=dao.game_stat)
-    keys = await get_typed_keys(game=game, identity=idp, dao=dao.typed_keys)
+    game_stat = await get_game_stat(game=game, identity=idp, dao=game_stat_dao)
+    keys = await get_typed_keys(game=game, identity=idp, dao=typed_keys)
     approximate_time = GamePublisher.get_approximate_time_of(game)
     await message.answer(
         "Начинаю отправку сценария в канал, в связи с ограничениями платформы, "

--- a/shvatka/tgbot/dialogs/game_scn/handlers.py
+++ b/shvatka/tgbot/dialogs/game_scn/handlers.py
@@ -11,6 +11,7 @@ from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
 from shvatka.core.games.editor_interactors import ImportGameZipInteractor
+from shvatka.core.interfaces.dal.game import GameCreator
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import enums
 from shvatka.core.services.achievement import add_achievement
@@ -43,7 +44,7 @@ async def process_name(
             player=author, name=enums.Achievement.game_name_joke, dao=dao.achievement
         )
         return await m.answer(
-            "Лол, я ждал эту шутку. " "Но нет, игра не может называться {name}".format(
+            "Лол, я ждал эту шутку. Но нет, игра не может называться {name}".format(
                 name=hd.bold(hd.quote(game_name))
             )
         )
@@ -105,13 +106,14 @@ async def save_game(
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
+    game_creator: FromDishka[GameCreator],
 ):
     author = await identity.get_required_player()
     name: str = manager.dialog_data["game_name"]
     levels = await get_all_my_free_levels(author, dao.level)
     multiselect = typing.cast(ManagedMultiselect, manager.find("my_free_level_ids"))
     levels = list(filter(lambda level: multiselect.is_checked(level.db_id), levels))
-    game = await create_game(author=author, name=name, dao=dao.game_creator, levels=levels)
+    game = await create_game(author=author, name=name, dao=game_creator, levels=levels)
     assert isinstance(c.message, Message)
     await c.message.edit_text("Игра успешно сохранена")
     await manager.done(result={"game": game})
@@ -129,11 +131,12 @@ async def add_level_handler(
     item_id: str,
     idp: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
+    game_creator: FromDishka[GameCreator],
 ):
     data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
     game_id = data["game_id"]
     author = await idp.get_required_player()
     game = await get_full_game(game_id, identity=idp, dao=dao.game)
     level = await get_by_id(int(item_id), author=author, dao=dao.level)
-    await add_level(game=game, level=level, author=author, dao=dao.game_creator)
+    await add_level(game=game, level=level, author=author, dao=game_creator)
     await manager.switch_to(state=states.GameEditSG.current_levels)

--- a/shvatka/tgbot/dialogs/game_spy/getters.py
+++ b/shvatka/tgbot/dialogs/game_spy/getters.py
@@ -6,6 +6,7 @@ from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.complex import GameStatDao
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.services.game_stat import get_game_spy
 from shvatka.core.services.organizers import get_by_player
@@ -40,12 +41,13 @@ async def get_spy(
     dialog_manager: DialogManager,
     identity: FromDishka[IdentityProvider],
     current_game: FromDishka[CurrentGameProvider],
+    game_stat: FromDishka[GameStatDao],
     **_,
 ):
     game = await current_game.get_required_game()
     player = await identity.get_required_player()
     stat = sorted(
-        await get_game_spy(game, player, dao.game_stat),
+        await get_game_spy(game, player, game_stat),
         key=lambda x: (-x.level_number, x.start_at),
     )
     result = defaultdict(list)

--- a/shvatka/tgbot/dialogs/game_spy/handlers.py
+++ b/shvatka/tgbot/dialogs/game_spy/handlers.py
@@ -7,9 +7,9 @@ from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.complex import TypedKeyGetter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.utils.datetime_utils import tz_utc
-from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.views.keys import create_keys_page
 from shvatka.tgbot.views.telegraph import Telegraph
 
@@ -20,13 +20,17 @@ async def keys_handler(
     widget: Button,
     manager: DialogManager,
     identity: FromDishka[IdentityProvider],
-    dao: FromDishka[HolderDao],
     telegraph: FromDishka[Telegraph],
+    typed_keys: FromDishka[TypedKeyGetter],
     current_game: FromDishka[CurrentGameProvider],
 ):
     game = await current_game.get_required_game()
     page = await create_keys_page(
-        game=game, telegraph=telegraph, dao=dao, salt=game.manage_token[:8], identity=identity
+        game=game,
+        telegraph=telegraph,
+        dao=typed_keys,
+        salt=game.manage_token[:8],
+        identity=identity,
     )
     manager.dialog_data["key_link"] = page["url"]
     manager.dialog_data["updated"] = datetime.now(tz=tz_utc).isoformat()

--- a/shvatka/tgbot/dialogs/level_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/level_manage/handlers.py
@@ -11,6 +11,7 @@ from dishka.integrations.aiogram import CONTAINER_NAME
 from dishka.integrations.aiogram_dialog import inject
 
 from shvatka.core.interfaces.dal.level import LevelDeleter
+from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.nursery import Nursery
 from shvatka.core.interfaces.scheduler import LevelTestScheduler
@@ -90,6 +91,7 @@ async def level_testing(
     view: FromDishka[LevelView],
     identity: FromDishka[IdentityProvider],
     dao: FromDishka[HolderDao],
+    level_testing: FromDishka[LevelTestingDao],
 ) -> None:
     data: dict[str, Any] = manager.start_data  # type: ignore[assignment]
     level_id = data["level_id"]
@@ -102,9 +104,7 @@ async def level_testing(
         return
     suite = dto.LevelTestSuite(tester=org, level=level)
     await manager.start(state=states.LevelTestSG.wait_key, data={"level_id": level_id})
-    await start_level_test(
-        suite=suite, scheduler=scheduler, view=view, dao=dao.level_testing_complex
-    )
+    await start_level_test(suite=suite, scheduler=scheduler, view=view, dao=level_testing)
 
 
 @inject
@@ -161,7 +161,11 @@ async def cancel_level_test(
 
 @inject
 async def process_key_message(
-    m: Message, dialog_: Any, manager: DialogManager, identity: FromDishka[IdentityProvider]
+    m: Message,
+    dialog_: Any,
+    manager: DialogManager,
+    identity: FromDishka[IdentityProvider],
+    level_testing: FromDishka[LevelTestingDao],
 ) -> None:
     dishka: AsyncContainer = manager.middleware_data[CONTAINER_NAME]
     author = await identity.get_required_player()
@@ -181,7 +185,7 @@ async def process_key_message(
         view=view,
         org_notifier=org_notifier,
         locker=locker,
-        dao=dao.level_testing_complex,
+        dao=level_testing,
     )
     if insert_result.level_completed:
         await manager.done()

--- a/shvatka/tgbot/dialogs/level_scn/handlers.py
+++ b/shvatka/tgbot/dialogs/level_scn/handlers.py
@@ -8,6 +8,7 @@ from aiogram_dialog.widgets.kbd import Button
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
+from shvatka.core.interfaces.dal.game import GameUpserter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.models.dto import action, hints, scn
@@ -303,6 +304,7 @@ async def save_level(
     identity: FromDishka[IdentityProvider],
     retort: FromDishka[Retort],
     dao: FromDishka[HolderDao],
+    game_upserter: FromDishka[GameUpserter],
 ):
     author = await identity.get_required_player()
     data = manager.dialog_data
@@ -316,7 +318,7 @@ async def save_level(
         conditions=conditions,
         __model_version__=1,
     )
-    level = await upsert_level(author=author, scenario=level_scn, dao=dao.game_upserter)
+    level = await upsert_level(author=author, scenario=level_scn, dao=game_upserter)
     await manager.done(result={"level": retort.dump(level)})
     await c.answer(text="Уровень успешно сохранён")
 

--- a/shvatka/tgbot/dialogs/starters/organizer.py
+++ b/shvatka/tgbot/dialogs/starters/organizer.py
@@ -4,6 +4,7 @@ from aiogram_dialog import DialogManager
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.dal.level_testing import LevelTestingDao
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.interfaces.scheduler import LevelTestScheduler
 from shvatka.core.models import dto
@@ -27,6 +28,7 @@ async def start_test_level(
     identity: FromDishka[IdentityProvider],
     scheduler: FromDishka[LevelTestScheduler],
     level_view: FromDishka[LevelView],
+    level_testing: FromDishka[LevelTestingDao],
 ):
     player = await identity.get_required_player()
     org = await get_org_by_id(callback_data.org_id, dao.organizer)
@@ -44,9 +46,7 @@ async def start_test_level(
         states.LevelTestSG.wait_key,
         data={"level_id": callback_data.level_id, "org_id": org.id},
     )
-    await start_level_test(
-        suite=suite, scheduler=scheduler, view=level_view, dao=dao.level_testing_complex
-    )
+    await start_level_test(suite=suite, scheduler=scheduler, view=level_view, dao=level_testing)
 
 
 def setup() -> Router:

--- a/shvatka/tgbot/dialogs/team_manage/handlers.py
+++ b/shvatka/tgbot/dialogs/team_manage/handlers.py
@@ -9,6 +9,7 @@ from aiogram_dialog.widgets.kbd import Button
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
+from shvatka.core.interfaces.dal.player import TeamLeaver
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import enums
 from shvatka.core.players.player import (
@@ -119,6 +120,7 @@ async def remove_player_handler(
     identity: FromDishka[IdentityProvider],
     team_notifier: FromDishka[TeamNotifier],
     dao: FromDishka[HolderDao],
+    team_leaver: FromDishka[TeamLeaver],
 ):
     captain_team_player = await get_actual_team_player(identity)
     player_id = manager.dialog_data["selected_player_id"]
@@ -127,7 +129,7 @@ async def remove_player_handler(
     await leave(
         player=player,
         remover=captain_team_player.player,
-        dao=dao.team_leaver,
+        dao=team_leaver,
         notifier=team_notifier,
     )
     await manager.switch_to(state=states.CaptainsBridgeSG.players)
@@ -244,7 +246,7 @@ async def gotten_chat_request(
     except exceptions.AnotherTeamInChat:
         await bot.send_message(
             chat_id=captain.get_chat_id(),  # type: ignore[arg-type]
-            text=f"‼️Другая команда уже находится в чате " f"({hd.quote(chat.name)}).\n",
+            text=f"‼️Другая команда уже находится в чате ({hd.quote(chat.name)}).\n",
         )
         return
     if old_chat_id is None:

--- a/shvatka/tgbot/dialogs/team_view/handlers.py
+++ b/shvatka/tgbot/dialogs/team_view/handlers.py
@@ -6,6 +6,7 @@ from aiogram_dialog.widgets.kbd import Button
 from dishka import FromDishka
 from dishka.integrations.aiogram_dialog import inject
 
+from shvatka.core.interfaces.dal.player import TeamLeaver
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.players.player import leave
 from shvatka.core.views.team import TeamNotifier
@@ -40,7 +41,8 @@ async def on_leave_team(
     identity: FromDishka[IdentityProvider],
     team_notifier: FromDishka[TeamNotifier],
     dao: FromDishka[HolderDao],
+    team_leaver: FromDishka[TeamLeaver],
 ):
     player = (await get_actual_team_player(identity)).player
-    await leave(player, player, dao.team_leaver, notifier=team_notifier)
+    await leave(player, player, team_leaver, notifier=team_notifier)
     await dialog_manager.done()

--- a/shvatka/tgbot/handlers/admin.py
+++ b/shvatka/tgbot/handlers/admin.py
@@ -5,6 +5,7 @@ from aiogram.filters import Command, CommandObject
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.dal.complex import TeamMerger
 from shvatka.core.notifications.request_interactors import CreatePlayerMergeRequestInteractor
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.views.game import GameLogWriter
@@ -20,6 +21,7 @@ async def merge_teams_command(
     command: CommandObject,
     game_log: FromDishka[GameLogWriter],
     dao: FromDishka[HolderDao],
+    team_merger: FromDishka[TeamMerger],
 ):
     if not command.args:
         await message.reply(
@@ -31,7 +33,7 @@ async def merge_teams_command(
     primary = await get_team_by_id(new_id, dao.team)
     assert primary.captain
     secondary = await get_team_by_id(old_id, dao.team)
-    await merge_teams(primary.captain, primary, secondary, game_log, dao.team_merger)
+    await merge_teams(primary.captain, primary, secondary, game_log, team_merger)
     await message.reply(f"Успешно объединены {primary.name} и {secondary.name}")
 
 

--- a/shvatka/tgbot/handlers/game/add_organizer.py
+++ b/shvatka/tgbot/handlers/game/add_organizer.py
@@ -11,6 +11,7 @@ from aiogram_dialog.api.protocols import BgManagerFactory
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.dal.organizer import OrgAdder
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.services.game import get_game
 from shvatka.core.services.organizers import (
@@ -88,6 +89,7 @@ async def agree_to_be_org_handler(
     identity: FromDishka[IdentityProvider],
     org_notifier: FromDishka[OrgNotifier],
     bg_manager_factory: FromDishka[BgManagerFactory],
+    org_adder: FromDishka[OrgAdder],
 ):
     player = await identity.get_required_player()
     try:
@@ -96,7 +98,7 @@ async def agree_to_be_org_handler(
             inviter_id=callback_data.inviter_id,
             player=player,
             org_notifier=org_notifier,
-            dao=dao.org_adder,
+            dao=org_adder,
         )
     except exceptions.SaltNotExist:
         await bot.edit_message_text(

--- a/shvatka/tgbot/handlers/merge.py
+++ b/shvatka/tgbot/handlers/merge.py
@@ -6,6 +6,8 @@ from aiogram_dialog.api.protocols import BgManagerFactory
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.dal.complex import TeamMerger
+from shvatka.core.players.interfaces import PlayerMerger
 from shvatka.core.players.player import merge_players
 from shvatka.core.services.team import get_team_by_id, merge_teams
 from shvatka.core.views.game import GameLogWriter
@@ -26,12 +28,13 @@ async def confirm_merge_team(
     dao: FromDishka[HolderDao],
     game_log: FromDishka[GameLogWriter],
     bg_manager_factory: FromDishka[BgManagerFactory],
+    team_merger: FromDishka[TeamMerger],
     bot: Bot,
 ):
     primary = await get_team_by_id(callback_data.primary_team_id, dao.team)
     assert primary.captain
     secondary = await get_team_by_id(callback_data.secondary_team_id, dao.team)
-    await merge_teams(primary.captain, primary, secondary, game_log, dao.team_merger)
+    await merge_teams(primary.captain, primary, secondary, game_log, team_merger)
     await callback_query.answer("Успешно объединено")
     assert isinstance(callback_query.message, Message)
     await callback_query.message.edit_reply_markup(reply_markup=None)
@@ -47,11 +50,12 @@ async def confirm_merge_players(
     dao: FromDishka[HolderDao],
     game_log: FromDishka[GameLogWriter],
     bg_manager_factory: FromDishka[BgManagerFactory],
+    player_merger: FromDishka[PlayerMerger],
     bot: Bot,
 ):
     primary = await dao.player.get_identities_by_id(callback_data.primary_player_id)
     secondary = await dao.player.get_identities_by_id(callback_data.secondary_player_id)
-    await merge_players(primary, secondary, game_log, dao.player_merger)
+    await merge_players(primary, secondary, game_log, player_merger)
     await callback_query.answer("Успешно объединено")
     assert isinstance(callback_query.message, Message)
     await callback_query.message.edit_reply_markup(reply_markup=None)

--- a/shvatka/tgbot/handlers/player.py
+++ b/shvatka/tgbot/handlers/player.py
@@ -16,6 +16,7 @@ from aiogram_dialog.api.protocols import BgManagerFactory
 from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
+from shvatka.core.interfaces.dal.player import PlayerPromoter, TeamLeaver
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.players.player import (
     agree_promotion,
@@ -101,6 +102,7 @@ async def agree_promotion_handler(
     bot: Bot,
     identity: FromDishka[IdentityProvider],
     bg_manager_factory: FromDishka[BgManagerFactory],
+    player_promoter: FromDishka[PlayerPromoter],
 ):
     player = await identity.get_required_player()
     try:
@@ -108,7 +110,7 @@ async def agree_promotion_handler(
             token=callback_data.token,
             inviter_id=callback_data.inviter_id,
             target=player,
-            dao=dao.player_promoter,
+            dao=player_promoter,
         )
     except SaltNotExist:
         await bot.edit_message_text(
@@ -153,13 +155,14 @@ async def leave_handler(
     dao: FromDishka[HolderDao],
     identity: FromDishka[IdentityProvider],
     team_notifier: FromDishka[TeamNotifier],
+    team_leaver: FromDishka[TeamLeaver],
 ):
     player = await identity.get_required_player()
     team = await get_my_team(player, dao.team_player)
     if team is None:
         await message.reply("Ты не состоишь в команде")
         return
-    await leave(player, player, dao.team_leaver, notifier=team_notifier)
+    await leave(player, player, team_leaver, notifier=team_notifier)
     text = render_leave_confirmation(
         player,
         team,

--- a/shvatka/tgbot/handlers/team/manage.py
+++ b/shvatka/tgbot/handlers/team/manage.py
@@ -17,6 +17,7 @@ from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
 from shvatka.core.interfaces.dal.player import PlayerTeamChecker
+from shvatka.core.interfaces.dal.team import TeamCreator
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto
 from shvatka.core.players.player import (
@@ -68,6 +69,7 @@ async def cmd_create_team(
     bot: Bot,
     identity: FromDishka[IdentityProvider],
     game_log: FromDishka[GameLogWriter],
+    team_creator: FromDishka[TeamCreator],
 ):
     chat = await identity.get_required_chat()
     player = await identity.get_required_player()
@@ -80,7 +82,7 @@ async def cmd_create_team(
 
     chat.description = (await bot.get_chat(chat.tg_id)).description
     try:
-        await create_team(chat, player, dao.team_creator, game_log)
+        await create_team(chat, player, team_creator, game_log)
     except PlayerAlreadyInTeam as e:
         team_name = hd.quote(e.team.name)  # type: ignore[union-attr]
         return await message.reply(

--- a/shvatka/tgbot/handlers/waivers.py
+++ b/shvatka/tgbot/handlers/waivers.py
@@ -10,6 +10,7 @@ from dishka import FromDishka
 from dishka.integrations.aiogram import inject
 
 from shvatka.core.interfaces.current_game import CurrentGameProvider
+from shvatka.core.interfaces.dal.waiver import WaiverApprover
 from shvatka.core.models import dto
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.models.enums.played import Played
@@ -189,6 +190,7 @@ async def confirm_approve_waivers_handler(
     identity_provider: FromDishka[TgBotIdentityProvider],
     interactor: FromDishka[TeamWaiversDraftReaderInteractor],
     current_game: FromDishka[CurrentGameProvider],
+    waiver_approver: FromDishka[WaiverApprover],
 ):
     game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
@@ -196,7 +198,7 @@ async def confirm_approve_waivers_handler(
     team = await get_my_team(player, dao.team_player)
     check_same_team(callback_data, player, team)
     assert team
-    await approve_waivers(game=game, team=team, approver=player, dao=dao.waiver_approver)
+    await approve_waivers(game=game, team=team, approver=player, dao=waiver_approver)
     waiver_results = await interactor(game_id=game.id, identity=identity_provider)
     await bot.send_message(
         chat_id=team.get_chat_id(),  # type: ignore[arg-type]
@@ -260,6 +262,7 @@ async def waiver_remove_user_vote(
     identity_provider: FromDishka[TgBotIdentityProvider],
     read_interactor: FromDishka[TeamWaiversDraftReaderInteractor],
     current_game: FromDishka[CurrentGameProvider],
+    waiver_approver: FromDishka[WaiverApprover],
 ):
     game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
@@ -269,7 +272,7 @@ async def waiver_remove_user_vote(
         raise PlayerNotInTeam(player=player, team=team)
     check_same_team(callback_data, player, team)
     target = await dao.player.get_by_id(callback_data.player_id)
-    await revoke_vote_by_captain(game, team, player, target, dao.waiver_approver)
+    await revoke_vote_by_captain(game, team, player, target, waiver_approver)
     waiver_results = await read_interactor(game_id=game.id, identity=identity_provider)
     await c.message.edit_text(  # type: ignore[union-attr]
         **start_approve_waivers(game, team, waiver_results)
@@ -283,6 +286,7 @@ async def waiver_add_force_menu(
     dao: FromDishka[HolderDao],
     identity_provider: FromDishka[TgBotIdentityProvider],
     current_game: FromDishka[CurrentGameProvider],
+    waiver_approver: FromDishka[WaiverApprover],
 ):
     game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
@@ -291,8 +295,8 @@ async def waiver_add_force_menu(
     if team is None:
         raise PlayerNotInTeam(player=player, team=team)
     check_same_team(callback_data, player, team)
-    check_allow_approve_waivers(await get_full_team_player(player, team, dao.waiver_approver))
-    players = await get_not_played_team_players(team=team, dao=dao.waiver_approver)
+    check_allow_approve_waivers(await get_full_team_player(player, team, waiver_approver))
+    players = await get_not_played_team_players(team=team, dao=waiver_approver)
     await c.message.edit_text(  # type: ignore[union-attr]
         text="Кого из игроков добавить в список вейверов принудительно?",
         reply_markup=kb.get_kb_force_add_waivers(team, players, game),
@@ -308,6 +312,7 @@ async def add_force_player(
     identity_provider: FromDishka[TgBotIdentityProvider],
     waiver_vote_adder_dao: FromDishka[WaiverVoteAdder],
     current_game: FromDishka[CurrentGameProvider],
+    waiver_approver: FromDishka[WaiverApprover],
 ):
     game = await current_game.get_required_game()
     player = await identity_provider.get_required_player()
@@ -316,10 +321,10 @@ async def add_force_player(
     if team is None:
         raise PlayerNotInTeam(player=player, team=team)
     check_same_team(callback_data, player, team)
-    check_allow_approve_waivers(await get_full_team_player(player, team, dao.waiver_approver))
+    check_allow_approve_waivers(await get_full_team_player(player, team, waiver_approver))
     target = await dao.player.get_by_id(callback_data.player_id)
     await force_add_vote(game, team, target, Played.yes, dao=waiver_vote_adder_dao)
-    players = await get_not_played_team_players(team=team, dao=dao.waiver_approver)
+    players = await get_not_played_team_players(team=team, dao=waiver_approver)
     await c.message.edit_text(  # type: ignore[union-attr]
         text="Кого из игроков добавить в список вейверов принудительно?",
         reply_markup=kb.get_kb_force_add_waivers(team, players, game),

--- a/shvatka/tgbot/views/keys.py
+++ b/shvatka/tgbot/views/keys.py
@@ -6,6 +6,7 @@ from typing import Any
 from aiogram.utils.text_decorations import html_decoration as hd
 from telegraph.aio import Telegraph
 
+from shvatka.core.interfaces.dal.complex import TypedKeyGetter
 from shvatka.core.interfaces.identity import IdentityProvider
 from shvatka.core.models import dto, enums
 from shvatka.core.models.dto import action, scn
@@ -63,11 +64,11 @@ def render_log_keys(log_keys: dict[dto.Team, list[dto.KeyTime]]) -> str:
 async def create_keys_page(
     game: dto.Game,
     telegraph: Telegraph,
-    dao: HolderDao,
+    dao: TypedKeyGetter,
     identity: IdentityProvider,
     salt: str = "",
 ) -> dict[str, Any]:
-    keys = await get_typed_keys(game=game, identity=identity, dao=dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=dao)
     text = render_log_keys(keys)
     page = await telegraph.create_page(
         title=f"{salt} Лог ключей игры {game.name}",
@@ -82,11 +83,15 @@ async def create_keys_page(
 
 
 async def get_or_create_keys_page(
-    game: dto.Game, identity: IdentityProvider, telegraph: Telegraph, dao: HolderDao
+    game: dto.Game,
+    identity: IdentityProvider,
+    telegraph: Telegraph,
+    dao: HolderDao,
+    typed_keys: TypedKeyGetter,
 ) -> str:
     if game.results.keys_url:
         return game.results.keys_url
-    page = await create_keys_page(game, telegraph, dao, identity=identity)
+    page = await create_keys_page(game, telegraph, typed_keys, identity=identity)
     await dao.game.set_keys_url(game, page["url"])
     await dao.game.commit()
     game.results.keys_url = page["url"]

--- a/tests/fixtures/game_fixtures.py
+++ b/tests/fixtures/game_fixtures.py
@@ -20,6 +20,9 @@ from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
 from shvatka.core.waiver.adapters import WaiverVoteAdder
 from shvatka.core.waiver.services import add_vote, approve_waivers, get_all_played
+from shvatka.infrastructure.db.dao.complex.game import GameUpserterImpl
+from shvatka.infrastructure.db.dao.complex.game_play import GamePlayerDaoImpl
+from shvatka.infrastructure.db.dao.complex.waiver import WaiverApproverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.mocks.team_notifier import TeamNotifierMock
 
@@ -35,7 +38,7 @@ async def game(
     return await upsert_game(
         complex_scn,
         author,
-        dao.game_upserter,
+        GameUpserterImpl(dao),
         retort,
         file_gateway,
     )
@@ -92,7 +95,9 @@ async def finished_game(
 ) -> dto.FullGame:
     game = started_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     await key_processor.submit_key(
         key="SHWRONG",
         player=ron,
@@ -123,7 +128,7 @@ async def finished_game(
         player=draco,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(slytherin, game.levels[0], game, 1)
+    await GamePlayerDaoImpl(dao).level_up(slytherin, game.levels[0], game, 1)
     await asyncio.sleep(0.1)
     await key_processor.submit_key(
         key="SH123",
@@ -131,7 +136,7 @@ async def finished_game(
         player=ron,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(gryffindor, game.levels[0], game, 1)
+    await GamePlayerDaoImpl(dao).level_up(gryffindor, game.levels[0], game, 1)
     await asyncio.sleep(0.2)
     await key_processor.submit_key(
         key="SHOOT",
@@ -139,7 +144,7 @@ async def finished_game(
         player=hermione,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(gryffindor, game.levels[1], game, 2)
+    await GamePlayerDaoImpl(dao).level_up(gryffindor, game.levels[1], game, 2)
     await asyncio.sleep(0.1)
     await key_processor.submit_key(
         key="SHOOT",
@@ -147,7 +152,7 @@ async def finished_game(
         player=draco,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(slytherin, game.levels[1], game, 2)
+    await GamePlayerDaoImpl(dao).level_up(slytherin, game.levels[1], game, 2)
     await dao.game.set_finished(game)
     await dao.commit()
 
@@ -162,7 +167,7 @@ async def routed_game(
     file_gateway: FileGateway,
     retort: Retort,
 ):
-    game = await upsert_game(routed_scn, author, dao.game_upserter, retort, file_gateway)
+    game = await upsert_game(routed_scn, author, GameUpserterImpl(dao), retort, file_gateway)
     await dao.game.set_start_at(game, datetime.fromisoformat("2025-04-12T16:00:00Z"))
     await dao.commit()
     return game
@@ -219,7 +224,9 @@ async def finished_routed_game(
 ) -> dto.FullGame:
     game = started_routed_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     await key_processor.submit_key(
         key="SHWRONG",
         player=ron,
@@ -232,21 +239,21 @@ async def finished_routed_game(
         team=gryffindor,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(gryffindor, game.levels[0], game, 2)
+    await GamePlayerDaoImpl(dao).level_up(gryffindor, game.levels[0], game, 2)
     await key_processor.submit_key(
         key="SHTO3",
         player=draco,
         team=slytherin,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(slytherin, game.levels[0], game, 2)
+    await GamePlayerDaoImpl(dao).level_up(slytherin, game.levels[0], game, 2)
     await key_processor.submit_key(
         key="SHTO1",
         player=ron,
         team=gryffindor,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(gryffindor, game.levels[0], game, 0)
+    await GamePlayerDaoImpl(dao).level_up(gryffindor, game.levels[0], game, 0)
     await key_processor.submit_key(
         key="SHTO3",
         player=harry,
@@ -259,14 +266,14 @@ async def finished_routed_game(
         team=gryffindor,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(slytherin, game.levels[0], game, 3)
+    await GamePlayerDaoImpl(dao).level_up(slytherin, game.levels[0], game, 3)
     await key_processor.submit_key(
         key="SHT3",
         player=draco,
         team=slytherin,
         now=datetime.now(tz_utc),
     )
-    await dao.game_player.level_up(slytherin, game.levels[0], game, 3)
+    await GamePlayerDaoImpl(dao).level_up(slytherin, game.levels[0], game, 3)
     await dao.game.set_finished(game)
     await dao.commit()
 
@@ -295,8 +302,8 @@ async def add_waivers(
     await add_vote(game, gryffindor, ron, Played.no, waiver_vote_adder)
     await add_vote(game, slytherin, draco, Played.yes, waiver_vote_adder)
 
-    await approve_waivers(game, gryffindor, harry, dao.waiver_approver)
-    await approve_waivers(game, slytherin, draco, dao.waiver_approver)
+    await approve_waivers(game, gryffindor, harry, WaiverApproverImpl(dao))
+    await approve_waivers(game, slytherin, draco, WaiverApproverImpl(dao))
     return game
 
 

--- a/tests/fixtures/team.py
+++ b/tests/fixtures/team.py
@@ -4,6 +4,7 @@ from shvatka.core.models import dto
 from shvatka.core.services.chat import upsert_chat
 from shvatka.core.services.team import create_team
 from shvatka.core.views.game import GameLogWriter
+from shvatka.infrastructure.db.dao.complex.team import TeamCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.chat_constants import create_gryffindor_dto_chat, create_slytherin_dto_chat
 
@@ -24,7 +25,7 @@ async def create_team_(
     return await create_team(
         await upsert_chat(chat, dao.chat),
         captain,
-        dao.team_creator,
+        TeamCreatorImpl(dao),
         game_log,
     )
 
@@ -35,6 +36,6 @@ async def create_second_team(
     return await create_team(
         await upsert_chat(create_slytherin_dto_chat(), dao.chat),
         captain,
-        dao.team_creator,
+        TeamCreatorImpl(dao),
         game_log,
     )

--- a/tests/integration/api_full/test_file_delete.py
+++ b/tests/integration/api_full/test_file_delete.py
@@ -6,6 +6,7 @@ from shvatka.api.app.dependencies.auth import AuthProperties
 from shvatka.core.models import dto
 from shvatka.core.services.game import create_game
 from shvatka.infrastructure.clients.file_storage import LocalFileStorage
+from shvatka.infrastructure.db.dao.complex.game import GameCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
 
@@ -33,7 +34,7 @@ async def test_delete_unused_game_file(
     check_dao: HolderDao,
     local_storage: LocalFileStorage,
 ):
-    game = await create_game(author=author, name="draft delete file", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft delete file", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     guid = await upload(client, game.id, cookies)
     (file_id,) = await check_dao.file_info.get_ids_by_guids([guid])
@@ -75,7 +76,7 @@ async def test_cant_delete_file_used_by_the_release(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft release file", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft release file", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     guid = await upload(client, game.id, cookies)
     saved = await client.put(
@@ -100,8 +101,8 @@ async def test_delete_keeps_a_file_another_game_still_uses(
     check_dao: HolderDao,
     local_storage: LocalFileStorage,
 ):
-    game = await create_game(author=author, name="draft shared file", dao=dao.game_creator)
-    other = await create_game(author=author, name="draft shared file 2", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft shared file", dao=GameCreatorImpl(dao))
+    other = await create_game(author=author, name="draft shared file 2", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     guid = await upload(client, game.id, cookies)
     (file_id,) = await check_dao.file_info.get_ids_by_guids([guid])
@@ -126,7 +127,7 @@ async def test_delete_file_not_in_game(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft delete missing", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft delete missing", dao=GameCreatorImpl(dao))
     resp = await client.delete(
         f"/cdn/games/{game.id}/files/00000000-0000-0000-0000-000000000000",
         cookies=auth_cookies(auth, author),
@@ -143,7 +144,9 @@ async def test_delete_foreign_game_file_forbidden(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft delete forbidden", dao=dao.game_creator)
+    game = await create_game(
+        author=author, name="draft delete forbidden", dao=GameCreatorImpl(dao)
+    )
     guid = await upload(client, game.id, auth_cookies(auth, author))
 
     # harry is not the author of `game`

--- a/tests/integration/api_full/test_file_gc.py
+++ b/tests/integration/api_full/test_file_gc.py
@@ -12,6 +12,7 @@ from shvatka.core.models import dto
 from shvatka.core.services.game import create_game
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.clients.file_storage import LocalFileStorage
+from shvatka.infrastructure.db.dao.complex.game import GameCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
 
@@ -48,7 +49,7 @@ async def test_gc_dry_run_changes_nothing(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft for gc dry run", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft for gc dry run", dao=GameCreatorImpl(dao))
     guid = await upload(client, game.id, author_cookies(auth, author))
     (file_id,) = await check_dao.file_info.get_ids_by_guids([guid])
 
@@ -75,7 +76,7 @@ async def test_gc_deletes_unused_link_and_meta(
     check_dao: HolderDao,
     local_storage: LocalFileStorage,
 ):
-    game = await create_game(author=author, name="draft for gc", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft for gc", dao=GameCreatorImpl(dao))
     guid = await upload(client, game.id, author_cookies(auth, author))
     (file_id,) = await check_dao.file_info.get_ids_by_guids([guid])
     meta = await check_dao.file_info.get_by_guid(guid)
@@ -133,7 +134,7 @@ async def test_gc_keeps_files_the_release_uses(
     check_dao: HolderDao,
     local_storage: LocalFileStorage,
 ):
-    game = await create_game(author=author, name="draft with a banner", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft with a banner", dao=GameCreatorImpl(dao))
     author_auth = author_cookies(auth, author)
     guid = await upload(client, game.id, author_auth)
     (file_id,) = await check_dao.file_info.get_ids_by_guids([guid])

--- a/tests/integration/api_full/test_file_upload.py
+++ b/tests/integration/api_full/test_file_upload.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import NoResultFound
 from shvatka.api.app.dependencies.auth import AuthProperties
 from shvatka.core.models import dto
 from shvatka.core.services.game import create_game
+from shvatka.infrastructure.db.dao.complex.game import GameCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.mocks.file_gateway import FakeTelegram
 
@@ -30,7 +31,7 @@ async def test_uploaded_file_is_sent_to_telegram(
     check_dao: HolderDao,
     telegram: FakeTelegram,
 ):
-    game = await create_game(author=author, name="draft upload ok", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft upload ok", dao=GameCreatorImpl(dao))
 
     resp = await upload(client, game.id, auth_cookies(auth, author))
 
@@ -50,7 +51,7 @@ async def test_file_telegram_refuses_is_not_stored(
     check_dao: HolderDao,
     telegram: FakeTelegram,
 ):
-    game = await create_game(author=author, name="draft upload refused", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft upload refused", dao=GameCreatorImpl(dao))
     telegram.refuse = True
 
     resp = await upload(client, game.id, auth_cookies(auth, author))
@@ -73,7 +74,7 @@ async def test_force_keeps_the_file_telegram_refused(
     check_dao: HolderDao,
     telegram: FakeTelegram,
 ):
-    game = await create_game(author=author, name="draft upload forced", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft upload forced", dao=GameCreatorImpl(dao))
     telegram.refuse = True
 
     resp = await upload(client, game.id, auth_cookies(auth, author), force=True)
@@ -95,7 +96,7 @@ async def test_refused_upload_leaves_no_half_written_file(
     check_dao: HolderDao,
     telegram: FakeTelegram,
 ):
-    game = await create_game(author=author, name="draft upload rollback", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft upload rollback", dao=GameCreatorImpl(dao))
     telegram.refuse = True
 
     await upload(client, game.id, auth_cookies(auth, author))

--- a/tests/integration/api_full/test_game.py
+++ b/tests/integration/api_full/test_game.py
@@ -26,6 +26,7 @@ from shvatka.core.services.game import create_game
 from shvatka.core.services.organizers import flip_permission
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.infrastructure.db import models
+from shvatka.infrastructure.db.dao.complex.game import GameCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.infrastructure.nursery import AsyncioNursery
 from tests.fixtures.scn_fixtures import GUID, GUID_2
@@ -186,7 +187,7 @@ async def test_game_file_uploaded_not_referenced(
 ):
     # a file uploaded for the game but never referenced by a hint must still be
     # readable by the author (authorization is based on game_files, not scenario).
-    game = await create_game(author=author, name="game with unref file", dao=dao.game_creator)
+    game = await create_game(author=author, name="game with unref file", dao=GameCreatorImpl(dao))
     cookies = {"Authorization": "Bearer " + auth.create_user_token(author).access_token}
     up = await client.post(
         f"/cdn/games/{game.id}/files",

--- a/tests/integration/api_full/test_game_edit.py
+++ b/tests/integration/api_full/test_game_edit.py
@@ -10,6 +10,7 @@ from shvatka.core.models import dto
 from shvatka.core.models.enums import GameStatus
 from shvatka.core.services.game import create_game
 from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.infrastructure.db.dao.complex.game import GameCreatorImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
 
@@ -72,7 +73,7 @@ async def test_my_games_list(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft for list", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft for list", dao=GameCreatorImpl(dao))
     resp = await client.get("/games/my", cookies=auth_cookies(auth, author))
     assert resp.status_code == 200, resp.text
     ids = [g["id"] for g in resp.json()["content"]]
@@ -110,7 +111,7 @@ async def test_scenario_files_round_trip(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft with file ref", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft with file ref", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     # upload a file and reference it from a hint
     up = await client.post(
@@ -169,7 +170,7 @@ async def test_photo_hint_spoiler_round_trip(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft with spoiler", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft with spoiler", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     up = await client.post(
         f"/cdn/games/{game.id}/files",
@@ -228,7 +229,7 @@ async def test_change_scenario(
     dao: HolderDao,
     retort: Retort,
 ):
-    game = await create_game(author=author, name="draft to fill", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft to fill", dao=GameCreatorImpl(dao))
     resp = await client.put(
         f"/games/my/{game.id}/scenario",
         json=SNAKE_SCENARIO,
@@ -254,7 +255,7 @@ async def test_rename_game(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft to rename", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft to rename", dao=GameCreatorImpl(dao))
     resp = await client.put(
         f"/games/my/{game.id}/name",
         json={"name": "  переименованная игра  "},
@@ -296,8 +297,10 @@ async def test_rename_game_to_a_taken_name_forbidden(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    occupied = await create_game(author=author, name="name already used", dao=dao.game_creator)
-    game = await create_game(author=author, name="draft wanting that name", dao=dao.game_creator)
+    occupied = await create_game(author=author, name="name already used", dao=GameCreatorImpl(dao))
+    game = await create_game(
+        author=author, name="draft wanting that name", dao=GameCreatorImpl(dao)
+    )
     resp = await client.put(
         f"/games/my/{game.id}/name",
         json={"name": occupied.name},
@@ -317,7 +320,9 @@ async def test_rename_game_to_an_empty_name_forbidden(
     dao: HolderDao,
     check_dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft keeping its name", dao=dao.game_creator)
+    game = await create_game(
+        author=author, name="draft keeping its name", dao=GameCreatorImpl(dao)
+    )
     resp = await client.put(
         f"/games/my/{game.id}/name",
         json={"name": "   "},
@@ -355,7 +360,7 @@ async def test_change_start_at(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft to schedule", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft to schedule", dao=GameCreatorImpl(dao))
     start_at = datetime.now(tz=tz_utc) + timedelta(days=1)
     resp = await client.put(
         f"/games/my/{game.id}/start_at",
@@ -384,7 +389,7 @@ async def test_change_status(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft to publish", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft to publish", dao=GameCreatorImpl(dao))
     resp = await client.put(
         f"/games/my/{game.id}/status",
         json={"status": GameStatus.getting_waivers.value},
@@ -403,7 +408,7 @@ async def test_upload_game_file(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft with files", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft with files", dao=GameCreatorImpl(dao))
     resp = await client.post(
         f"/cdn/games/{game.id}/files",
         files={"file": ("note.txt", b"hello world", "text/plain")},
@@ -425,7 +430,7 @@ async def test_rename_game_file(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft rename file", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft rename file", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     up = await client.post(
         f"/cdn/games/{game.id}/files",
@@ -457,7 +462,9 @@ async def test_rename_foreign_game_file_forbidden(
     harry: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft rename forbidden", dao=dao.game_creator)
+    game = await create_game(
+        author=author, name="draft rename forbidden", dao=GameCreatorImpl(dao)
+    )
     up = await client.post(
         f"/cdn/games/{game.id}/files",
         files={"file": ("note.txt", b"hello world", "text/plain")},
@@ -481,7 +488,7 @@ async def test_rename_file_not_in_game(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft rename missing", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft rename missing", dao=GameCreatorImpl(dao))
     resp = await client.patch(
         f"/cdn/games/{game.id}/files/00000000-0000-0000-0000-000000000000",
         json={"filename": "renamed"},
@@ -497,7 +504,7 @@ async def test_uploaded_file_listed_without_reference(
     author: dto.Player,
     dao: HolderDao,
 ):
-    game = await create_game(author=author, name="draft unref file", dao=dao.game_creator)
+    game = await create_game(author=author, name="draft unref file", dao=GameCreatorImpl(dao))
     cookies = auth_cookies(auth, author)
     # upload a file for the game but never reference it from any level
     up = await client.post(

--- a/tests/integration/bot_full/test_member_tags.py
+++ b/tests/integration/bot_full/test_member_tags.py
@@ -11,6 +11,7 @@ from dishka import AsyncContainer
 from shvatka.core.models import dto
 from shvatka.core.players.player import get_full_team_player, join_team, leave
 from shvatka.core.services.team import rename_team
+from shvatka.infrastructure.db.dao.complex.team import TeamLeaverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.config.models.bot import BotConfig
 from shvatka.tgbot.services.bot_rights import BotRights, ChatRights
@@ -65,7 +66,7 @@ async def test_tag_set_and_cleared_on_team_ops(
     # the team name is longer than the 16 characters telegram allows in a tag
     assert render_tag(gryffindor.name) == tag.tag
 
-    await leave(hermione, hermione, dao.team_leaver, notifier=notifier)
+    await leave(hermione, hermione, TeamLeaverImpl(dao), notifier=notifier)
 
     _, cleared = tags(bot_session)
     assert hermione.get_chat_id() == cleared.user_id

--- a/tests/integration/bot_full/test_outdated_dialog.py
+++ b/tests/integration/bot_full/test_outdated_dialog.py
@@ -16,6 +16,7 @@ from shvatka.core.players.player import (
     join_team,
     leave,
 )
+from shvatka.infrastructure.db.dao.complex.team import TeamLeaverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from shvatka.tgbot.dialogs.outdated import NOT_IN_TEAM
 from shvatka.tgbot.views.commands import START_COMMAND
@@ -56,7 +57,9 @@ async def test_my_team_opened_after_removed_from_team(
     await join_team(hermione, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
     main_menu = await open_main_menu(hermione_client, message_manager)
 
-    await leave(player=hermione, remover=harry, dao=dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(
+        player=hermione, remover=harry, dao=TeamLeaverImpl(dao), notifier=TeamNotifierMock()
+    )
 
     message_manager.reset_history()
     await hermione_client.click(main_menu, InlineButtonTextLocator(MY_TEAM_BUTTON))
@@ -88,7 +91,9 @@ async def test_captains_bridge_opened_after_removed_from_team(
     await hermione_client.click(main_menu, InlineButtonTextLocator(MANAGE_TEAM_BUTTON))
     captains_bridge = message_manager.last_message()
 
-    await leave(player=hermione, remover=harry, dao=dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(
+        player=hermione, remover=harry, dao=TeamLeaverImpl(dao), notifier=TeamNotifierMock()
+    )
 
     message_manager.reset_history()
     await hermione_client.click(captains_bridge, InlineButtonTextLocator(PLAYERS_BUTTON))

--- a/tests/integration/test_file_links.py
+++ b/tests/integration/test_file_links.py
@@ -8,6 +8,7 @@ from shvatka.core.interfaces.clients.file_storage import FileGateway
 from shvatka.core.models import dto
 from shvatka.core.models.dto.scn.game import RawGameScenario
 from shvatka.core.services.game import upsert_game
+from shvatka.infrastructure.db.dao.complex.game import GameUpserterImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
 
@@ -21,7 +22,7 @@ async def test_upsert_game_fills_level_and_game_files(
     retort: Retort,
     file_gateway: FileGateway,
 ):
-    game = await upsert_game(complex_scn, author, dao.game_upserter, retort, file_gateway)
+    game = await upsert_game(complex_scn, author, GameUpserterImpl(dao), retort, file_gateway)
     (file_id,) = await check_dao.file_info.get_ids_by_guids([GUID])
 
     first, second = game.levels[0], game.levels[1]
@@ -41,7 +42,7 @@ async def test_removing_file_syncs_level_files_but_keeps_game_files(
     retort: Retort,
     file_gateway: FileGateway,
 ):
-    game = await upsert_game(complex_scn, author, dao.game_upserter, retort, file_gateway)
+    game = await upsert_game(complex_scn, author, GameUpserterImpl(dao), retort, file_gateway)
     (file_id,) = await check_dao.file_info.get_ids_by_guids([GUID])
     first = game.levels[0]
     assert await check_dao.level_file.get_file_ids(first.db_id) == {file_id}
@@ -53,7 +54,7 @@ async def test_removing_file_syncs_level_files_but_keeps_game_files(
     await upsert_game(
         RawGameScenario(scn=stripped, files={GUID: BytesIO(b"123")}),
         author,
-        dao.game_upserter,
+        GameUpserterImpl(dao),
         retort,
         file_gateway,
     )

--- a/tests/integration/test_game.py
+++ b/tests/integration/test_game.py
@@ -17,6 +17,7 @@ from shvatka.core.services.game import (
 from shvatka.core.services.level import upsert_level
 from shvatka.core.services.organizers import get_orgs
 from shvatka.core.utils.exceptions import CantEditGame
+from shvatka.infrastructure.db.dao.complex.game import GameUpserterImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.identity import MockIdentityProvider
 
@@ -29,7 +30,7 @@ async def test_game_simple(
     retort: Retort,
     file_gateway: FileGateway,
 ):
-    game = await upsert_game(three_lvl_scn, author, dao.game_upserter, retort, file_gateway)
+    game = await upsert_game(three_lvl_scn, author, GameUpserterImpl(dao), retort, file_gateway)
 
     assert await dao.game.count() == 1
     assert await dao.level.count() == 3
@@ -49,7 +50,11 @@ async def test_game_simple(
     another_scn["levels"].append(another_scn["levels"].pop(0))
 
     game = await upsert_game(
-        RawGameScenario(scn=another_scn, files={}), author, dao.game_upserter, retort, file_gateway
+        RawGameScenario(scn=another_scn, files={}),
+        author,
+        GameUpserterImpl(dao),
+        retort,
+        file_gateway,
     )
 
     assert await dao.game.count() == 1
@@ -69,7 +74,11 @@ async def test_game_simple(
     another_scn["levels"].pop()
 
     game = await upsert_game(
-        RawGameScenario(scn=another_scn, files={}), author, dao.game_upserter, retort, file_gateway
+        RawGameScenario(scn=another_scn, files={}),
+        author,
+        GameUpserterImpl(dao),
+        retort,
+        file_gateway,
     )
 
     assert await dao.game.count() == 1
@@ -102,7 +111,9 @@ async def test_game_get_full(
     retort: Retort,
     file_gateway: FileGateway,
 ):
-    game_expected = await upsert_game(simple_scn, author, dao.game_upserter, retort, file_gateway)
+    game_expected = await upsert_game(
+        simple_scn, author, GameUpserterImpl(dao), retort, file_gateway
+    )
     game_actual = await dao.game.get_full(game_expected.id)
     assert game_expected == game_actual
 
@@ -115,7 +126,9 @@ async def test_game_get_preview(
     retort: Retort,
     file_gateway: FileGateway,
 ):
-    game_expected = await upsert_game(simple_scn, author, dao.game_upserter, retort, file_gateway)
+    game_expected = await upsert_game(
+        simple_scn, author, GameUpserterImpl(dao), retort, file_gateway
+    )
     game_actual = await dao.game.get_preview(game_expected.id)
     assert len(game_expected.levels) == game_actual.levels_count
     assert game_expected.id == game_actual.id
@@ -128,7 +141,7 @@ async def test_game_get_preview(
 async def test_cant_change_finished(finished_game: dto.FullGame, dao: HolderDao):
     level = finished_game.levels[0]
     with pytest.raises(CantEditGame):
-        await upsert_level(finished_game.author, level.scenario, dao.game_upserter)
+        await upsert_level(finished_game.author, level.scenario, GameUpserterImpl(dao))
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_game_org.py
+++ b/tests/integration/test_game_org.py
@@ -16,6 +16,7 @@ from shvatka.core.services.organizers import (
 )
 from shvatka.core.utils.exceptions import SaltNotExist
 from shvatka.core.views.game import NewOrg
+from shvatka.infrastructure.db.dao.complex.orgs import OrgAdderImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.mocks.org_notifier import OrgNotifierMock
 
@@ -57,7 +58,7 @@ async def test_agree_invite(
         inviter_id=author.id,
         player=harry,
         org_notifier=org_notifier,
-        dao=dao.org_adder,
+        dao=OrgAdderImpl(dao),
     )
     secondary_orgs = await get_secondary_orgs(game, check_dao.organizer)
     assert len(secondary_orgs) == 1

--- a/tests/integration/test_game_play.py
+++ b/tests/integration/test_game_play.py
@@ -27,6 +27,9 @@ from shvatka.core.views.game import (
     LevelUp,
 )
 from shvatka.infrastructure.db import models
+from shvatka.infrastructure.db.dao.complex.game_play import GamePlayerDaoImpl, GameStarterImpl
+from shvatka.infrastructure.db.dao.complex.key_log import TypedKeyGetterImpl
+from shvatka.infrastructure.db.dao.complex.team import TeamLeaverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.game_fixtures import CurrentGameProviderMock
 from tests.fixtures.identity import MockIdentityProvider
@@ -62,7 +65,7 @@ async def test_start_game(
     game_with_waivers.start_at = datetime.now(tz=tz_utc)
 
     sender = ViewSenderMock(dummy_view, OrgNotifierMock(), dummy_log)
-    await start_game(game_with_waivers, dao.game_starter, sender, scheduler)
+    await start_game(game_with_waivers, GameStarterImpl(dao), sender, scheduler)
 
     dummy_log.assert_one_event(
         GameLogEvent(GameLogType.GAME_STARTED, {"game": game_with_waivers.name})
@@ -90,13 +93,15 @@ async def test_wrong_key(
 ):
     game = started_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
 
     dummy_org_notifier = OrgNotifierMock()
     key_checker = CheckKeyInteractor(
-        dao=dao.game_player,
+        dao=GamePlayerDaoImpl(dao),
         sender=ViewSenderMock(dummy_view, dummy_org_notifier, dummy_log),
         locker=locker,
         scheduler=scheduler,
@@ -111,7 +116,7 @@ async def test_wrong_key(
     )
 
     identity = MockIdentityProvider(player=author)
-    keys = await get_typed_keys(game=game, identity=identity, dao=check_dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=TypedKeyGetterImpl(check_dao))
     assert [gryffindor] == list(keys.keys())
     assert len(keys[gryffindor]) == 1
     expected_first_key = dto.KeyTime(
@@ -140,13 +145,15 @@ async def test_bonus_hint_key(
 ):
     game = started_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
 
     dummy_org_notifier = OrgNotifierMock()
     check_key = CheckKeyInteractor(
-        dao=dao.game_player,
+        dao=GamePlayerDaoImpl(dao),
         sender=ViewSenderMock(dummy_view, dummy_org_notifier, dummy_log),
         locker=locker,
         scheduler=scheduler,
@@ -164,7 +171,7 @@ async def test_bonus_hint_key(
     )
 
     identity = MockIdentityProvider(player=author)
-    keys = await get_typed_keys(game=game, identity=identity, dao=check_dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=TypedKeyGetterImpl(check_dao))
     assert [gryffindor] == list(keys.keys())
     assert len(keys[gryffindor]) == 1
     expected_first_key = dto.KeyTime(
@@ -201,9 +208,11 @@ async def test_game_play(
 ):
     game = started_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     # delete slytherin from game
-    await leave(draco, draco, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(draco, draco, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
 
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
@@ -225,7 +234,7 @@ async def test_game_play(
     orgs = await get_orgs(game, dao.organizer)
     identity = MockIdentityProvider(player=harry, team=gryffindor)
     check_key = CheckKeyInteractor(
-        dao=dao.game_player,
+        dao=GamePlayerDaoImpl(dao),
         sender=ViewSenderMock(dummy_view, dummy_org_notifier, dummy_log),
         locker=locker,
         scheduler=scheduler,
@@ -288,7 +297,7 @@ async def test_game_play(
     dummy_view.assert_game_finished_all({gryffindor})
 
     identity = MockIdentityProvider(player=author)
-    keys = await get_typed_keys(game=game, identity=identity, dao=check_dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=TypedKeyGetterImpl(check_dao))
 
     assert [gryffindor] == list(keys.keys())
     assert len(keys[gryffindor]) == 4
@@ -296,7 +305,7 @@ async def test_game_play(
     assert_time_key(expected_second_key, list(keys[gryffindor])[1])
     assert_time_key(expected_third_key, list(keys[gryffindor])[2])
     assert_time_key(expected_fourth_key, list(keys[gryffindor])[3])
-    assert await dao.game_player.is_all_team_finished(game)
+    assert await GamePlayerDaoImpl(dao).is_all_team_finished(game)
     assert GameStatus.finished == (await check_dao.game.get_by_id(game.id, author)).status
     dummy_view.assert_no_unchecked()
     dummy_org_notifier.assert_no_calls()
@@ -317,9 +326,11 @@ async def test_fast_play_routed_game(
 ):
     game = started_routed_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     # delete slytherin from game
-    await leave(draco, draco, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(draco, draco, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
 
@@ -327,7 +338,7 @@ async def test_fast_play_routed_game(
     orgs = await get_orgs(game, dao.organizer)
     identity = MockIdentityProvider(player=harry, team=gryffindor)
     check_key = CheckKeyInteractor(
-        dao=dao.game_player,
+        dao=GamePlayerDaoImpl(dao),
         sender=ViewSenderMock(dummy_view, dummy_org_notifier, dummy_log),
         locker=locker,
         scheduler=scheduler,
@@ -366,13 +377,13 @@ async def test_fast_play_routed_game(
     dummy_view.assert_game_finished_all({gryffindor})
 
     identity = MockIdentityProvider(player=author)
-    keys = await get_typed_keys(game=game, identity=identity, dao=check_dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=TypedKeyGetterImpl(check_dao))
 
     assert list(keys.keys()) == [gryffindor]
     assert len(keys[gryffindor]) == 2
     assert_time_key(expected_first_key, next(iter(keys[gryffindor])))
     assert_time_key(expected_second_key, list(keys[gryffindor])[1])
-    assert await dao.game_player.is_all_team_finished(game)
+    assert await GamePlayerDaoImpl(dao).is_all_team_finished(game)
     assert GameStatus.finished == (await check_dao.game.get_by_id(game.id, author)).status
     dummy_view.assert_no_unchecked()
     dummy_org_notifier.assert_no_calls()
@@ -393,9 +404,11 @@ async def test_cycle_play_routed_game(
 ):
     game = started_routed_game
     current_game = CurrentGameProviderMock(game, dao.waiver)
-    key_processor = KeyProcessor(dao=dao.game_player, current_game=current_game, locker=locker)
+    key_processor = KeyProcessor(
+        dao=GamePlayerDaoImpl(dao), current_game=current_game, locker=locker
+    )
     # delete slytherin from game
-    await leave(draco, draco, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(draco, draco, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
     dummy_view = GameViewMock()
     dummy_log = GameLogWriterMock()
 
@@ -403,7 +416,7 @@ async def test_cycle_play_routed_game(
     orgs = await get_orgs(game, dao.organizer)
     identity = MockIdentityProvider(player=harry, team=gryffindor)
     check_key = CheckKeyInteractor(
-        dao=dao.game_player,
+        dao=GamePlayerDaoImpl(dao),
         sender=ViewSenderMock(dummy_view, dummy_org_notifier, dummy_log),
         locker=locker,
         scheduler=scheduler,
@@ -474,7 +487,7 @@ async def test_cycle_play_routed_game(
     dummy_view.assert_game_finished_all({gryffindor})
 
     identity = MockIdentityProvider(player=author)
-    keys = await get_typed_keys(game=game, identity=identity, dao=check_dao.typed_keys)
+    keys = await get_typed_keys(game=game, identity=identity, dao=TypedKeyGetterImpl(check_dao))
 
     assert list(keys.keys()) == [gryffindor]
     assert len(keys[gryffindor]) == 4
@@ -482,7 +495,7 @@ async def test_cycle_play_routed_game(
     assert_time_key(expected_second_key, list(keys[gryffindor])[1])
     assert_time_key(expected_third_key, list(keys[gryffindor])[2])
     assert_time_key(expected_last_key, list(keys[gryffindor])[3])
-    assert await dao.game_player.is_all_team_finished(game)
+    assert await GamePlayerDaoImpl(dao).is_all_team_finished(game)
     assert GameStatus.finished == (await check_dao.game.get_by_id(game.id, author)).status
     dummy_view.assert_no_unchecked()
     dummy_org_notifier.assert_no_calls()
@@ -499,7 +512,7 @@ async def test_get_current_hints(
     hermione: dto.Player,
     gryffindor: dto.Team,
 ):
-    await leave(ron, ron, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(ron, ron, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
     level_time = models.LevelTime(
         game_id=game_with_waivers.id,
         team_id=gryffindor.id,
@@ -601,7 +614,7 @@ async def test_get_passed_levels_requires_waiver(
     harry: dto.Player,
     gryffindor: dto.Team,
 ):
-    await leave(ron, ron, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(ron, ron, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
     dao.level_time._save(
         models.LevelTime(
             game_id=game_with_waivers.id,

--- a/tests/integration/test_game_stat.py
+++ b/tests/integration/test_game_stat.py
@@ -10,6 +10,8 @@ from shvatka.core.services.game_stat import (
     get_typed_keys,
 )
 from shvatka.core.utils.datetime_utils import tz_utc
+from shvatka.infrastructure.db.dao.complex.key_log import TypedKeyGetterImpl
+from shvatka.infrastructure.db.dao.complex.level_times import GameStatImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.identity import MockIdentityProvider
 from tests.mocks.datetime_mock import ClockMock
@@ -18,7 +20,7 @@ from tests.mocks.datetime_mock import ClockMock
 @pytest.mark.asyncio
 async def test_game_level_times(finished_game: dto.FullGame, dao: HolderDao):
     game_stat = await get_game_stat(
-        finished_game, MockIdentityProvider(player=finished_game.author), dao.game_stat
+        finished_game, MockIdentityProvider(player=finished_game.author), GameStatImpl(dao)
     )
     for team, level_times in game_stat.level_times.items():
         assert all(team.id == lt.team.id for lt in level_times)
@@ -34,7 +36,7 @@ async def test_game_log_keys(
     actual = await get_typed_keys(
         game=finished_game,
         identity=MockIdentityProvider(player=finished_game.author),
-        dao=dao.typed_keys,
+        dao=TypedKeyGetterImpl(dao),
     )
     assert len(actual[gryffindor]) == 5
     assert len(actual[slytherin]) == 3
@@ -46,7 +48,7 @@ async def test_game_spy_started(started_game: dto.FullGame, dao: HolderDao, cloc
     clock.clear()
     clock.add_mock(tz=tz_utc, result=started_game.start_at + timedelta(seconds=10))
     clock.add_mock(tz=tz_utc, result=started_game.start_at + timedelta(seconds=10))
-    game_stat = await get_game_spy(started_game, started_game.author, dao.game_stat)
+    game_stat = await get_game_spy(started_game, started_game.author, GameStatImpl(dao))
     assert len(clock.calls) == 2
     assert len(game_stat) == 2
     for level_time in game_stat:
@@ -65,7 +67,7 @@ async def test_game_spy_with_first_and_last_hint(
     clock.clear()
     clock.add_mock(tz=tz_utc, result=started_game.start_at + timedelta(seconds=10))
     clock.add_mock(tz=tz_utc, result=started_game.start_at + timedelta(minutes=6, seconds=1))
-    game_stat = await get_game_spy(started_game, started_game.author, dao.game_stat)
+    game_stat = await get_game_spy(started_game, started_game.author, GameStatImpl(dao))
     assert len(clock.calls) == 2
     assert len(game_stat) == 2
     assert game_stat[1].hint.number == 3
@@ -96,7 +98,7 @@ async def test_game_spy_with_second_level_first_and_last_hint(
     clock.add_mock(tz=tz_utc, result=datetime.now(tz_utc) + timedelta(minutes=1))
     clock.add_mock(tz=tz_utc, result=datetime.now(tz_utc) + timedelta(seconds=10))
     clock.add_mock(tz=tz_utc, result=datetime.now(tz_utc) + timedelta(minutes=5))
-    game_stat = await get_game_spy(started_game, started_game.author, dao.game_stat)
+    game_stat = await get_game_spy(started_game, started_game.author, GameStatImpl(dao))
     assert len(clock.calls) == 4
     assert len(game_stat) == 2
     assert game_stat[1].hint.number == 3

--- a/tests/integration/test_level.py
+++ b/tests/integration/test_level.py
@@ -6,6 +6,7 @@ from shvatka.core.models.dto.scn.level import LevelScenario
 from shvatka.core.players.player import upsert_player
 from shvatka.core.services.level import upsert_raw_level
 from shvatka.core.services.user import upsert_user
+from shvatka.infrastructure.db.dao.complex.game import GameUpserterImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.user_constants import create_dto_harry
 
@@ -16,7 +17,9 @@ async def test_simple_level(simple_scn: RawGameScenario, dao: HolderDao, retort:
     await dao.player.promote(author, author)
     await dao.commit()
     author.can_be_author = True
-    lvl = await upsert_raw_level(simple_scn.scn["levels"][0], author, retort, dao.game_upserter)
+    lvl = await upsert_raw_level(
+        simple_scn.scn["levels"][0], author, retort, GameUpserterImpl(dao)
+    )
 
     assert lvl.db_id is not None
     assert await dao.level.count() == 1

--- a/tests/integration/test_level_tesing.py
+++ b/tests/integration/test_level_tesing.py
@@ -11,6 +11,7 @@ from shvatka.core.services.level_testing import (
 from shvatka.core.utils.datetime_utils import tz_utc
 from shvatka.core.utils.key_checker_lock import KeyCheckerFactory
 from shvatka.core.views.game import LevelTestCompleted
+from shvatka.infrastructure.db.dao.complex.level_testing import LevelTestComplex
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.mocks.level_view import LevelViewMock
 from tests.mocks.org_notifier import OrgNotifierMock
@@ -32,7 +33,7 @@ async def test_level_testing(
     assert not await dao.level_test.is_still_testing(suite)
 
     await start_level_test(
-        suite=suite, scheduler=scheduler, view=level_view, dao=dao.level_testing_complex
+        suite=suite, scheduler=scheduler, view=level_view, dao=LevelTestComplex(dao)
     )
     actual_suite, actual_hint_number, actual_run_at = scheduler.calls.pop()
     assert suite == actual_suite
@@ -45,7 +46,7 @@ async def test_level_testing(
     assert await dao.level_test.is_still_testing(suite)
 
     await check_level_testing_key(
-        "SH123", suite, level_view, org_notifier, locker, dao.level_testing_complex
+        "SH123", suite, level_view, org_notifier, locker, LevelTestComplex(dao)
     )
     correct_keys = await dao.level_test.get_correct_tested_keys(suite)
     assert {"SH123"} == correct_keys
@@ -59,7 +60,7 @@ async def test_level_testing(
     assert actual_key == "SH123"
 
     await check_level_testing_key(
-        "SHWRONG", suite, level_view, org_notifier, locker, dao.level_testing_complex
+        "SHWRONG", suite, level_view, org_notifier, locker, LevelTestComplex(dao)
     )
     correct_keys = await dao.level_test.get_correct_tested_keys(suite)
     assert {"SH123"} == correct_keys
@@ -72,7 +73,7 @@ async def test_level_testing(
     assert actual_key == "SHWRONG"
 
     await check_level_testing_key(
-        "SH321", suite, level_view, org_notifier, locker, dao.level_testing_complex
+        "SH321", suite, level_view, org_notifier, locker, LevelTestComplex(dao)
     )
     assert not await dao.level_test.is_still_testing(suite)
     correct_keys = await dao.level_test.get_correct_tested_keys(suite)
@@ -109,10 +110,10 @@ async def test_send_hint_for_tester_level(
     await dao.commit()
     suite = dto.LevelTestSuite(level=level, tester=harry_org)
     await start_level_test(
-        suite=suite, scheduler=scheduler, view=level_view, dao=dao.level_testing_complex
+        suite=suite, scheduler=scheduler, view=level_view, dao=LevelTestComplex(dao)
     )
 
-    await send_testing_level_hint(suite, 1, level_view, scheduler, dao.level_testing_complex)
+    await send_testing_level_hint(suite, 1, level_view, scheduler, LevelTestComplex(dao))
     actual_suit, hint_number = level_view.calls["send_hint"].pop()
     assert suite == actual_suit
     assert hint_number == 1

--- a/tests/integration/test_save_team.py
+++ b/tests/integration/test_save_team.py
@@ -20,7 +20,7 @@ async def test_save_team(dao: HolderDao, game_log: GameLogWriter):
     user = await upsert_user(create_dto_harry(), dao.user)
     player = await upsert_player(user, dao.player)
     await promote(player, dao)
-    team = await create_team(chat, player, dao.team_creator, game_log)
+    team = await create_team(chat, player, TeamCreatorImpl(dao), game_log)
     assert team.id is not None
     assert team.name == chat.name
 

--- a/tests/integration/test_team_player.py
+++ b/tests/integration/test_team_player.py
@@ -13,6 +13,7 @@ from shvatka.core.utils import exceptions
 from shvatka.core.utils.defaults_constants import CAPTAIN_ROLE, DEFAULT_ROLE
 from shvatka.core.utils.exceptions import CantBeAuthor, PermissionsError, PlayerAlreadyInTeam
 from shvatka.core.views.game import GameLogWriter
+from shvatka.infrastructure.db.dao.complex.team import TeamLeaverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.player import promote
 from tests.fixtures.team import create_second_team
@@ -89,7 +90,7 @@ async def test_restore_player_to_team(
     assert await dao.team_player.count() == 2
     assert await get_my_role(hermione, dao.team_player) == DEFAULT_ROLE
 
-    await leave(hermione, harry, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(hermione, harry, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
 
     players = await dao.team_player.get_players(gryffindor)
     assert len(players) == 1
@@ -120,10 +121,10 @@ async def test_no_restore_player_to_team_just_add(
     assert gryffindor == await get_my_team(hermione, dao.team_player)
     assert await get_my_role(hermione, dao.team_player) == DEFAULT_ROLE
 
-    await leave(hermione, hermione, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(hermione, hermione, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
 
     await join_team(hermione, slytherin, draco, dao.team_player, notifier=TeamNotifierMock())
-    await leave(hermione, hermione, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(hermione, hermione, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
 
     players = await dao.team_player.get_players(gryffindor)
     assert len(players) == 1

--- a/tests/integration/test_upsert_game_telegram_rejection.py
+++ b/tests/integration/test_upsert_game_telegram_rejection.py
@@ -8,6 +8,7 @@ from shvatka.core.models import dto
 from shvatka.core.models.dto.scn.game import RawGameScenario
 from shvatka.core.services.game import upsert_game
 from shvatka.core.utils.exceptions import FilesCantBeSentToTg
+from shvatka.infrastructure.db.dao.complex.game import GameUpserterImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.fixtures.scn_fixtures import GUID
 from tests.mocks.file_gateway import FakeTelegram
@@ -36,7 +37,7 @@ async def test_upsert_game_saves_nothing_when_telegram_refuses_a_file(
         await upsert_game(
             _scn_with_file_not_yet_in_tg(complex_scn),
             author,
-            dao.game_upserter,
+            GameUpserterImpl(dao),
             retort,
             file_gateway,
         )
@@ -59,7 +60,7 @@ async def test_upsert_game_saves_the_files_telegram_took(
     game = await upsert_game(
         _scn_with_file_not_yet_in_tg(complex_scn),
         author,
-        dao.game_upserter,
+        GameUpserterImpl(dao),
         retort,
         file_gateway,
     )

--- a/tests/integration/test_waiver.py
+++ b/tests/integration/test_waiver.py
@@ -15,6 +15,8 @@ from shvatka.core.waiver.services import (
     get_vote_to_voted,
 )
 from shvatka.infrastructure.db import models
+from shvatka.infrastructure.db.dao.complex.team import TeamLeaverImpl
+from shvatka.infrastructure.db.dao.complex.waiver import WaiverApproverImpl
 from shvatka.infrastructure.db.dao.holder import HolderDao
 from tests.mocks.team_notifier import TeamNotifierMock
 
@@ -42,7 +44,7 @@ async def test_get_voted_list(
     actual_voted = actual[Played.yes]
     assert len(actual_voted) == 2
 
-    await approve_waivers(game, gryffindor, harry, dao.waiver_approver)
+    await approve_waivers(game, gryffindor, harry, WaiverApproverImpl(dao))
     assert await dao.waiver.count() == 2
     assert [gryffindor] == await dao.waiver.get_played_teams(game)
     waivers = await get_all_played(game, dao.waiver)
@@ -51,20 +53,20 @@ async def test_get_voted_list(
     assert len(players) == 2
     assert {harry.id, hermione.id} == {player.player.id for player in players}
 
-    await leave(hermione, hermione, dao.team_leaver, notifier=TeamNotifierMock())
+    await leave(hermione, hermione, TeamLeaverImpl(dao), notifier=TeamNotifierMock())
     actual = await get_vote_to_voted(gryffindor, waiver_vote_getter)
     assert len(actual) == 1
     actual_voted = actual[Played.yes]
     assert len(actual_voted) == 1
     assert actual_voted[0].player.id == harry.id
 
-    await approve_waivers(game, gryffindor, harry, dao.waiver_approver)
+    await approve_waivers(game, gryffindor, harry, WaiverApproverImpl(dao))
     assert await dao.waiver.count() == 1
     assert [gryffindor] == await dao.waiver.get_played_teams(game)
 
     with pytest.raises(PlayerRestoredInTeam):
         await join_team(hermione, gryffindor, harry, dao.team_player, notifier=TeamNotifierMock())
-    await approve_waivers(game, gryffindor, harry, dao.waiver_approver)
+    await approve_waivers(game, gryffindor, harry, WaiverApproverImpl(dao))
     # vote not restored after restored player in team
     assert await dao.waiver.count() == 1
 
@@ -80,7 +82,7 @@ async def test_get_voted_list(
     with pytest.raises(WaiverForbidden):
         await add_vote(game, gryffindor, hermione, Played.yes, waiver_vote_adder)
 
-    await approve_waivers(game, gryffindor, harry, dao.waiver_approver)
+    await approve_waivers(game, gryffindor, harry, WaiverApproverImpl(dao))
     assert await dao.waiver.count() == 2
     assert [gryffindor] == await dao.waiver.get_played_teams(game)
 


### PR DESCRIPTION
## What

`HolderDao` carried sixteen `@property` shortcuts (`waiver_approver`, `game_upserter`, `game_stat`, `typed_keys`, `team_leaver`, …) that each built a `dao/complex/*` adapter over itself. All of them are gone; the adapters now reach their consumers through DI.

## Why it unlocked the rest

Because the holder imported those impls, every impl had to import `HolderDao` back under `if typing.TYPE_CHECKING:` to break the cycle. A quoted annotation is opaque to dishka, so each adapter needed a hand-written `@provide` factory. With the properties gone the cycle is gone too, and both consequences follow:

- every `complex/*` and `complex2/*` impl now imports `HolderDao` natively — no `TYPE_CHECKING` block, no `dao: "HolderDao"`;
- every remaining explicit adapter factory in the di providers collapses to the class-provide shorthand, e.g. `game_release_editor = provide(GameReleaseEditorImpl, provides=GameReleaseEditor)`. `GamePlayDaoImpl` is the one exception and keeps a factory — its `cache` is per-request scratch space dishka can't build.

## How the adapters are wired now

New `ComplexDaoProvider` in `infrastructure/di/db.py`, returned by `get_providers()`, so the bot, api and root containers all see it. It holds the seventeen adapters that used to be properties (plus `LevelDeleter`, moved over from `DAOProvider` for company). `TeamCreatorImpl` is provided as `AnyOf[TeamCreator, ChatlessTeamCreator]`, which is why `TeamProvider.chatless_team_creator` and `WaiverProvider.waiver_approver` could go.

This mattered for placement: `GameEditProvider` and `AdminProvider` are api-only, but bot handlers need `GameUpserter`, `GameCreator` and `TeamCreator` — hence a shared provider rather than topical ones.

## Call sites

- aiogram handlers, dialog handlers/getters and scheduler wrappers take the narrow Protocol as `FromDishka[...]` instead of reaching through `dao`.
- api routes take `FromDishka[GamePackager]`.
- `ResultsPainter.__init__` takes `GameStatDao`; `create_keys_page` takes a `TypedKeyGetter` as its `dao`; `get_or_create_keys_page` takes both (it still writes `keys_url` through the holder); the scenario loader threads a `GameUpserter` resolved from the request container.
- `AddGameOrgInteractor`, `AcceptRequestInteractor`, `CreateOrgInviteInteractor` and the two remove-player interactors get their org adder / mergers / promoter / team leaver injected rather than pulled off `dao`.
- Tests build the adapter they need directly over their own fixture — `GamePlayerDaoImpl(dao)`, `TypedKeyGetterImpl(check_dao)` — so `check_dao` assertions keep observing their own session.

## Docs

`AGENTS.md`: the "don't add new HolderDAO properties" rule becomes "`HolderDao` holds per-table daos only"; the dishka example now shows the class-provide shorthand and says when an explicit factory is still needed; the DAO-layer section gains a rule for where a complex dao lives and how it travels.

## Testing

- `ruff format --check .` and `ruff check .` clean (with the pinned ruff 0.2.x, not the newer one on PATH).
- `mypy .` — no issues in 836 source files.
- `pytest tests/unit` — 604 passed, including `test_di.py` / `test_di_containers.py`, which build and validate every container.
- The testcontainer suite needs Docker, which isn't available in this environment; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxM5Bxwfs1rKXie6LXP93H


---
_Generated by [Claude Code](https://claude.ai/code/session_01UxM5Bxwfs1rKXie6LXP93H)_