### PR TITLE
feat(tgbot): умные пагинаторы — форма пагинатора зависит от числа страниц

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,12 @@ overrides) lives in `pyproject.toml`.
 - **In aiogram / aiogram_dialog handlers, take dependencies from DI**
   (`FromDishka[...]` on an `@inject`-decorated handler), including
   `dao: FromDishka[HolderDao]` — not `manager.middleware_data`.
+- **A scrolling list uses `SmartScrollingGroup`** (`tgbot/dialogs/paging.py`),
+  never `ScrollingGroup` straight from the library. It takes the same arguments
+  and shows a pager only when there is something to page: nothing for a single
+  page, a button per page up to eight, the endless `⏮ ◀️ 7/13 ▶️ ⏭` row beyond
+  that. Pair `SmartPager` with a `StubScroll` to page a long text the same way.
+  SHEP-0015.
 - **Every aiogram_dialog `Window` with a getter needs `preview_data`** (getters
   aren't called in preview mode). Reuse/add fixtures in
   `tgbot/dialogs/preview_data.py`. Every state of a `StatesGroup` needs a window.

--- a/docs/modules/shep/nav.adoc
+++ b/docs/modules/shep/nav.adoc
@@ -13,4 +13,5 @@
 ** xref:shep-0012-team-captain-by-id.adoc[SHEP-0012 Team captain by id]
 ** xref:shep-0013-undoing-a-false-start.adoc[SHEP-0013 Undoing a false start]
 ** xref:shep-0014-event-loop-latency.adoc[SHEP-0014 Event loop latency]
+** xref:shep-0015-smart-pagers.adoc[SHEP-0015 Smart pagers]
 ** xref:template.adoc[SHEP template]

--- a/docs/modules/shep/pages/index.adoc
+++ b/docs/modules/shep/pages/index.adoc
@@ -82,6 +82,10 @@ came out of it*.
 | xref:shep-0014-event-loop-latency.adoc[SHEP-0014]
 | Event loop latency
 | Accepted, partially implemented
+
+| xref:shep-0015-smart-pagers.adoc[SHEP-0015]
+| Smart pagers
+| Accepted, partially implemented
 |===
 
 == Status vocabulary

--- a/docs/modules/shep/pages/shep-0015-smart-pagers.adoc
+++ b/docs/modules/shep/pages/shep-0015-smart-pagers.adoc
@@ -1,0 +1,131 @@
+= SHEP-0015 — Smart pagers
+:navtitle: SHEP-0015 Smart pagers
+
+[cols="1,4"]
+|===
+| SHEP | 0015
+| Title | Smart pagers
+| Status | `Accepted`
+| Created | 2026-09-07
+| Updated | 2026-09-07
+| Related | issue #118
+|===
+
+== Summary
+
+Every scrolling list in the bot showed the same five-button pager, even when
+there was a single page to switch between. `SmartScrollingGroup`
+(`shvatka/tgbot/dialogs/paging.py`) replaces it with a pager whose shape follows
+the number of pages: nothing for one page, a button per page for a few, and the
+endless `⏮ ◀️ 7/13 ▶️ ⏭` row for many.
+
+== Context
+
+Lists in the bot are `ScrollingGroup`s with `height=10`: teams, games, levels,
+hints, timers, orgs. `aiogram_dialog`'s `ScrollingGroup` draws its own pager —
+a fixed `1 < 2 > 12` row — and it draws it whenever there is at least one page,
+so a team with three players spent a keyboard row on `1 < 1 > 1`. Its
+`hide_on_single_page` flag fixes that one case and nothing else: with four pages
+the same row still makes page 3 two taps away, when four buttons would fit.
+
+`aiogram_dialog` 2.6 has the pieces for something better. A `ScrollingGroup`
+built with `hide_pager=True` renders only its contents, and separate pager
+widgets — `NumberedPager`, `FirstPage`, `PrevPage`, `CurrentPage`, `NextPage`,
+`LastPage` — attach to any scroll by id and can be placed anywhere in a window.
+The same widgets attach to a `StubScroll`, which counts pages of *text* rather
+than buttons. What the library does not have is a pager that picks a shape:
+`when` conditions see the getter's data, not the page count, so the choice
+cannot be expressed at the call site.
+
+== Decision
+
+=== One widget decides, three shapes come out
+
+`SmartPager` counts pages once and renders one of three things:
+
+* `pages <= 1` — nothing. A list that fits on one page needs no pager, and with
+  `height=10` that is exactly the "fewer than ten items" case from the issue;
+* `pages <= MAX_NUMBERED_PAGES` (8) — `NumberedPager`, a button per page, the
+  current one bracketed: `1 2 [ 3 ] 4 5`. Any page is one tap away, and eight
+  buttons is as wide as a keyboard row goes before the labels stop being
+  readable;
+* more — the endless row `⏮ ◀️ 7/13 ▶️ ⏭`, which also says where in the list the
+  reader is, something the library's own pager never showed.
+
+The three shapes are built from the library's widgets rather than from raw
+`InlineKeyboardButton`s, so styles, text widgets and callback handling stay
+whatever `aiogram_dialog` does with them.
+
+=== The page count is passed in, not asked for
+
+`ScrollingGroup.get_page_count` renders every button of every page to count the
+rows. A pager assembled the library's way asks the scroll for that count once
+per page button — six full renders of the list for the endless row alone, each
+one running a `Jinja` template per item.
+
+So `SmartPager.render_pages` takes `pages` and `current_page` as arguments, and
+`SmartScrollingGroup` — which had to render the contents anyway to cut the
+current page out of them — passes the number it already has.
+`SmartPager._render_keyboard` still resolves the count from the scroll itself,
+which is what a standalone pager over a `StubScroll` (where counting is free)
+needs.
+
+=== The pager shares the group's widget id
+
+Every button of every shape does one thing: switch the scroll to a page number.
+They all carry the group's own widget id, so `sg:3` arrives at
+`ScrollingGroup._process_item_callback` and is handled by the code that always
+handled it. No new callback prefix, no extra routing, and `manager.find("sg")`
+still returns the scroll.
+
+=== Alternatives that lost
+
+*`hide_on_single_page=True` and nothing else.* Solves the first line of the
+issue and leaves the other two. The five-button row stays wrong for four pages.
+
+*A pager per window.* `aiogram_dialog`'s composition already allows
+`ScrollingGroup(hide_pager=True)` plus a `NumberedPager` next to it. That is two
+widgets and one shape decision at each of the seventeen call sites — the
+decision this SHEP exists to make once.
+
+== Consequences
+
+* Lists shorter than a page gain a row of screen and lose a dead button.
+* `SmartScrollingGroup` is a drop-in for `ScrollingGroup`: same arguments
+  (minus `hide_pager` / `hide_on_single_page`, which it decides itself), same
+  widget ids, so `preview_data.py` and the dialog tests needed no changes.
+* `SmartPager` works over a `StubScroll` too, so paging a long *text* — a
+  scenario, a results table — is now a solved problem rather than a new one.
+* One more widget of ours between the dialogs and the library: an
+  `aiogram_dialog` release that reshapes `ScrollingGroup._render_keyboard` or
+  `NumberedPager._prepare_data` will need this file looked at.
+
+== Phases and status
+
+[cols="1,4,2",options="header"]
+|===
+| Phase | Content | Status
+
+| 1
+| `SmartPager` / `SmartScrollingGroup` in `tgbot/dialogs/paging.py`, unit tests
+| ✅ done
+
+| 2
+| Every `ScrollingGroup` in the bot switched over (17 call sites, 11 modules)
+| ✅ done
+
+| 3
+| Page long texts with `StubScroll` + `SmartPager` where a window is truncated
+  today
+| ⏳ not started
+|===
+
+== Deviations from the plan
+
+None so far.
+
+== Open questions
+
+* Should `MAX_NUMBERED_PAGES` be per-window? Eight is right for a list of teams
+  in a one-button-wide group; a two-wide group of hints reaches eight pages much
+  later. One constant until a window disagrees in practice.

--- a/shvatka/tgbot/dialogs/effects/dialogs.py
+++ b/shvatka/tgbot/dialogs/effects/dialogs.py
@@ -5,12 +5,12 @@ from aiogram_dialog.widgets.kbd import (
     Button,
     Cancel,
     ListGroup,
-    ScrollingGroup,
     SwitchTo,
 )
 from aiogram_dialog.widgets.text import Case, Const, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import PREVIEW_EFFECTS_DATA, PREVIEW_HINTS_DATA
 
 from .getters import get_effects, get_hints
@@ -119,7 +119,7 @@ effects = Dialog(
     ),
     Window(
         Jinja("💡Подсказки\n\n{{hints | hints}}"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             ListGroup(
                 Button(
                     Jinja("{{item[1] | single_hint}}"),

--- a/shvatka/tgbot/dialogs/game_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_manage/dialogs.py
@@ -5,7 +5,6 @@ from aiogram_dialog.widgets.kbd import (
     Button,
     Calendar,
     Cancel,
-    ScrollingGroup,
     Select,
     Start,
     SwitchTo,
@@ -14,6 +13,7 @@ from aiogram_dialog.widgets.kbd import (
 from aiogram_dialog.widgets.text import Case, Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_GAME,
     PREVIEW_NOW,
@@ -63,7 +63,7 @@ from .handlers import (
 games = Dialog(
     Window(
         Const("Список прошедших"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("{item.name}"),
                 id="games",
@@ -252,7 +252,7 @@ my_games = Dialog(
         Start(Const("✍Написать игру"), id="write_game", state=states.GameWriteSG.game_name),
         Start(Const("✍Написать уровень"), id="write_level", state=states.LevelSG.level_id),
         Start(Const("🗂Уровни"), id="levels", state=states.LevelListSG.levels),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("{item.name}"),
                 id="my_games",

--- a/shvatka/tgbot/dialogs/game_orgs/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_orgs/dialogs.py
@@ -4,13 +4,13 @@ from aiogram_dialog.widgets.kbd import (
     Back,
     Button,
     Cancel,
-    ScrollingGroup,
     Select,
     SwitchInlineQuery,
 )
 from aiogram_dialog.widgets.text import Const, Format, Jinja, Multi
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_ORG,
     PREVIEW_ORG_PERMISSIONS,
@@ -30,7 +30,7 @@ game_orgs = Dialog(
             Format("{inline_query}"),
             when=~F["game"].is_complete(),
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Multi(
                     Const("🗑", when=F["item"].deleted),

--- a/shvatka/tgbot/dialogs/game_scn/dialogs.py
+++ b/shvatka/tgbot/dialogs/game_scn/dialogs.py
@@ -6,13 +6,13 @@ from aiogram_dialog.widgets.kbd import (
     Cancel,
     Multiselect,
     Next,
-    ScrollingGroup,
     Select,
     SwitchTo,
 )
 from aiogram_dialog.widgets.text import Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_FULL_GAME,
     PREVIEW_GAME,
@@ -46,7 +46,7 @@ game_writer = Dialog(
     Window(
         Jinja("Игра <b>{{game_name}}</b>\n\n"),
         Const("<b>Уровни</b>\n\nВыбери уровни которые нужно добавить"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Multiselect(
                 Format("✓ {item.name_id}"),
                 Format("{item.name_id}"),
@@ -86,7 +86,7 @@ game_editor = Dialog(
             id="to_add_level",
             state=states.GameEditSG.add_level,
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("{item.name_id}"),
                 id="game_level_ids",
@@ -109,7 +109,7 @@ game_editor = Dialog(
     Window(
         Jinja("Игра <b>{{game.name}}</b>\n\n"),
         Const("<b>Уровни</b>\n\nВыбери уровни которые нужно добавить"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("{item.name_id}"),
                 id="level_select",

--- a/shvatka/tgbot/dialogs/level_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/level_manage/dialogs.py
@@ -2,10 +2,11 @@ from aiogram import F
 from aiogram.types import ContentType
 from aiogram_dialog import Dialog, Window
 from aiogram_dialog.widgets.input import MessageInput
-from aiogram_dialog.widgets.kbd import Button, Cancel, ScrollingGroup, Select, SwitchTo
+from aiogram_dialog.widgets.kbd import Button, Cancel, Select, SwitchTo
 from aiogram_dialog.widgets.text import Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_FULL_GAME,
     PREVIEW_LEVEL,
@@ -32,7 +33,7 @@ from .handlers import (
 levels_list = Dialog(
     Window(
         Const("Уровни"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("{item.name_id}"),
                 id="levels_select",
@@ -112,7 +113,7 @@ level_manage = Dialog(
             "Кому отправить его на тестирование?\n\n"
             "ℹЧтобы добавить кого-то в этот список, нужно добавить организатора из меню игры"
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Jinja("{{item.player.name_mention}}"),
                 id="game_orgs",

--- a/shvatka/tgbot/dialogs/level_scn/dialogs.py
+++ b/shvatka/tgbot/dialogs/level_scn/dialogs.py
@@ -6,12 +6,12 @@ from aiogram_dialog.widgets.kbd import (
     Cancel,
     ListGroup,
     Next,
-    ScrollingGroup,
     Select,
 )
 from aiogram_dialog.widgets.text import Const, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_EFFECTS,
     PREVIEW_EFFECTS_CONDITIONS,
@@ -246,7 +246,7 @@ hints_dialog = Dialog(
             "пока нет ни одной"
             "{% endif %}"
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Jinja("{{item | time_hint}}"),
                 id="level_hints",
@@ -301,7 +301,7 @@ effects_key_dialog = Dialog(
             "{% endfor %}",
             when=F["effects_conditions"],
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             ListGroup(
                 Button(
                     Jinja("{{item[0] + 1}} - {{item[1].effects | effects}}"),

--- a/shvatka/tgbot/dialogs/merge/dialogs.py
+++ b/shvatka/tgbot/dialogs/merge/dialogs.py
@@ -1,10 +1,11 @@
 from aiogram.enums import ContentType
 from aiogram_dialog import Dialog, Window
 from aiogram_dialog.widgets.input import MessageInput
-from aiogram_dialog.widgets.kbd import Button, Cancel, ScrollingGroup, Select, SwitchTo
+from aiogram_dialog.widgets.kbd import Button, Cancel, Select, SwitchTo
 from aiogram_dialog.widgets.text import Const, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_FORUM_TEAM,
     PREVIEW_FORUM_TEAMS,
@@ -36,7 +37,7 @@ merge_teams_dialog = Dialog(
     ),
     Window(
         Jinja("Итак мы ищем форумную версию для команды {{team.name}}"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Jinja("🚩{{item.name}}"),
                 id="forum_teams",

--- a/shvatka/tgbot/dialogs/paging.py
+++ b/shvatka/tgbot/dialogs/paging.py
@@ -1,0 +1,173 @@
+from collections.abc import Sequence
+from itertools import chain
+
+from aiogram_dialog.api.internal import ButtonVariant, RawKeyboard
+from aiogram_dialog.api.protocols import DialogManager
+from aiogram_dialog.widgets.common import OnPageChangedVariants, Scroll, WhenCondition
+from aiogram_dialog.widgets.kbd import Keyboard, NumberedPager, ScrollingGroup, SwitchPage
+from aiogram_dialog.widgets.kbd.pager import DEFAULT_PAGER_ID, BasePager, PageDirection
+from aiogram_dialog.widgets.text import Const, Format
+
+MAX_NUMBERED_PAGES = 8
+"""Above this many pages a button per page stops being worth its width."""
+
+MAX_BUTTONS_IN_ROW = 8
+"""Telegram squeezes a wider row until the labels are unreadable."""
+
+FIRST_PAGE_TEXT = Const("⏮")
+PREV_PAGE_TEXT = Const("◀️")
+CURRENT_PAGE_TEXT = Format("{current_page1}/{pages}")
+NEXT_PAGE_TEXT = Const("▶️")
+LAST_PAGE_TEXT = Const("⏭")
+
+
+class _SwitchPage(SwitchPage):
+    """`SwitchPage` rendered from an already counted page count."""
+
+    async def render_page(
+        self,
+        data: dict,
+        pages: int,
+        current_page: int,
+        manager: DialogManager,
+    ) -> RawKeyboard:
+        target_page = await self._get_target_page(current_page, pages)
+        button_data = await self._prepare_data(
+            data=data,
+            target_page=target_page,
+            current_page=current_page,
+            pages=pages,
+        )
+        return await Keyboard.render_keyboard(self, button_data, manager)
+
+
+class _NumberedPages(NumberedPager):
+    """`NumberedPager` rendered from an already counted page count."""
+
+    async def render_pages(
+        self,
+        data: dict,
+        pages: int,
+        current_page: int,
+        manager: DialogManager,
+    ) -> RawKeyboard:
+        pager_data = await self._prepare_data(
+            data=data,
+            current_page=current_page,
+            pages=pages,
+        )
+        return await Keyboard.render_keyboard(self, pager_data, manager)
+
+
+class SmartPager(BasePager):
+    """
+    A pager whose shape follows the number of pages.
+
+    * one page (or none at all) — nothing is rendered, the list speaks for itself;
+    * up to `max_numbered_pages` — every page gets a button of its own, so any of
+      them is one tap away;
+    * more than that — the endless `⏮ ◀️ 3/42 ▶️ ⏭` row.
+
+    Works with any scroll: a `ScrollingGroup` (see `SmartScrollingGroup`, which
+    already carries one) or a `StubScroll` counting pages of text.
+    """
+
+    def __init__(
+        self,
+        scroll: str | Scroll | None,
+        id: str = DEFAULT_PAGER_ID,  # noqa: A002
+        max_numbered_pages: int = MAX_NUMBERED_PAGES,
+        when: WhenCondition = None,
+    ) -> None:
+        super().__init__(id=id, scroll=scroll, when=when)
+        self.max_numbered_pages = max_numbered_pages
+        # every button of every mode switches the same scroll to a page number,
+        # so they all share one widget id — and one callback handler with it
+        self.numbered = _NumberedPages(scroll=scroll, id=id, length=MAX_BUTTONS_IN_ROW)
+        self.endless: Sequence[_SwitchPage] = [
+            _SwitchPage(page=direction, scroll=scroll, id=id, text=text)
+            for direction, text in (
+                (PageDirection.FIRST, FIRST_PAGE_TEXT),
+                (PageDirection.PREV, PREV_PAGE_TEXT),
+                (PageDirection.IGNORE, CURRENT_PAGE_TEXT),
+                (PageDirection.NEXT, NEXT_PAGE_TEXT),
+                (PageDirection.LAST, LAST_PAGE_TEXT),
+            )
+        ]
+
+    async def _render_keyboard(self, data: dict, manager: DialogManager) -> RawKeyboard:
+        scroll = self._find_scroll(manager)
+        return await self.render_pages(
+            data=data,
+            pages=await scroll.get_page_count(data),
+            current_page=await scroll.get_page(),
+            manager=manager,
+        )
+
+    async def render_pages(
+        self,
+        data: dict,
+        pages: int,
+        current_page: int,
+        manager: DialogManager,
+    ) -> RawKeyboard:
+        """
+        Render the pager for a page count someone else has already got.
+
+        Counting pages of a `ScrollingGroup` means rendering all of its buttons,
+        so the owner of the scroll passes the number it knows instead of letting
+        every page button ask for it again.
+        """
+        if pages <= 1:
+            return []
+        current_page = min(current_page, pages - 1)
+        if pages <= self.max_numbered_pages:
+            return await self.numbered.render_pages(data, pages, current_page, manager)
+        row: list[ButtonVariant] = []
+        for switch in self.endless:
+            rendered = await switch.render_page(data, pages, current_page, manager)
+            row.extend(chain.from_iterable(rendered))
+        return [row]
+
+
+class SmartScrollingGroup(ScrollingGroup):
+    """`ScrollingGroup` showing a `SmartPager` instead of the fixed five-button pager."""
+
+    def __init__(
+        self,
+        *buttons: Keyboard,
+        id: str,  # noqa: A002
+        width: int | None = None,
+        height: int = 0,
+        when: WhenCondition = None,
+        on_page_changed: OnPageChangedVariants = None,
+        max_numbered_pages: int = MAX_NUMBERED_PAGES,
+    ) -> None:
+        super().__init__(
+            *buttons,
+            id=id,
+            width=width,
+            height=height,
+            when=when,
+            on_page_changed=on_page_changed,
+            hide_pager=True,
+        )
+        # the pager shares the group's widget id, so switching a page arrives as
+        # this group's own callback — see `ScrollingGroup._process_item_callback`
+        self.pager = SmartPager(scroll=self, id=id, max_numbered_pages=max_numbered_pages)
+
+    async def _render_keyboard(self, data: dict, manager: DialogManager) -> RawKeyboard:
+        keyboard = await self._render_contents(data, manager)
+        pages = self._get_page_count(keyboard)
+        # `ScrollingGroup._render_page` counts the pages once more, and it is the
+        # count the pager needs anyway — so cut the page out here instead
+        current_page = min(await self.get_page(manager), max(pages - 1, 0))
+        offset = current_page * self.height
+        page_keyboard = keyboard[offset : offset + self.height]
+        pager = await self.pager.render_pages(
+            data=data,
+            pages=pages,
+            current_page=current_page,
+            manager=manager,
+        )
+        return page_keyboard + pager

--- a/shvatka/tgbot/dialogs/team_manage/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_manage/dialogs.py
@@ -1,10 +1,11 @@
 from aiogram import F
 from aiogram_dialog import Dialog, Window
 from aiogram_dialog.widgets.input import MessageInput, TextInput
-from aiogram_dialog.widgets.kbd import Button, Cancel, ScrollingGroup, Select, SwitchTo
+from aiogram_dialog.widgets.kbd import Button, Cancel, Select, SwitchTo
 from aiogram_dialog.widgets.text import Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_MY_TEAM,
     PREVIEW_SELECTED_TEAM_PLAYER_DATA,
@@ -109,7 +110,7 @@ captains_bridge = Dialog(
     ),
     Window(
         Jinja("Игроки команды 🚩<b>{{team.name}}</b>"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Jinja("{{item|player_emoji}}{{item.player.name_mention}}"),
                 id="players",

--- a/shvatka/tgbot/dialogs/team_view/dialogs.py
+++ b/shvatka/tgbot/dialogs/team_view/dialogs.py
@@ -1,9 +1,10 @@
 from aiogram_dialog import Dialog, Window
-from aiogram_dialog.widgets.kbd import Button, Cancel, ScrollingGroup, Select, SwitchTo
+from aiogram_dialog.widgets.kbd import Button, Cancel, Select, SwitchTo
 from aiogram_dialog.widgets.text import Case, Const, Format, Jinja
 
 from shvatka.tgbot import states
 from shvatka.tgbot.dialogs.common import BOOL_VIEW
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_TEAM_CARD,
     PREVIEW_TEAMS,
@@ -28,7 +29,7 @@ team_view = Dialog(
             "{{archive|bool_emoji}} Архивные"
         ),
         SwitchTo(Const("🔣Фильтр"), state=states.TeamsSg.filter, id="to_filter"),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Format("🚩{item.name}"),
                 id="teams",
@@ -52,7 +53,7 @@ team_view = Dialog(
             "Капитан: {{team.captain.name_mention}}\n"
             "Сыгранные игры: {{' '.join(game_numbers)}}"
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             Select(
                 Jinja("{{item|player_emoji}}{{item.player.name_mention}}"),
                 id="players",

--- a/shvatka/tgbot/dialogs/time_hint/dialogs.py
+++ b/shvatka/tgbot/dialogs/time_hint/dialogs.py
@@ -7,13 +7,13 @@ from aiogram_dialog.widgets.kbd import (
     Cancel,
     Group,
     ListGroup,
-    ScrollingGroup,
     Select,
     SwitchTo,
 )
 from aiogram_dialog.widgets.text import Case, Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_HINTS_DATA,
     TIMES_PRESET,
@@ -94,7 +94,7 @@ time_hint_edit = Dialog(
             id="change_time",
             state=states.TimeHintEditSG.time,
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             ListGroup(
                 Button(
                     Jinja("{{item[1] | single_hint}}"),

--- a/shvatka/tgbot/dialogs/timers/dialogs.py
+++ b/shvatka/tgbot/dialogs/timers/dialogs.py
@@ -6,13 +6,13 @@ from aiogram_dialog.widgets.kbd import (
     Cancel,
     Group,
     ListGroup,
-    ScrollingGroup,
     Select,
     SwitchTo,
 )
 from aiogram_dialog.widgets.text import Const, Format, Jinja
 
 from shvatka.tgbot import states
+from shvatka.tgbot.dialogs.paging import SmartScrollingGroup
 from shvatka.tgbot.dialogs.preview_data import (
     PREVIEW_EFFECTS,
     PREVIEW_LEVEL,
@@ -52,7 +52,7 @@ timers_dialog = Dialog(
             "{{ timer.action_time }}: {{ timer.effects | effects }}\n"
             "{% endfor %}"
         ),
-        ScrollingGroup(
+        SmartScrollingGroup(
             ListGroup(
                 Button(
                     Jinja("{{item.action_time}}: {{item.effects | effects}}"),

--- a/tests/unit/test_smart_pager.py
+++ b/tests/unit/test_smart_pager.py
@@ -1,0 +1,127 @@
+from collections.abc import Sequence
+from typing import cast
+
+import pytest
+from aiogram.types import InlineKeyboardButton
+from aiogram_dialog.api.internal import ButtonVariant, RawKeyboard
+from aiogram_dialog.tools.preview import FakeManager
+from aiogram_dialog.widgets.kbd import Select, StubScroll
+from aiogram_dialog.widgets.text import Format
+
+from shvatka.tgbot.dialogs.paging import MAX_NUMBERED_PAGES, SmartPager, SmartScrollingGroup
+
+HEIGHT = 10
+GROUP_ID = "items_sg"
+
+
+@pytest.fixture
+def manager() -> FakeManager:
+    manager = FakeManager()
+    manager.reset_context()
+    return manager
+
+
+def _group() -> SmartScrollingGroup:
+    return SmartScrollingGroup(
+        Select(
+            Format("{item}"),
+            id="items",
+            item_id_getter=str,
+            items="items",
+        ),
+        id=GROUP_ID,
+        width=1,
+        height=HEIGHT,
+    )
+
+
+async def _render(manager: FakeManager, items: int, page: int = 0) -> RawKeyboard:
+    manager.current_context().widget_data[GROUP_ID] = page
+    return await _group().render_keyboard({"items": list(range(items))}, manager)
+
+
+def _texts(row: Sequence[ButtonVariant]) -> list[str]:
+    return [button.text for button in row]
+
+
+def _callbacks(row: Sequence[ButtonVariant]) -> list[str | None]:
+    return [cast("InlineKeyboardButton", button).callback_data for button in row]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("items", [0, 1, 9, HEIGHT])
+async def test_single_page_has_no_pager(manager: FakeManager, items: int) -> None:
+    keyboard = await _render(manager, items)
+
+    assert len(keyboard) == items
+    assert _texts([button for row in keyboard for button in row]) == [
+        str(item) for item in range(items)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_few_pages_are_numbered(manager: FakeManager) -> None:
+    keyboard = await _render(manager, items=HEIGHT + 1)
+
+    assert len(keyboard) == HEIGHT + 1  # a full page of items plus the pager
+    assert _texts(keyboard[-1]) == ["[ 1 ]", "2"]
+    assert _callbacks(keyboard[-1]) == [f"{GROUP_ID}:0", f"{GROUP_ID}:1"]
+
+
+@pytest.mark.asyncio
+async def test_last_numbered_page_count(manager: FakeManager) -> None:
+    keyboard = await _render(manager, items=HEIGHT * MAX_NUMBERED_PAGES, page=2)
+
+    assert _texts(keyboard[-1]) == ["1", "2", "[ 3 ]", "4", "5", "6", "7", "8"]
+
+
+@pytest.mark.asyncio
+async def test_many_pages_are_endless(manager: FakeManager) -> None:
+    keyboard = await _render(manager, items=HEIGHT * MAX_NUMBERED_PAGES + 1, page=4)
+
+    assert _texts(keyboard[-1]) == ["⏮", "◀️", "5/9", "▶️", "⏭"]
+    assert _callbacks(keyboard[-1]) == [
+        f"{GROUP_ID}:0",
+        f"{GROUP_ID}:3",
+        f"{GROUP_ID}:4",
+        f"{GROUP_ID}:5",
+        f"{GROUP_ID}:8",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_endless_pager_stops_at_the_edges(manager: FakeManager) -> None:
+    pages = MAX_NUMBERED_PAGES + 1
+    keyboard = await _render(manager, items=HEIGHT * pages, page=pages - 1)
+
+    assert _texts(keyboard[-1]) == ["⏮", "◀️", "9/9", "▶️", "⏭"]
+    assert _callbacks(keyboard[-1])[-2:] == [f"{GROUP_ID}:8", f"{GROUP_ID}:8"]
+
+
+@pytest.mark.asyncio
+async def test_page_out_of_range_shows_the_last_one(manager: FakeManager) -> None:
+    keyboard = await _render(manager, items=HEIGHT + 1, page=42)
+
+    assert _texts(keyboard[0]) == [str(HEIGHT)]
+    assert _texts(keyboard[-1]) == ["1", "[ 2 ]"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("pages", "expected"),
+    [
+        (0, []),
+        (1, []),
+        (3, ["[ 1 ]", "2", "3"]),
+        (MAX_NUMBERED_PAGES + 1, ["⏮", "◀️", "1/9", "▶️", "⏭"]),
+    ],
+)
+async def test_pager_of_a_stub_scroll(
+    manager: FakeManager, pages: int, expected: list[str]
+) -> None:
+    scroll = StubScroll(id="text", pages="pages")
+    pager = SmartPager(scroll=scroll, id="text")
+
+    keyboard = await pager.render_keyboard({"pages": pages}, manager)
+
+    assert [text for row in keyboard for text in _texts(row)] == expected


### PR DESCRIPTION
Closes #118

## Что было

Каждый список в боте — это `ScrollingGroup` с `height=10`, а он всегда рисует один и тот же ряд `1 < 2 > 12`, даже когда страница одна: команда из трёх человек тратила строку клавиатуры на `1 < 1 > 1`. Флаг `hide_on_single_page` чинит только этот случай: при четырёх страницах ряд всё ещё заставляет тыкать «вперёд» вместо того, чтобы показать четыре кнопки.

## Что стало

`SmartScrollingGroup` (`shvatka/tgbot/dialogs/paging.py`) — drop-in замена `ScrollingGroup` с теми же аргументами и теми же id виджетов:

| страниц | пагинатор |
| --- | --- |
| 0–1 | ничего не рисуется |
| 2–8 | кнопка на каждую страницу: `1 2 [ 3 ] 4 5` |
| 9+ | бесконечный `⏮ ◀️ 7/13 ▶️ ⏭` (заодно видно, где ты в списке) |

При `height=10` первая строка таблицы — это ровно «элементов меньше 10» из issue.

## Как

В aiogram_dialog 2.6 пагинатор отцепляется от скролла: `ScrollingGroup(hide_pager=True)` рисует только содержимое, а `NumberedPager` / `FirstPage` / `PrevPage` / `CurrentPage` / `NextPage` / `LastPage` цепляются к любому скроллу по id — включая `StubScroll`, который считает страницы текста. Чего в библиотеке нет — так это выбора формы: `when` видит данные геттера, а не число страниц, поэтому решение нельзя выразить на месте вызова.

- `SmartPager` считает страницы один раз и рендерит один из трёх вариантов из библиотечных виджетов (стили, текстовые виджеты и обработка колбэков остаются библиотечными);
- `SmartPager.render_pages()` принимает уже посчитанное число страниц: `ScrollingGroup.get_page_count()` рендерит все кнопки всех страниц, а собранный «как в библиотеке» пагинатор спрашивал бы это число у скролла на каждую кнопку — шесть полных рендеров списка на один ряд. `SmartScrollingGroup` содержимое уже отрендерил и передаёт число сам;
- все кнопки пагинатора несут id самой группы, поэтому `sg:3` приходит в `ScrollingGroup._process_item_callback` — новых префиксов и маршрутизации не появилось, `manager.find("sg")` по-прежнему возвращает скролл;
- `SmartPager` работает и отдельно, поверх `StubScroll` — постраничный длинный текст теперь решённая задача.

## Изменения

- `shvatka/tgbot/dialogs/paging.py` — `SmartPager`, `SmartScrollingGroup`;
- 17 мест в 11 модулях диалогов переехали на `SmartScrollingGroup`;
- `tests/unit/test_smart_pager.py` — все три формы, границы (`8` / `9` страниц), клэмп страницы вне диапазона, пагинатор поверх `StubScroll`;
- SHEP-0015 + строка в `AGENTS.md`.

## Проверено

`ruff format` / `ruff check` / `mypy` — чисто; `pytest tests/unit` — 634 passed (включая `test_dialogs_preview`, который рендерит все окна).

Интеграционные тесты локально не гонялись (нужен Docker) — за ними CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LrBdNx1Bopo1Vta91SmuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_016LrBdNx1Bopo1Vta91SmuJ)_